### PR TITLE
A quick and dirty workaround for Windows

### DIFF
--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/shared/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/shared/ProtobufBuild.kt
@@ -24,6 +24,7 @@ import com.google.protobuf.gradle.protoc
 import com.google.protobuf.gradle.remove
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.the
 
@@ -42,7 +43,7 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
 
         plugins {
             id("protokt") {
-                path = binaryPath
+                path = normalizePath(binaryPath)
             }
         }
 
@@ -65,3 +66,10 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
         }
     }
 }
+
+private fun normalizePath(binaryPath: String) =
+    if (OperatingSystem.current().isWindows) {
+        binaryPath.replace('\\', '/') + ".bat"
+    } else {
+        binaryPath
+    }

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/shared/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/shared/ProtobufBuild.kt
@@ -69,6 +69,7 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
 
 private fun normalizePath(binaryPath: String) =
     if (OperatingSystem.current().isWindows) {
+        // on windows, protoc expects a full, /-separated path to the binary
         binaryPath.replace('\\', '/') + ".bat"
     } else {
         binaryPath


### PR DESCRIPTION
On Windows, `protoc` expects a `/`-separated path to the plugin binary. The binary needs to include the extension (`.bat` in our case).

Tested on Windows 10.