### PR TITLE
Fix JVM compatibility field in gradle module metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,10 @@ subprojects {
         }
     }
 
+    configure<JavaPluginExtension> {
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     tasks.withType<Jar> {
         manifest {
             attributes(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ subprojects {
     }
 
     configure<JavaPluginExtension> {
+        sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 

--- a/protokt-codegen/build.gradle.kts
+++ b/protokt-codegen/build.gradle.kts
@@ -69,11 +69,6 @@ idea {
     }
 }
 
-tasks.withType<JavaCompile> {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
-}
-
 protobuf {
     protoc {
         artifact = libraries.protoc


### PR DESCRIPTION
Must configure the Java plugin for gradle to correctly record JVM compatibility in the gradle module metadata file.

This fixes the `Required org.gradle.jvm.version '8' and found incompatible value '11'` error for consumers on recent versions of Gradle targeting Java 8.

