### PR TITLE
Use nativeTypeName in deserializer expression for oneofs

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/AnnotatorUtils.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/AnnotatorUtils.kt
@@ -41,7 +41,7 @@ internal fun oneOfScope(f: Oneof, type: String, ctx: Context) =
         ctx.stripRootMessageNamePrefix(
             ConcatWithScope.render(
                 scope = type,
-                value = f.nativeTypeName
+                value = f.name
             )
         )
     )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -27,12 +27,11 @@ import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptReadFn
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapperName
-import com.toasttab.protokt.codegen.snakeToCamel
 import com.toasttab.protokt.codegen.template.Message.Message.DeserializerInfo
 import com.toasttab.protokt.codegen.template.Message.Message.DeserializerInfo.Assignment
+import com.toasttab.protokt.codegen.template.Oneof as OneofTemplate
 import com.toasttab.protokt.codegen.template.Renderers.Deserialize
 import com.toasttab.protokt.codegen.template.Renderers.Deserialize.Options
-import com.toasttab.protokt.codegen.template.Renderers.OneofDeserialize
 import com.toasttab.protokt.codegen.template.Renderers.Read
 import com.toasttab.protokt.rt.PType
 
@@ -121,9 +120,9 @@ private constructor(
     )
 
     private fun oneOfDes(f: Oneof, ff: StandardField) =
