### PR TITLE
add testProtoktExtensions

### DIFF
--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/DslExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/DslExtensions.kt
@@ -30,6 +30,9 @@ fun Project.protokt(cfg: ProtoktExtension.() -> Unit) = project.configure(cfg)
 fun DependencyHandler.protoktExtensions(dependencyNotation: Any): Dependency? =
     add(EXTENSIONS, dependencyNotation)
 
+fun DependencyHandler.testProtoktExtensions(dependencyNotation: Any): Dependency? =
+    add(TEST_EXTENSIONS, dependencyNotation)
+
 val SourceSet.kotlin: SourceDirectorySet
     get() =
         (this as HasConvention)

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt.gradle
 
+import com.google.protobuf.gradle.GenerateProtoTask
 import com.google.protobuf.gradle.builtins
 import com.google.protobuf.gradle.generateProtoTasks
 import com.google.protobuf.gradle.id
@@ -24,6 +25,7 @@ import com.google.protobuf.gradle.protoc
 import com.google.protobuf.gradle.remove
 import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.os.OperatingSystem
@@ -63,7 +65,7 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
                 task.plugins {
                     id("protokt") {
                         project.afterEvaluate {
-                            option("$KOTLIN_EXTRA_CLASSPATH=${project.extraClasspath()}")
+                            option("$KOTLIN_EXTRA_CLASSPATH=${extraClasspath(project, task)}")
                             option("$RESPECT_JAVA_PACKAGE=${ext.respectJavaPackage}")
                             option("$GENERATE_GRPC=${ext.generateGrpc}")
                             option("$ONLY_GENERATE_GRPC=${ext.onlyGenerateGrpc}")
@@ -75,10 +77,15 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
     }
 }
 
-private fun Project.extraClasspath() =
-    (configurations.getByName(EXTENSIONS) + configurations.getByName(TEST_EXTENSIONS))
-        .asPath
-        .replace(':', ';')
+private fun extraClasspath(project: Project, task: GenerateProtoTask): String {
+    var extensions: FileCollection = project.configurations.getByName(EXTENSIONS)
+
+    if (task.isTest) {
+        extensions += project.configurations.getByName(TEST_EXTENSIONS)
+    }
+
+    return extensions.asPath.replace(':', ';')
+}
 
 private fun configureSources(project: Project, generatedSourcesPath: String) {
     val protoktDir = "$generatedSourcesPath/main/protokt"

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -63,13 +63,7 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
                 task.plugins {
                     id("protokt") {
                         project.afterEvaluate {
-                            val classpath =
-                                project.configurations
-                                    .getByName(EXTENSIONS)
-                                    .asPath
-                                    .replace(':', ';')
-
-                            option("$KOTLIN_EXTRA_CLASSPATH=$classpath")
+                            option("$KOTLIN_EXTRA_CLASSPATH=${project.extraClasspath()}")
                             option("$RESPECT_JAVA_PACKAGE=${ext.respectJavaPackage}")
                             option("$GENERATE_GRPC=${ext.generateGrpc}")
                             option("$ONLY_GENERATE_GRPC=${ext.onlyGenerateGrpc}")
@@ -80,6 +74,11 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
         }
     }
 }
+
+private fun Project.extraClasspath() =
+    (configurations.getByName(EXTENSIONS) + configurations.getByName(TEST_EXTENSIONS))
+        .asPath
+        .replace(':', ';')
 
 private fun configureSources(project: Project, generatedSourcesPath: String) {
     val protoktDir = "$generatedSourcesPath/main/protokt"

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtoktBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtoktBuild.kt
@@ -22,20 +22,28 @@ const val CODEGEN_NAME = "protoc-gen-protokt"
 
 const val EXTENSIONS = "protoktExtensions"
 
+const val TEST_EXTENSIONS = "testProtoktExtensions"
+
 const val MANIFEST_VERSION_PROPERTY = "Implementation-Version"
 
 fun configureProtokt(project: Project, resolveBinary: () -> String) {
-    createExtensionConfiguration(project)
+    createExtensionConfigurations(project)
 
     val ext = project.extensions.create<ProtoktExtension>("protokt")
 
     configureProtobufPlugin(project, ext, resolveBinary())
 }
 
-private fun createExtensionConfiguration(project: Project) {
+private fun createExtensionConfigurations(project: Project) {
     val extensionsConfiguration = project.configurations.create(EXTENSIONS)
 
     project.configurations.named("api") {
         extendsFrom(extensionsConfiguration)
+    }
+
+    val testExtensionsConfiguration = project.configurations.create(TEST_EXTENSIONS)
+
+    project.configurations.named("testApi") {
+        extendsFrom(testExtensionsConfiguration)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,8 +43,9 @@ include(
 
     "testing:conformance-driver",
     "testing:conformance-tests",
-    "testing:options-api",
     "testing:options",
+    "testing:options-api",
+    "testing:options-test-configurations",
     "testing:plugin-options",
     "testing:plugin-options:ignore-java-package",
     "testing:protobuf-java",

--- a/testing/options-test-configurations/build.gradle.kts
+++ b/testing/options-test-configurations/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.protobuf.gradle.testProtobuf
+import com.toasttab.protokt.gradle.testProtoktExtensions
+
+localProtokt()
+pureKotlin()
+
+dependencies {
+    testProtoktExtensions(project(":testing:options-api"))
+    testProtoktExtensions(project(":extensions:publish"))
+
+    testProtobuf(project(":testing:options"))
+}


### PR DESCRIPTION
Allows protobuf in src/test/proto to use extensions not available to main code.