### PR TITLE
Fix name conflict when oneof implements interface with same name as itself

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -129,9 +129,11 @@ private constructor(
     }
 
     private fun options(oneof: Oneof) =
-        oneof.options.protokt.implements.emptyToNone().fold(
-            { OneofTemplate.Options(false) },
-            { OneofTemplate.Options(true, possiblyQualify(it)) }
+        OneofTemplate.Options(
+            oneof.options.protokt.implements.emptyToNone().fold(
+                { null },
+                { possiblyQualify(it) }
+            )
         )
 
     private fun possiblyQualify(implements: String) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Oneof.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Oneof.kt
@@ -32,8 +32,7 @@ object Oneof {
         )
 
         class Options(
-            val doesImplement: Boolean,
-            val implements: String = ""
+            val implements: String?
         )
     }
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Oneof.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Oneof.kt
@@ -33,7 +33,7 @@ object Oneof {
 
         class Options(
             val doesImplement: Boolean,
-            val implements: String
+            val implements: String = ""
         )
     }
 

--- a/protokt-codegen/src/main/resources/message.stg
+++ b/protokt-codegen/src/main/resources/message.stg
@@ -35,6 +35,7 @@ private constructor(
 ) : KtMessage<messageImplements()> {
     <if (oneofs)>
     <oneofs:{it |<it>}; separator="\n\n">
+
     <else>
     <endif>
     override val messageSize by lazy { sizeof() }

--- a/protokt-codegen/src/main/resources/oneof.stg
+++ b/protokt-codegen/src/main/resources/oneof.stg
@@ -25,7 +25,6 @@ sealed class <name> <oneofDoesImplement()>{
     val <types.(k).fieldName>: <types.(k).type>
 ) : <name>()<oneofImplements()>}; separator="\n\n">
 }
-
 >>
 
 defaultValue() ::= "null"

--- a/protokt-codegen/src/main/resources/oneof.stg
+++ b/protokt-codegen/src/main/resources/oneof.stg
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import "options.stg"
 import "renderers.stg"
 
 oneof(name, types, options) ::= <<
@@ -30,3 +29,15 @@ sealed class <name> <oneofDoesImplement()>{
 defaultValue() ::= "null"
 
 deserialize(oneof, name, read) ::= "<oneof>.<name>(<read>)"
+
+oneofDoesImplement() ::= <%
+    <if (options.implements)>
+        : <options.implements><\ >
+    <endif>
+%>
+
+oneofImplements() ::= <%
+    <if (options.implements)>
+        , <options.implements> by <types.(k).fieldName><\ >
+    <endif>
+%>

--- a/protokt-codegen/src/main/resources/options.stg
+++ b/protokt-codegen/src/main/resources/options.stg
@@ -61,18 +61,6 @@ messagePropertyOverrides() ::= <%
     <if (p.overrides)>override <endif>
 %>
 
-oneofDoesImplement() ::= <%
-    <if (options.doesImplement)>
-        : <options.implements><\ >
-    <endif>
-%>
-
-oneofImplements() ::= <%
-    <if (options.doesImplement)>
-        , <options.implements> by <types.(k).fieldName><\ >
-    <endif>
-%>
-
 deprecated(any) ::= <%
     <if (any.deprecation)>
         @Deprecated(

--- a/testing/options/src/main/proto/com/toasttab/protokt/testing/options/oneof_implements.proto
+++ b/testing/options/src/main/proto/com/toasttab/protokt/testing/options/oneof_implements.proto
@@ -43,4 +43,17 @@ message ContainsOneofThatImplements {
     ImplementsOneof1 implements_one = 1;
     ImplementsOneof2 implements_two = 2;
   }
+
+  // name conflict
+  oneof OneofModel {
+    option (.protokt.oneof).implements = "OneofModel";
+
+    ImplementsOneof1 implements_one_with_name_conflict = 3;
+  }
+
+  oneof OneofModelFullyQualified {
+    option (.protokt.oneof).implements = "com.toasttab.protokt.testing.options.OneofModel";
+
+    ImplementsOneof1 implements_one_with_full_qualification = 4;
+  }
 }


### PR DESCRIPTION
```kotlin
interface Config
```

```protobuf
message MyDomainObject {
  oneof Config {
    option (protokt.oneof).implements = "Config";
    ServerSpecified server_updated = 2;
  }
}
```

```
sealed class Config : com.toasttab.example.Config {
    data class ServerUpdated(
        val serverSpecified: ServerSpecified

    // interface name must be fully qualified; currently is not
    ) : Config(), com.toasttab.example.Config by serverUpdated 

...
```