-        OneofDeserialize.render(
-            oneof = snakeToCamel(f.name).capitalize(),
-            name = snakeToCamel(ff.name).capitalize(),
+        OneofTemplate.Deserialize.render(
+            oneof = f.nativeTypeName,
+            name = ff.name.capitalize(),
             read = deserializeString(ff)
         )
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -121,7 +121,7 @@ private constructor(
 
     private fun oneOfDes(f: Oneof, ff: StandardField) =
         OneofTemplate.Deserialize.render(
-            oneof = f.nativeTypeName,
+            oneof = f.name,
             name = ff.name.capitalize(),
             read = deserializeString(ff)
         )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -37,7 +37,7 @@ private constructor(
             when (it) {
                 is Oneof ->
                     OneofTemplate.render(
-                        name = it.nativeTypeName,
+                        name = it.name,
                         types = it.fields.associate(::oneOfValue),
                         options = options(it)
                     )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -25,7 +25,6 @@ import com.toasttab.protokt.codegen.impl.Wrapper.interceptTypeName
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.model.PClass
 import com.toasttab.protokt.codegen.model.possiblyQualify
-import com.toasttab.protokt.codegen.snakeToCamel
 import com.toasttab.protokt.codegen.template.Oneof.Oneof as OneofTemplate
 
 internal class OneofAnnotator
@@ -47,19 +46,16 @@ private constructor(
         }.filter { it.isNotEmpty() }
 
     private fun oneOfValue(f: StandardField) =
-        snakeToCamel(f.name).let { fieldName ->
-            fieldName.capitalize().let { oneofFieldTypeName ->
-                oneofFieldTypeName to info(f, fieldName, oneofFieldTypeName)
-            }
+        f.name.capitalize().let { oneofFieldTypeName ->
+            oneofFieldTypeName to info(f, oneofFieldTypeName)
         }
 
     private fun info(
         f: StandardField,
-        fieldName: String,
         oneofFieldTypeName: String
     ) =
         OneofTemplate.Info(
-            fieldName = fieldName,
+            fieldName = f.name,
             type = qualifyWrapperType(
                 f,
                 PClass.fromName(oneofFieldTypeName),

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -81,7 +81,7 @@ private constructor(
                             Type.render(
                                 oneof = true,
                                 nullable = nullable,
-                                any = it.nativeTypeName
+                                any = it.name
                             ),
                         defaultValue = it.defaultValue(),
                         oneOf = true,

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -34,8 +34,8 @@ import com.toasttab.protokt.codegen.impl.Wrapper.interceptDefaultValue
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptTypeName
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.template.Message.Message.PropertyInfo
+import com.toasttab.protokt.codegen.template.Oneof as OneofTemplate
 import com.toasttab.protokt.codegen.template.Renderers.DefaultValue
-import com.toasttab.protokt.codegen.template.Renderers.OneofDefaultValue
 import com.toasttab.protokt.codegen.template.Renderers.Standard
 import com.toasttab.protokt.codegen.template.Renderers.Type
 import com.toasttab.protokt.rt.PType
@@ -146,7 +146,7 @@ private constructor(
                     ctx
                 )
             is Oneof ->
-                OneofDefaultValue.render()
+                OneofTemplate.DefaultValue.render()
         }
 
     companion object {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
@@ -126,7 +126,7 @@ private constructor(
         ConditionalParams(
             ConcatWithScope.render(
                 scope = oneOfScope(f, type, ctx),
-                value = f.fieldTypeNames[ff.name] ?: ""
+                value = f.fieldTypeNames.getValue(ff.name)
             ),
             serializeString(ff, Some(f.fieldName))
         )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -97,7 +97,7 @@ private constructor(
             ConditionalParams(
                 ConcatWithScope.render(
                     scope = oneOfScope(f, type, ctx),
-                    value = f.fieldTypeNames[it.name] ?: ""
+                    value = f.fieldTypeNames.getValue(it.name)
                 ),
                 sizeOfString(
                     it,

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protocol.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protocol.kt
@@ -296,10 +296,9 @@ private fun toOneOf(
             )
     })
     return Oneof(
-        name = oneOf.name,
+        name = newTypeName(oneOf.name, typeNames),
         fieldTypeNames = standardTuple.a,
         fieldName = newName,
-        nativeTypeName = newTypeName(oneOf.name, typeNames),
         fields = standardTuple.c,
         options =
             OneofOptions(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protocol.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protocol.kt
@@ -290,7 +290,7 @@ private fun toOneOf(
         ), { oneofIdx, acc, t ->
             val ftn = newTypeName(t.name, acc.b)
             Tuple3(
-                acc.a + (t.name to ftn),
+                acc.a + (convertStandardFieldName(t.name) to ftn),
                 acc.b + ftn,
                 acc.c + toStandard(idx + oneofIdx, ctx, t, emptySet(), true)
             )
@@ -321,7 +321,7 @@ private fun toStandard(
     fdp.type ?: error("Missing field type")).let { type ->
     StandardField(
         number = fdp.number,
-        name = fdp.name!!,
+        name = convertStandardFieldName(fdp.name),
         type = type,
         typeName = fdp.typeName,
         repeated = fdp.label == LABEL_REPEATED,
@@ -351,6 +351,9 @@ private fun toStandard(
         index = idx
     )
 }
+
+private fun convertStandardFieldName(name: String) =
+    snakeToCamel(name)
 
 private fun packageName(
     fdp: FileDescriptorProto,

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Oneof.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Oneof.kt
@@ -17,8 +17,10 @@ package com.toasttab.protokt.codegen.template
 
 import com.toasttab.protokt.codegen.impl.Deprecation
 
+abstract class OneofTemplate : StTemplate(StGroup.Oneof)
+
 object Oneof {
-    object Oneof : StTemplate(StGroup.Oneof) {
+    object Oneof : OneofTemplate() {
         fun render(name: String, types: Map<String, Info>, options: Options) =
             renderArgs(name, types, options)
 
@@ -33,5 +35,12 @@ object Oneof {
             val doesImplement: Boolean,
             val implements: String
         )
+    }
+
+    object DefaultValue : NoParamStTemplate(StGroup.Oneof)
+
+    object Deserialize : OneofTemplate() {
+        fun render(oneof: String, name: String, read: String) =
+            renderArgs(oneof, name, read)
     }
 }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
@@ -42,16 +42,9 @@ object Renderers {
             renderArgs(type, box)
     }
 
-    object OneofDefaultValue : NoParamStTemplate(StGroup.Renderers)
-
     object ConcatWithScope : RenderersTemplate() {
         fun render(scope: String, value: String) =
             renderArgs(scope, value)
-    }
-
-    object OneofDeserialize : RenderersTemplate() {
-        fun render(oneof: String, name: String, read: String) =
-            renderArgs(oneof, name, read)
     }
 
     object DefaultValue : RenderersTemplate() {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/types.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/types.kt
@@ -147,7 +147,6 @@ class Oneof(
     val fieldName: String,
     val fields: List<StandardField>,
     val fieldTypeNames: Map<String, String>,
-    val nativeTypeName: String,
     val options: OneofOptions,
     val index: Int
 ) : Field()

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -203,11 +203,7 @@ deserializeVar(p) ::= <%
     <\ >= <deserializeValue(p)>
 %>
 
-oneofDefaultValue() ::= "null"
-
 concatWithScope(scope, value) ::= "<scope>.<value>"
-
-oneofDeserialize(oneof, name, read) ::= "<oneof>.<name>(<read>)"
 
 defaultValue(field, type, name) ::= <%
     <if (field.map)>

--- a/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/shared_name.proto
+++ b/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/shared_name.proto
@@ -13,21 +13,12 @@
  * limitations under the License.
  */
 
-import "options.stg"
-import "renderers.stg"
+syntax = "proto3";
 
-oneof(name, types, options) ::= <<
-sealed class <name> <oneofDoesImplement()>{
-    <types.keys:{k |<\\>
-    <blockComment(types.(k).documentation)><\\>
-    <deprecated(types.(k))><\\>
-    data class <k>(
-    val <types.(k).fieldName>: <types.(k).type>
-) : <name>()<oneofImplements()>}; separator="\n\n">
+package com.toasttab.protokt.testing.rt.oneof;
+
+message MessageName {
+  oneof message_name {
+    string child = 1;
+  }
 }
-
->>
-
-defaultValue() ::= "null"
-
-deserialize(oneof, name, read) ::= "<oneof>.<name>(<read>)"


### PR DESCRIPTION
Additionally, clean up StandardField `name`.

cc @jsanford-toast

Given:
```protobuf
message MessageName {
  oneof message_name {
    string child = 1;
  }
}
```

We were getting:
```kotlin
when (deserializer.readTag()) {
    ...
    10 -> messageName = 
        MessageName.Child(deserializer.readString())
    ...
}
```
and we want:
```kotlin
when (deserializer.readTag()) {
    ...
    10 -> messageName = 
        MessageName_.Child(deserializer.readString())
    ...
}
```

Alternatively we can ditch the underscores. The following would need fully qualified names:
```kotlin
override fun equals(other: Any?): Boolean =
    other is com.toasttab.protokt.testing.rt.oneof.MessageName &&
```

and

```kotlin
companion object Deserializer : KtDeserializer<com.toasttab.protokt.testing.rt.oneof.MessageName>, (MessageNameDsl.() -> Unit) -> com.toasttab.protokt.testing.rt.oneof.MessageName {
    override fun deserialize(deserializer: KtMessageDeserializer): com.toasttab.protokt.testing.rt.oneof.MessageName {
```

... but there may be further complications down the line if more messages are nested, especially if they have the same name. The amount of full qualification necessary may just increase forever. It's cleaner generated code to use underscores, and cleaner calling code to fully qualify where needed.