### PR TITLE
Fix wrappers for all primitive types

### DIFF
--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -129,6 +129,23 @@ isScalar ::= [
     default: false
 ]
 
+javaTypeNames ::= [
+    "BOOL": "Boolean",
+    "DOUBLE": "Double",
+    "FIXED32": "Integer",
+    "FIXED64": "Long",
+    "FLOAT": "Float",
+    "INT32": "Integer",
+    "INT64": "Long",
+    "SFIXED32": "Integer",
+    "SFIXED64": "Long",
+    "SINT32": "Integer",
+    "SINT64": "Long",
+    "STRING": "String",
+    "UINT32": "Integer",
+    "UINT64": "Long"
+]
+
 isMessage ::= ["MESSAGE": true, default: false]
 
 isEnum ::= ["ENUM": true, default: false]
@@ -142,8 +159,8 @@ isBytes ::= ["BYTES": true, "STRING": true, default: false]
 type2nativeF(type) ::= "<kotlinTypeNames.(type)>"
 
 type2NameF(type) ::= <%
-    <if (isScalar.(type))>
-        kotlin.<kotlinTypeNames.(type)>
+    <if (javaTypeNames.(type))>
+        java.lang.<javaTypeNames.(type)>
     <else>
         [B
     <endif>

--- a/testing/options-api/src/main/kotlin/com/toasttab/model/PrimitiveConverters.kt
+++ b/testing/options-api/src/main/kotlin/com/toasttab/model/PrimitiveConverters.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.model
+
+import com.google.auto.service.AutoService
+import com.toasttab.protokt.ext.Converter
+import com.toasttab.protokt.rt.Bytes
+
+data class BoolBox(val wrapped: Boolean)
+
+@AutoService(Converter::class)
+object BooleanConverter : Converter<BoolBox, Boolean> {
+    override val wrapped = Boolean::class
+    override val wrapper = BoolBox::class
+    override fun unwrap(wrapped: BoolBox) = wrapped.wrapped
+    override fun wrap(unwrapped: Boolean) = BoolBox(unwrapped)
+}
+
+data class ByteArrayBox(val wrapped: Bytes)
+
+@AutoService(Converter::class)
+object BytesConverter : Converter<ByteArrayBox, ByteArray> {
+    override val wrapped = ByteArray::class
+    override val wrapper = ByteArrayBox::class
+    override fun unwrap(wrapped: ByteArrayBox) = wrapped.wrapped.bytes
+    override fun wrap(unwrapped: ByteArray) = ByteArrayBox(Bytes(unwrapped))
+}
+
+data class DoubleBox(val wrapped: Double)
+
+@AutoService(Converter::class)
+object DoubleConverter : Converter<DoubleBox, Double> {
+    override val wrapped = Double::class
+    override val wrapper = DoubleBox::class
+    override fun unwrap(wrapped: DoubleBox) = wrapped.wrapped
+    override fun wrap(unwrapped: Double) = DoubleBox(unwrapped)
+}
+
+data class IntBox(val wrapped: Int)
+
+@AutoService(Converter::class)
+object IntConverter : Converter<IntBox, Int> {
+    override val wrapped = Int::class
+    override val wrapper = IntBox::class
+    override fun unwrap(wrapped: IntBox) = wrapped.wrapped
+    override fun wrap(unwrapped: Int) = IntBox(unwrapped)
+}
+
+data class LongBox(val wrapped: Long)
+
+@AutoService(Converter::class)
+object LongConverter : Converter<LongBox, Long> {
+    override val wrapped = Long::class
+    override val wrapper = LongBox::class
+    override fun unwrap(wrapped: LongBox) = wrapped.wrapped
+    override fun wrap(unwrapped: Long) = LongBox(unwrapped)
+}
+
+data class FloatBox(val wrapped: Float)
+
+@AutoService(Converter::class)
+object FloatConverter : Converter<FloatBox, Float> {
+    override val wrapped = Float::class
+    override val wrapper = FloatBox::class
+    override fun unwrap(wrapped: FloatBox) = wrapped.wrapped
+    override fun wrap(unwrapped: Float) = FloatBox(unwrapped)
+}
+
+data class StringBox(val wrapped: String)
+
+@AutoService(Converter::class)
+object StringConverter : Converter<StringBox, String> {
+    override val wrapped = String::class
+    override val wrapper = StringBox::class
+    override fun unwrap(wrapped: StringBox) = wrapped.wrapped
+    override fun wrap(unwrapped: String) = StringBox(unwrapped)
+}

--- a/testing/options/src/main/proto/com/toasttab/model/primitive_wrapped_types.proto
+++ b/testing/options/src/main/proto/com/toasttab/model/primitive_wrapped_types.proto
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package com.toasttab.model;
+
+import "protokt/protokt.proto";
+
+message PrimitiveWrappedTypes {
+  bytes bytes = 1 [
+    (protokt.property).wrap = "ByteArrayBox"
+  ];
+
+  bool bool = 2 [
+    (protokt.property).wrap = "BoolBox"
+  ];
+
+  double double = 3 [
+    (protokt.property).wrap = "DoubleBox"
+  ];
+
+  fixed32 fixed32 = 4 [
+    (protokt.property).wrap = "IntBox"
+  ];
+
+  fixed64 fixed64 = 5 [
+    (protokt.property).wrap = "LongBox"
+  ];
+
+  float float = 6 [
+    (protokt.property).wrap = "FloatBox"
+  ];
+
+  int32 int32 = 7 [
+    (protokt.property).wrap = "IntBox"
+  ];
+
+  int64 int64 = 8 [
+    (protokt.property).wrap = "LongBox"
+  ];
+
+  sfixed32 sfixed32 = 9 [
+    (protokt.property).wrap = "IntBox"
+  ];
+
+  sfixed64 sfixed64 = 10 [
+    (protokt.property).wrap = "LongBox"
+  ];
+
+  sint32 sint32 = 11 [
+    (protokt.property).wrap = "IntBox"
+  ];
+
+  sint64 sint64 = 12 [
+    (protokt.property).wrap = "LongBox"
+  ];
+
+  string string = 13 [
+    (protokt.property).wrap = "StringBox"
+  ];
+
+  uint32 uint32 = 14 [
+    (protokt.property).wrap = "IntBox"
+  ];
+
+  uint64 uint64 = 15 [
+    (protokt.property).wrap = "LongBox"
+  ];
+}


### PR DESCRIPTION
When introducing the `wrapped` field on Converters for protokt to look up, byte arrays were inadvertently the only primitive type that worked, since `Class.forName(kotlin.X)` doesn't actually work. Those types have to be represented by their Java class names.

Related issue: https://youtrack.jetbrains.com/issue/KT-10440