### PR TITLE
Fix more reserved type name issues

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/Format.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/Format.kt
@@ -19,7 +19,10 @@ internal object Keywords {
     val reserved =
         setOf(
             "Boolean",
-            "Companion",
+            "Deserializer",
+            "KtDeserializer",
+            "KtSerializer",
+            "KtMessageSerializer",
             "Double",
             "Float",
             "Int",
@@ -28,15 +31,11 @@ internal object Keywords {
             "Map",
             "String",
             "Unit",
-            "emptyList",
-            "protokt",
+            "deserializer",
+            "serializer",
             "messageSize",
-            "deserialize",
-            "serialize",
-            "enumValue",
-            "unknownFields",
-            "res",
-            "default")
+            "emptyList"
+        )
     val kotlinReserved =
         setOf(
             "as",
@@ -66,7 +65,7 @@ internal object Keywords {
             "var",
             "when",
             "while"
-    )
+        )
 }
 
 internal fun snakeToCamel(str: String): String {
@@ -85,8 +84,17 @@ internal fun snakeToCamel(str: String): String {
     }
 }
 
-internal fun newTypeName(preferred: String, set: Set<String> = emptySet()): String {
-    var name = snakeToCamel(preferred).capitalize()
+internal fun newTypeNameFromCamel(
+    preferred: String,
+    set: Set<String> = emptySet()
+) =
+    newTypeNameFromPascal(snakeToCamel(preferred).capitalize(), set)
+
+internal fun newTypeNameFromPascal(
+    preferred: String,
+    set: Set<String> = emptySet()
+): String {
+    var name = preferred
     name = appendUnderscores(name, set)
     return name
 }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/Format.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/Format.kt
@@ -27,6 +27,7 @@ internal object Keywords {
             "Long",
             "Map",
             "String",
+            "Unit",
             "emptyList",
             "protokt",
             "messageSize",

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/Format.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/Format.kt
@@ -19,10 +19,6 @@ internal object Keywords {
     val reserved =
         setOf(
             "Boolean",
-            "Deserializer",
-            "KtDeserializer",
-            "KtSerializer",
-            "KtMessageSerializer",
             "Double",
             "Float",
             "Int",
@@ -31,6 +27,11 @@ internal object Keywords {
             "Map",
             "String",
             "Unit",
+            "Deserializer",
+            "KtDeserializer",
+            "KtSerializer",
+            "KtMessageSerializer",
+            "Tag",
             "deserializer",
             "serializer",
             "messageSize",
@@ -93,11 +94,8 @@ internal fun newTypeNameFromCamel(
 internal fun newTypeNameFromPascal(
     preferred: String,
     set: Set<String> = emptySet()
-): String {
-    var name = preferred
-    name = appendUnderscores(name, set)
-    return name
-}
+) =
+    appendUnderscores(preferred, set)
 
 internal fun newFieldName(preferred: String, set: Set<String>): String {
     var name = snakeToCamel(preferred).decapitalize()

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -57,7 +57,7 @@ private constructor(
                         }
                     },
                     {
-                        oneOfDes(it, field).let { value ->
+                        oneofDes(it, field).let { value ->
                             Assignment(
                                 it.fieldName,
                                 value,
@@ -119,10 +119,10 @@ private constructor(
         val oneof: Option<Oneof>
     )
 
-    private fun oneOfDes(f: Oneof, ff: StandardField) =
+    private fun oneofDes(f: Oneof, ff: StandardField) =
         OneofTemplate.Deserialize.render(
             oneof = f.name,
-            name = ff.name.capitalize(),
+            name = f.fieldTypeNames.getValue(ff.name),
             read = deserializeString(ff)
         )
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -78,7 +78,7 @@ private constructor(
                 4 + // when (...)
                 field.tag.toString().length +
                 4 + // ` -> `
-                field.fieldName.length +
+                field.name.length +
                 3 // ` = `
 
         val spaceLeft = idealMaxWidth - spaceTaken

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DuplicateNameInOneofImportFilterer.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DuplicateNameInOneofImportFilterer.kt
@@ -19,7 +19,6 @@ import com.toasttab.protokt.codegen.MessageType
 import com.toasttab.protokt.codegen.Oneof
 import com.toasttab.protokt.codegen.TypeDesc
 import com.toasttab.protokt.codegen.algebra.AST
-import com.toasttab.protokt.codegen.snakeToCamel
 
 fun Sequence<Import>.filterClassesWithSameNameAsOneofFieldTypeIn(
     asts: List<AST<TypeDesc>>
@@ -46,6 +45,5 @@ private fun typeNames(m: MessageType): Sequence<String> =
 
 private fun typeNames(o: Oneof) =
     o.fields.asSequence()
-        // TODO: merge with oneof naming logic in other PR
-        .map { snakeToCamel(it.typeName).capitalize() }
+        .map { it.name.capitalize() }
         .map { it.substringAfterLast('.') }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DuplicateNameInOneofImportFilterer.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DuplicateNameInOneofImportFilterer.kt
@@ -19,6 +19,7 @@ import com.toasttab.protokt.codegen.MessageType
 import com.toasttab.protokt.codegen.Oneof
 import com.toasttab.protokt.codegen.TypeDesc
 import com.toasttab.protokt.codegen.algebra.AST
+import com.toasttab.protokt.codegen.model.PClass
 
 fun Sequence<Import>.filterClassesWithSameNameAsOneofFieldTypeIn(
     asts: List<AST<TypeDesc>>
@@ -45,5 +46,5 @@ private fun typeNames(m: MessageType): Sequence<String> =
 
 private fun typeNames(o: Oneof) =
     o.fields.asSequence()
-        .map { it.name.capitalize() }
-        .map { it.substringAfterLast('.') }
+        .map { o.fieldTypeNames.getValue(it.name) }
+        .map { PClass.fromName(it).simpleName }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -19,7 +19,7 @@ import com.toasttab.protokt.codegen.MessageType
 import com.toasttab.protokt.codegen.Oneof
 import com.toasttab.protokt.codegen.StandardField
 import com.toasttab.protokt.codegen.impl.Deprecation.renderOptions
-import com.toasttab.protokt.codegen.impl.FieldDocumentationAnnotator.Companion.annotateFieldDocumentation
+import com.toasttab.protokt.codegen.impl.PropertyDocumentationAnnotator.Companion.annotatePropertyDocumentation
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptTypeName
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
@@ -69,7 +69,7 @@ private constructor(
                     ctx
                 )
             ),
-            documentation = annotateFieldDocumentation(f, ctx),
+            documentation = annotatePropertyDocumentation(f, ctx),
             deprecation =
                 if (f.options.default.deprecated) {
                     renderOptions(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -38,16 +38,16 @@ private constructor(
                 is Oneof ->
                     OneofTemplate.render(
                         name = it.name,
-                        types = it.fields.associate(::oneOfValue),
+                        types = it.fields.associate { ff -> oneof(it, ff) },
                         options = options(it)
                     )
                 else -> ""
             }
         }.filter { it.isNotEmpty() }
 
-    private fun oneOfValue(f: StandardField) =
-        f.name.capitalize().let { oneofFieldTypeName ->
-            oneofFieldTypeName to info(f, oneofFieldTypeName)
+    private fun oneof(f: Oneof, ff: StandardField) =
+        f.fieldTypeNames.getValue(ff.name).let { oneofFieldTypeName ->
+            oneofFieldTypeName to info(ff, oneofFieldTypeName)
         }
 
     private fun info(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -25,10 +25,10 @@ import com.toasttab.protokt.codegen.MessageType
 import com.toasttab.protokt.codegen.Oneof
 import com.toasttab.protokt.codegen.StandardField
 import com.toasttab.protokt.codegen.impl.Deprecation.renderOptions
-import com.toasttab.protokt.codegen.impl.FieldDocumentationAnnotator.Companion.annotateFieldDocumentation
 import com.toasttab.protokt.codegen.impl.Implements.overrides
 import com.toasttab.protokt.codegen.impl.NonNullable.hasNonNullOption
 import com.toasttab.protokt.codegen.impl.NonNullable.nullable
+import com.toasttab.protokt.codegen.impl.PropertyDocumentationAnnotator.Companion.annotatePropertyDocumentation
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptDefaultValue
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptTypeName
@@ -47,7 +47,7 @@ private constructor(
 ) {
     private fun annotateProperties(): List<PropertyInfo> {
         return msg.fields.map {
-            val documentation = annotateFieldDocumentation(it, ctx)
+            val documentation = annotatePropertyDocumentation(it, ctx)
             val nullable = it.nullable
 
             when (it) {
@@ -99,7 +99,7 @@ private constructor(
             nullable = f.nullable,
             any =
                 if (f.map) {
-                    typeParams(f.typeName)
+                    typeParams(f.protoTypeName)
                 } else {
                     interceptTypeName(
                         f,

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyDocumentationAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyDocumentationAnnotator.kt
@@ -23,12 +23,12 @@ import com.toasttab.protokt.codegen.StandardField
 import com.toasttab.protokt.codegen.impl.MessageDocumentationAnnotator.baseLocation
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 
-internal class FieldDocumentationAnnotator
+internal class PropertyDocumentationAnnotator
 private constructor(
     private val field: Field,
     private val ctx: Context
 ) {
-    private fun annotateFieldDocumentation() =
+    private fun annotatePropertyDocumentation() =
         baseLocation(
             ctx,
             when (field) {
@@ -38,7 +38,7 @@ private constructor(
         ).cleanDocumentation()
 
     companion object {
-        fun annotateFieldDocumentation(field: Field, ctx: Context) =
-            FieldDocumentationAnnotator(field, ctx).annotateFieldDocumentation()
+        fun annotatePropertyDocumentation(field: Field, ctx: Context) =
+            PropertyDocumentationAnnotator(field, ctx).annotatePropertyDocumentation()
     }
 }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
@@ -58,7 +58,7 @@ private constructor(
                         !it.hasNonNullOption,
                         it.fields
                             .sortedBy { f -> f.number }
-                            .map { f -> oneOfSer(it, f, msg.type) }
+                            .map { f -> oneOfSer(it, f, msg.name) }
                     )
             }
         }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -58,7 +58,7 @@ private constructor(
                         false,
                         it.fieldName,
                         !it.hasNonNullOption,
-                        oneOfSize(it, msg.name)
+                        oneofSize(it, msg.name)
                     )
             }
         }
@@ -92,7 +92,7 @@ private constructor(
         )
     }
 
-    private fun oneOfSize(f: Oneof, type: String) =
+    private fun oneofSize(f: Oneof, type: String) =
         f.fields.map {
             ConditionalParams(
                 ConcatWithScope.render(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -58,7 +58,7 @@ private constructor(
                         false,
                         it.fieldName,
                         !it.hasNonNullOption,
-                        oneOfSize(it, msg.type)
+                        oneOfSize(it, msg.name)
                     )
             }
         }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldImportResolver.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldImportResolver.kt
@@ -38,7 +38,7 @@ class StandardFieldImportResolver(
             wrapperTypeImports()
 
     private fun listImports() =
-        if (f.repeated) {
+        if (f.repeated && !f.map) {
             immutableSetOf(
                 rtMethod("copyList"),
                 rtMethod("finishList")
@@ -54,10 +54,7 @@ class StandardFieldImportResolver(
 
     private fun mapImports() =
         if (f.map) {
-            setOf(
-                rtMethod("sizeofMap"),
-                rtMethod("finishList")
-            )
+            setOf(rtMethod("sizeofMap"))
         } else {
             setOf()
         }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldImportResolver.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldImportResolver.kt
@@ -63,7 +63,7 @@ class StandardFieldImportResolver(
         }
 
     private fun ptypeImports() =
-        f.type.kotlinRepresentation?.let {
+        f.type.inlineRepresentation?.let {
             listOf(pclass(it))
         } ?: emptyList()
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/WellKnownTypes.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/WellKnownTypes.kt
@@ -26,9 +26,9 @@ object WellKnownTypes {
         get() =
             options.protokt.wrap.emptyToNone()
                 .orElse {
-                    if (typeName.startsWith("$googleProto.")) {
+                    if (protoTypeName.startsWith("$googleProto.")) {
                         JavaClassNameForWellKnownType.render(
-                            type = typeName.removePrefix("$googleProto.")
+                            type = protoTypeName.removePrefix("$googleProto.")
                         ).emptyToNone()
                     } else {
                         None

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Wrapper.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Wrapper.kt
@@ -32,7 +32,6 @@ import com.toasttab.protokt.codegen.template.Options.BytesSlice
 import com.toasttab.protokt.codegen.template.Options.DefaultBytesSlice
 import com.toasttab.protokt.codegen.template.Options.ReadBytesSlice
 import com.toasttab.protokt.codegen.template.Options.Sizeof
-import com.toasttab.protokt.codegen.template.Options.TypeToJavaClassName
 import com.toasttab.protokt.codegen.template.Options.WrapField
 import com.toasttab.protokt.codegen.template.Renderers.ConcatWithScope
 import com.toasttab.protokt.codegen.template.Renderers.FieldSizeof
@@ -69,12 +68,13 @@ internal object Wrapper {
                 {
                     ifSome(
                         it,
-                        typeName.emptyToNone().fold(
+                        protoTypeName.emptyToNone().fold(
                             {
                                 // Protobuf primitives have no typeName
-                                Class.forName(
-                                    TypeToJavaClassName.render(type = type)
-                                ).kotlin
+                                requireNotNull(type.kotlinRepresentation) {
+                                    "no kotlin representation for type of " +
+                                        "$name: $type"
+                                }
                             },
                             { getClass(typePClass(ctx), ctx) }
                         )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Options.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Options.kt
@@ -30,11 +30,6 @@ object Options {
             renderArgs(wrapName, arg, type, oneof)
     }
 
-    object TypeToJavaClassName : OptionsTemplate() {
-        fun render(type: PType) =
-            renderArgs(type)
-    }
-
     object AccessField : OptionsTemplate() {
         fun render(wrapName: String, arg: String) =
             renderArgs(wrapName, arg)

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/types.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/types.kt
@@ -24,14 +24,10 @@ import com.toasttab.protokt.codegen.model.PPackage
 import com.toasttab.protokt.ext.Protokt
 import com.toasttab.protokt.rt.PType
 
-sealed class Type {
-    abstract val name: String
-    abstract val type: String
-}
+sealed class Type
 
 class MessageType(
-    override val name: String,
-    override val type: String,
+    val name: String,
     val fields: List<Field>,
     val nestedTypes: List<Type>,
     val mapEntry: Boolean,
@@ -46,8 +42,7 @@ data class MessageOptions(
 )
 
 class EnumType(
-    override val name: String,
-    override val type: String,
+    val name: String,
     val options: EnumOptions,
     val values: List<Value>,
     val index: Int
@@ -72,8 +67,8 @@ class EnumValueOptions(
 )
 
 class ServiceType(
-    override val name: String,
-    override val type: String,
+    val name: String,
+    val type: String,
     val methods: List<Method>,
     val deprecated: Boolean,
     val options: ServiceOptions
@@ -110,8 +105,7 @@ class StandardField(
     val optional: Boolean,
     val packed: Boolean,
     val map: Boolean,
-    val typeName: String,
-    val nativeTypeName: Option<String>,
+    val protoTypeName: String,
     val options: FieldOptions,
     val index: Int
 ) : Field()
@@ -214,7 +208,6 @@ class Protocol(
     val types: List<Type>
 )
 
-// Interpreter Types
 class AnnotatedType(
     val rawType: Type,
     val code: Option<String> = None

--- a/protokt-codegen/src/main/resources/options.stg
+++ b/protokt-codegen/src/main/resources/options.stg
@@ -29,31 +29,6 @@ wrapField(wrapName, arg, type, oneof) ::= <%
     )
 %>
 
-protoTypesToJavaClassNames ::= [
-    "BOOL": "Boolean",
-    "DOUBLE": "Double",
-    "FIXED32": "Integer",
-    "FIXED64": "Long",
-    "FLOAT": "Float",
-    "INT32": "Integer",
-    "INT64": "Long",
-    "SFIXED32": "Integer",
-    "SFIXED64": "Long",
-    "SINT32": "Integer",
-    "SINT64": "Long",
-    "STRING": "String",
-    "UINT32": "Integer",
-    "UINT64": "Long"
-]
-
-typeToJavaClassName(type) ::= <%
-    <if (protoTypesToJavaClassNames.(type))>
-        java.lang.<protoTypesToJavaClassNames.(type)>
-    <else>
-        [B
-    <endif>
-%>
-
 nullDeserializeVar ::= [
     "MESSAGE": true,
     default: false

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/types.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/types.kt
@@ -107,27 +107,31 @@ class BytesSlice(
     }
 }
 
-enum class PType(val kotlinRepresentation: KClass<*>? = null) {
-    BOOL,
-    BYTES,
-    DOUBLE,
+enum class PType(
+    val kotlinRepresentation: KClass<*>? = null,
+    val inlineRepresentation: KClass<*>? = null
+) {
+    BOOL(Boolean::class),
+    BYTES(ByteArray::class),
+    DOUBLE(Double::class),
     ENUM,
-    FIXED32(Fixed32::class),
-    FIXED64(Fixed64::class),
-    FLOAT,
-    INT32(Int32::class),
-    INT64(Int64::class),
+    FIXED32(Int::class, Fixed32::class),
+    FIXED64(Long::class, Fixed64::class),
+    FLOAT(Float::class),
+    INT32(Int::class, Int32::class),
+    INT64(Long::class, Int64::class),
     MESSAGE,
-    SFIXED32(SFixed32::class),
-    SFIXED64(SFixed64::class),
-    SINT32(SInt32::class),
-    SINT64(SInt64::class),
-    STRING,
-    UINT32(UInt32::class),
-    UINT64(UInt64::class);
+    SFIXED32(Int::class, SFixed32::class),
+    SFIXED64(Long::class, SFixed64::class),
+    SINT32(Int::class, SInt32::class),
+    SINT64(Long::class, SInt64::class),
+    STRING(String::class),
+    UINT32(Int::class, UInt32::class),
+    UINT64(Long::class, UInt64::class);
 
-    val packed get() =
-        this != BYTES &&
-        this != MESSAGE &&
-        this != STRING
+    val packed
+        get() =
+            this != BYTES &&
+                this != MESSAGE &&
+                this != STRING
 }

--- a/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/name_conflicts.proto
+++ b/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/name_conflicts.proto
@@ -34,3 +34,15 @@ message Constant {
 message Model {
   other.Model model = 1;
 }
+
+message ContainsUnit {
+  enum Unit {
+    first = 0;
+  }
+
+  Unit unit = 1;
+}
+
+message Unit {
+  ContainsUnit unit = 1;
+}

--- a/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/name_conflicts.proto
+++ b/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/name_conflicts.proto
@@ -46,3 +46,9 @@ message ContainsUnit {
 message Unit {
   ContainsUnit unit = 1;
 }
+
+message ContainsFloat {
+  oneof type {
+    string float = 1;
+  }
+}


### PR DESCRIPTION
Built on https://github.com/open-toast/protokt/pull/38.

The next step in code change is to move `StandardField.typePClass()` into StandardField itself, so the process of figuring out a class representation for each field will be unified and as far up the chain as possible.