### PR TITLE
Add deprecation to DSL builder when a field is deprecated

### DIFF
--- a/protokt-codegen/src/main/resources/dsl.stg
+++ b/protokt-codegen/src/main/resources/dsl.stg
@@ -24,7 +24,7 @@ fun copy(dsl: <message.name>Dsl.() -> Unit) =
     }
 
 class <message.name>Dsl {
-    <params:{p | var <dslVar(p)>}; separator="\n">
+    <params:{p | <deprecated(p)>var <dslVar(p)>}; separator="\n">
     var unknown: Map\<Int, Unknown> = emptyMap()
         set(newValue) { field = copyMap(newValue) }
 

--- a/testing/options/src/test/kotlin/com/toasttab/protokt/options/DeprecatedTest.kt
+++ b/testing/options/src/test/kotlin/com/toasttab/protokt/options/DeprecatedTest.kt
@@ -58,6 +58,15 @@ class DeprecatedTest {
     }
 
     @Test
+    fun `deprecated message DSL field`() {
+        assertFieldDeprecation(
+            com.toasttab.model.DeprecatedModel.DeprecatedModelDsl::class,
+            "id",
+            "mildly deprecated"
+        )
+    }
+
+    @Test
     fun `deprecated oneof field`() {
         assertClassDeprecation(
             com.toasttab.model.DeprecatedModel.DeprecatedOneof.Option::class,


### PR DESCRIPTION
```kotlin
    class DeprecatedModelDsl {
+       @Deprecated("mildly deprecated")
        var id = ""
        var deprecatedOneof: DeprecatedOneof? = null
        var unknown: Map<Int, Unknown> = emptyMap()
            set(newValue) { field = copyMap(newValue) }

        fun build() =
            DeprecatedModel(
                id,
                deprecatedOneof,
                unknown
            )
    }
```