### PR TITLE
Add wrapper types for map keys and values

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/AnnotatorUtils.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/AnnotatorUtils.kt
@@ -20,7 +20,7 @@ import arrow.core.Some
 import com.toasttab.protokt.codegen.algebra.AST
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyTypeName
-import com.toasttab.protokt.codegen.impl.Wrapper.interceptTypeName
+import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapValueTypeName
 import com.toasttab.protokt.codegen.protoc.MapEntry
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.Oneof
@@ -38,7 +38,7 @@ fun resolveMapEntryTypes(f: StandardField, ctx: Context) =
     f.mapEntry!!.let {
         MapTypeParams(
             interceptMapKeyTypeName(f, it.key.unqualifiedTypeName, ctx),
-            interceptTypeName(f, it.value.typePClass.renderName(ctx.pkg), ctx)
+            interceptMapValueTypeName(f, it.value.typePClass.renderName(ctx.pkg), ctx)
         )
     }
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -24,6 +24,8 @@ import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptReadFn
 import com.toasttab.protokt.codegen.impl.Wrapper.keyWrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
+import com.toasttab.protokt.codegen.impl.Wrapper.mapValueConverter
+import com.toasttab.protokt.codegen.impl.Wrapper.valueWrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapperName
 import com.toasttab.protokt.codegen.model.FieldType
@@ -101,10 +103,12 @@ private constructor(
             lhs = f.fieldName,
             packed = packed,
             options =
-                if (f.wrapped || f.keyWrapped) {
+                if (f.wrapped || f.keyWrapped || f.valueWrapped) {
                     Options(
                         wrapName = wrapperName(f, ctx).getOrElse { "" },
                         keyWrap = mapKeyConverter(f, ctx),
+                        valueWrap = mapValueConverter(f, ctx),
+                        valueType = f.mapEntry?.value?.type,
                         type = f.type.toString(),
                         oneof = true
                     )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -104,7 +104,7 @@ private constructor(
                 if (f.wrapped || f.keyWrapped) {
                     Options(
                         wrapName = wrapperName(f, ctx).getOrElse { "" },
-                        keyWrap = mapKeyConverter(f, msg, ctx),
+                        keyWrap = mapKeyConverter(f, ctx),
                         type = f.type.toString(),
                         oneof = true
                     )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -21,9 +21,9 @@ import arrow.core.Some
 import arrow.core.getOrElse
 import com.toasttab.protokt.codegen.impl.MessageAnnotator.idealMaxWidth
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
-import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptReadFn
 import com.toasttab.protokt.codegen.impl.Wrapper.keyWrapped
+import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapperName
 import com.toasttab.protokt.codegen.model.FieldType

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -21,8 +21,9 @@ import arrow.core.Some
 import arrow.core.getOrElse
 import com.toasttab.protokt.codegen.impl.MessageAnnotator.idealMaxWidth
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
-import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyAccess
+import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptReadFn
+import com.toasttab.protokt.codegen.impl.Wrapper.keyWrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapperName
 import com.toasttab.protokt.codegen.model.FieldType
@@ -100,10 +101,10 @@ private constructor(
             lhs = f.fieldName,
             packed = packed,
             options =
-                if (f.wrapped || f.options.protokt.keyWrap.isNotEmpty()) {
+                if (f.wrapped || f.keyWrapped) {
                     Options(
                         wrapName = wrapperName(f, ctx).getOrElse { "" },
-                        keyWrap = interceptMapKeyAccess(f, msg, ctx),
+                        keyWrap = mapKeyConverter(f, msg, ctx),
                         type = f.type.toString(),
                         oneof = true
                     )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/DeserializerAnnotator.kt
@@ -21,6 +21,7 @@ import arrow.core.Some
 import arrow.core.getOrElse
 import com.toasttab.protokt.codegen.impl.MessageAnnotator.idealMaxWidth
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
+import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptReadFn
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapped
 import com.toasttab.protokt.codegen.impl.Wrapper.wrapperName
@@ -99,9 +100,10 @@ private constructor(
             lhs = f.fieldName,
             packed = packed,
             options =
-                if (f.wrapped) {
+                if (f.wrapped || f.options.protokt.keyWrap.isNotEmpty()) {
                     Options(
                         wrapName = wrapperName(f, ctx).getOrElse { "" },
+                        keyWrap = interceptMapKeyAccess(f, msg, ctx),
                         type = f.type.toString(),
                         oneof = true
                     )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -101,7 +101,7 @@ private constructor(
             field = f,
             any =
                 if (f.map) {
-                    typeParams(f.protoTypeName)
+                    typeParams(f)
                 } else {
                     interceptTypeName(
                         f,
@@ -111,24 +111,10 @@ private constructor(
                 }
         )
 
-    private fun typeParams(n: String) =
-        findType(n, msg)
-            .map { resolveMapEntryTypes(it, ctx) }
+    private fun typeParams(f: StandardField) =
+        findType(f.protoTypeName, msg)
+            .map { resolveMapEntryTypes(f, it, ctx) }
             .getOrElse { error("missing type params") }
-
-    private fun findType(
-        tn: String,
-        msg: Message
-    ): Option<Message> {
-        val n = tn.split(".").let { if (it.isEmpty()) tn else it.last() }
-        return msg.nestedTypes.find {
-            when (it) {
-                is Message ->
-                    if (it.name == n) Some(it) else findType(n, it)
-                else -> None
-            }.isDefined()
-        }.toOption().map { f -> f as Message }
-    }
 
     private fun Field.defaultValue(ctx: Context) =
         when (this) {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -15,11 +15,7 @@
 
 package com.toasttab.protokt.codegen.impl
 
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.Some
 import arrow.core.getOrElse
-import arrow.core.toOption
 import com.toasttab.protokt.codegen.impl.Deprecation.renderOptions
 import com.toasttab.protokt.codegen.impl.Implements.overrides
 import com.toasttab.protokt.codegen.impl.Nullability.deserializeType
@@ -112,9 +108,7 @@ private constructor(
         )
 
     private fun typeParams(f: StandardField) =
-        findType(f.protoTypeName, msg)
-            .map { resolveMapEntryTypes(f, it, ctx) }
-            .getOrElse { error("missing type params") }
+        resolveMapEntryTypes(f, findMapEntryMessage(f.protoTypeName, msg), ctx)
 
     private fun Field.defaultValue(ctx: Context) =
         when (this) {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -15,7 +15,6 @@
 
 package com.toasttab.protokt.codegen.impl
 
-import arrow.core.getOrElse
 import com.toasttab.protokt.codegen.impl.Deprecation.renderOptions
 import com.toasttab.protokt.codegen.impl.Implements.overrides
 import com.toasttab.protokt.codegen.impl.Nullability.deserializeType
@@ -97,7 +96,11 @@ private constructor(
             field = f,
             any =
                 if (f.map) {
-                    typeParams(f)
+                    resolveMapEntryTypes(
+                        f,
+                        findMapEntryMessage(f.protoTypeName, msg),
+                        ctx
+                    )
                 } else {
                     interceptTypeName(
                         f,
@@ -106,9 +109,6 @@ private constructor(
                     )
                 }
         )
-
-    private fun typeParams(f: StandardField) =
-        resolveMapEntryTypes(f, findMapEntryMessage(f.protoTypeName, msg), ctx)
 
     private fun Field.defaultValue(ctx: Context) =
         when (this) {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/PropertyAnnotator.kt
@@ -96,11 +96,7 @@ private constructor(
             field = f,
             any =
                 if (f.map) {
-                    resolveMapEntryTypes(
-                        f,
-                        findMapEntryMessage(f.protoTypeName, msg),
-                        ctx
-                    )
+                    resolveMapEntryTypes(f, ctx)
                 } else {
                     interceptTypeName(
                         f,

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
@@ -99,7 +99,7 @@ private constructor(
             tag = f.tag.value,
             box =
                 if (f.map) {
-                    f.boxMap(ctx)
+                    f.boxMap(msg, ctx)
                 } else {
                     f.box(fieldAccess)
                 },

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SerializerAnnotator.kt
@@ -99,7 +99,7 @@ private constructor(
             tag = f.tag.value,
             box =
                 if (f.map) {
-                    f.boxMap(msg, ctx)
+                    f.boxMap(ctx)
                 } else {
                     f.box(fieldAccess)
                 },

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -21,7 +21,7 @@ import arrow.core.Some
 import com.toasttab.protokt.codegen.impl.Nullability.hasNonNullOption
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptFieldSizeof
-import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyAccess
+import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptSizeof
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.protoc.Message
@@ -89,7 +89,7 @@ private constructor(
                     fieldSizeof = interceptFieldSizeof(f, name, ctx),
                     fieldAccess =
                         interceptValueAccess(f, ctx, IterationVar.render()),
-                    keyAccess = interceptMapKeyAccess(f, msg, ctx)
+                    keyAccess = mapKeyConverter(f, msg, ctx)
                 )
         )
     }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -21,9 +21,9 @@ import arrow.core.Some
 import com.toasttab.protokt.codegen.impl.Nullability.hasNonNullOption
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptFieldSizeof
-import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptSizeof
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
+import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.Oneof
 import com.toasttab.protokt.codegen.protoc.StandardField

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -21,6 +21,7 @@ import arrow.core.Some
 import com.toasttab.protokt.codegen.impl.Nullability.hasNonNullOption
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptFieldSizeof
+import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptSizeof
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.protoc.Message
@@ -87,7 +88,8 @@ private constructor(
                 Options(
                     fieldSizeof = interceptFieldSizeof(f, name, ctx),
                     fieldAccess =
-                        interceptValueAccess(f, ctx, IterationVar.render())
+                        interceptValueAccess(f, ctx, IterationVar.render()),
+                    keyAccess = interceptMapKeyAccess(f, msg, ctx)
                 )
         )
     }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -24,6 +24,7 @@ import com.toasttab.protokt.codegen.impl.Wrapper.interceptFieldSizeof
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptSizeof
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
+import com.toasttab.protokt.codegen.impl.Wrapper.mapValueConverter
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.Oneof
 import com.toasttab.protokt.codegen.protoc.StandardField
@@ -89,7 +90,9 @@ private constructor(
                     fieldSizeof = interceptFieldSizeof(f, name, ctx),
                     fieldAccess =
                         interceptValueAccess(f, ctx, IterationVar.render()),
-                    keyAccess = mapKeyConverter(f, ctx)
+                    keyAccess = mapKeyConverter(f, ctx),
+                    valueAccess = mapValueConverter(f, ctx),
+                    valueType = f.mapEntry?.value?.type
                 )
         )
     }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/SizeofAnnotator.kt
@@ -89,7 +89,7 @@ private constructor(
                     fieldSizeof = interceptFieldSizeof(f, name, ctx),
                     fieldAccess =
                         interceptValueAccess(f, ctx, IterationVar.render()),
-                    keyAccess = mapKeyConverter(f, msg, ctx)
+                    keyAccess = mapKeyConverter(f, ctx)
                 )
         )
     }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
@@ -16,7 +16,7 @@
 package com.toasttab.protokt.codegen.impl
 
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
-import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyAccess
+import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.StandardField
@@ -72,7 +72,7 @@ internal fun StandardField.boxMap(m: Message, ctx: Context) =
     BoxMap.render(
         type = type,
         box = unqualifiedNestedTypeName(ctx),
-        keyAccess = interceptMapKeyAccess(this, m, ctx)
+        keyWrap = mapKeyConverter(this, m, ctx)
     )
 
 internal fun StandardField.box(s: String) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
@@ -16,7 +16,7 @@
 package com.toasttab.protokt.codegen.impl
 
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
-import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyValueAccess
+import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.StandardField
@@ -72,7 +72,7 @@ internal fun StandardField.boxMap(m: Message, ctx: Context) =
     BoxMap.render(
         type = type,
         box = unqualifiedNestedTypeName(ctx),
-        keyAccess = interceptMapKeyValueAccess(this, m, ctx)
+        keyAccess = interceptMapKeyAccess(this, m, ctx)
     )
 
 internal fun StandardField.box(s: String) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
@@ -18,6 +18,7 @@ package com.toasttab.protokt.codegen.impl
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
+import com.toasttab.protokt.codegen.impl.Wrapper.mapValueConverter
 import com.toasttab.protokt.codegen.protoc.StandardField
 import com.toasttab.protokt.codegen.protoc.Tag
 import com.toasttab.protokt.codegen.template.Renderers.Box
@@ -71,7 +72,11 @@ internal fun StandardField.boxMap(ctx: Context) =
     BoxMap.render(
         type = type,
         box = unqualifiedNestedTypeName(ctx),
-        keyWrap = mapKeyConverter(this, ctx)
+        options = BoxMap.Options(
+            keyWrap = mapKeyConverter(this, ctx),
+            valueWrap = mapValueConverter(this, ctx),
+            valueType = mapEntry!!.value.type
+        )
     )
 
 internal fun StandardField.box(s: String) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
@@ -18,7 +18,6 @@ package com.toasttab.protokt.codegen.impl
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
-import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.StandardField
 import com.toasttab.protokt.codegen.protoc.Tag
 import com.toasttab.protokt.codegen.template.Renderers.Box
@@ -68,11 +67,11 @@ internal fun StandardField.nonDefault(ctx: Context) =
         name = interceptValueAccess(this, ctx)
     )
 
-internal fun StandardField.boxMap(m: Message, ctx: Context) =
+internal fun StandardField.boxMap(ctx: Context) =
     BoxMap.render(
         type = type,
         box = unqualifiedNestedTypeName(ctx),
-        keyWrap = mapKeyConverter(this, m, ctx)
+        keyWrap = mapKeyConverter(this, ctx)
     )
 
 internal fun StandardField.box(s: String) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
@@ -16,8 +16,8 @@
 package com.toasttab.protokt.codegen.impl
 
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
-import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
+import com.toasttab.protokt.codegen.impl.Wrapper.mapKeyConverter
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.StandardField
 import com.toasttab.protokt.codegen.protoc.Tag

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldExt.kt
@@ -16,7 +16,9 @@
 package com.toasttab.protokt.codegen.impl
 
 import com.toasttab.protokt.codegen.impl.STAnnotator.Context
+import com.toasttab.protokt.codegen.impl.Wrapper.interceptMapKeyValueAccess
 import com.toasttab.protokt.codegen.impl.Wrapper.interceptValueAccess
+import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.protoc.StandardField
 import com.toasttab.protokt.codegen.protoc.Tag
 import com.toasttab.protokt.codegen.template.Renderers.Box
@@ -66,10 +68,11 @@ internal fun StandardField.nonDefault(ctx: Context) =
         name = interceptValueAccess(this, ctx)
     )
 
-internal fun StandardField.boxMap(ctx: Context) =
+internal fun StandardField.boxMap(m: Message, ctx: Context) =
     BoxMap.render(
         type = type,
-        box = unqualifiedNestedTypeName(ctx)
+        box = unqualifiedNestedTypeName(ctx),
+        keyAccess = interceptMapKeyValueAccess(this, m, ctx)
     )
 
 internal fun StandardField.box(s: String) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldImportResolver.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/StandardFieldImportResolver.kt
@@ -18,7 +18,7 @@ package com.toasttab.protokt.codegen.impl
 import com.github.andrewoma.dexx.kollection.ImmutableSet
 import com.github.andrewoma.dexx.kollection.immutableSetOf
 import com.toasttab.protokt.codegen.impl.Wrapper.converter
-import com.toasttab.protokt.codegen.impl.Wrapper.foldWrap
+import com.toasttab.protokt.codegen.impl.Wrapper.foldFieldWrap
 import com.toasttab.protokt.codegen.model.Import
 import com.toasttab.protokt.codegen.model.PPackage
 import com.toasttab.protokt.codegen.model.pclass
@@ -81,7 +81,7 @@ class StandardFieldImportResolver(
             set.add(Import.Class(f.typePClass))
         }
 
-        f.foldWrap(
+        f.foldFieldWrap(
             pkg,
             ctx,
             { },

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Wrapper.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Wrapper.kt
@@ -41,7 +41,7 @@ import com.toasttab.protokt.codegen.template.Renderers.FieldSizeof
 import com.toasttab.protokt.ext.OptimizedSizeofConverter
 import kotlin.reflect.KClass
 
-internal object Wrapper {
+object Wrapper {
     val StandardField.wrapped
         get() = wrapWithWellKnownInterception.isDefined()
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Wrapper.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Wrapper.kt
@@ -249,7 +249,7 @@ internal object Wrapper {
                 { unqualifiedWrap(it, ctx.pkg) }
             )
 
-    fun interceptMapKeyValueAccess(f: StandardField, m: Message, ctx: Context) =
+    fun interceptMapKeyAccess(f: StandardField, m: Message, ctx: Context) =
         f.options.protokt.keyWrap.emptyToNone()
             .map {
                 getClass(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Protocol.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Protocol.kt
@@ -333,7 +333,7 @@ private fun toStandard(
                     fdp.type == FieldDescriptorProto.Type.TYPE_MESSAGE &&
                     ctx.findLocal(fdp.typeName).fold(
                         { false },
-                        { it.options?.mapEntry == true }
+                        { it.options.mapEntry }
                     ),
             fieldName = newFieldName(fdp.name, usedFieldNames),
             options =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/ProtocolContext.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/ProtocolContext.kt
@@ -15,10 +15,6 @@
 
 package com.toasttab.protokt.codegen.protoc
 
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.extensions.list.foldable.find
-import com.google.protobuf.DescriptorProtos.DescriptorProto
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 import com.toasttab.protokt.codegen.model.PPackage
 import com.toasttab.protokt.gradle.GENERATE_GRPC
@@ -46,28 +42,3 @@ fun respectJavaPackage(params: Map<String, String>) =
 
 fun ProtocolContext.ppackage(typeName: String) =
     allPackagesByTypeName.getValue(typeName)
-
-fun ProtocolContext.findLocal(
-    name: String,
-    parent: Option<DescriptorProto> = None
-): Option<DescriptorProto> {
-    val (typeList, typeName) =
-        parent.fold(
-            {
-                fdp.messageTypeList.filterNotNull() to
-                    name.removePrefix(".${fdp.`package`}.")
-            },
-            { it.nestedTypeList.filterNotNull() to name }
-        )
-
-    typeName.indexOf('.').let { idx ->
-        return if (idx == -1) {
-            typeList.find { it.name == typeName }
-        } else {
-            findLocal(
-                typeName.substring(idx + 1),
-                typeList.find { it.name == typeName.substring(0, idx) }
-            )
-        }
-    }
-}

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Types.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Types.kt
@@ -104,11 +104,19 @@ class StandardField(
     val repeated: Boolean,
     val optional: Boolean,
     val packed: Boolean,
-    val map: Boolean,
+    val mapEntry: MapEntry?,
     val protoTypeName: String,
     val options: FieldOptions,
     val index: Int
-) : Field()
+) : Field() {
+    val map
+        get() = mapEntry != null
+}
+
+class MapEntry(
+    val key: StandardField,
+    val value: StandardField
+)
 
 class FieldOptions(
     val default: DescriptorProtos.FieldOptions,

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
@@ -33,8 +33,14 @@ object Renderers {
     }
 
     object BoxMap : RenderersTemplate() {
-        fun render(type: FieldType, box: String, keyWrap: String?) =
-            renderArgs(type, box, keyWrap)
+        fun render(type: FieldType, box: String, options: Options) =
+            renderArgs(type, box, options)
+
+        class Options(
+            val keyWrap: String?,
+            val valueWrap: String?,
+            val valueType: FieldType
+        )
     }
 
     object ConcatWithScope : RenderersTemplate() {
@@ -82,6 +88,8 @@ object Renderers {
         class Options(
             val wrapName: String,
             val keyWrap: String?,
+            val valueWrap: String?,
+            val valueType: FieldType?,
             val type: String,
             val oneof: Boolean
         )
@@ -104,7 +112,9 @@ object Renderers {
         class Options(
             val fieldSizeof: String,
             val fieldAccess: Any,
-            val keyAccess: String?
+            val keyAccess: String?,
+            val valueAccess: String?,
+            val valueType: FieldType?
         )
     }
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
@@ -81,6 +81,7 @@ object Renderers {
 
         class Options(
             val wrapName: String,
+            val keyWrap: String?,
             val type: String,
             val oneof: Boolean
         )

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
@@ -33,8 +33,8 @@ object Renderers {
     }
 
     object BoxMap : RenderersTemplate() {
-        fun render(type: FieldType, box: String) =
-            renderArgs(type, box)
+        fun render(type: FieldType, box: String, keyAccess: String?) =
+            renderArgs(type, box, keyAccess)
     }
 
     object ConcatWithScope : RenderersTemplate() {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
@@ -33,8 +33,8 @@ object Renderers {
     }
 
     object BoxMap : RenderersTemplate() {
-        fun render(type: FieldType, box: String, keyAccess: String?) =
-            renderArgs(type, box, keyAccess)
+        fun render(type: FieldType, box: String, keyWrap: String?) =
+            renderArgs(type, box, keyWrap)
     }
 
     object ConcatWithScope : RenderersTemplate() {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Renderers.kt
@@ -102,7 +102,8 @@ object Renderers {
 
         class Options(
             val fieldSizeof: String,
-            val fieldAccess: Any
+            val fieldAccess: Any,
+            val keyAccess: String?
         )
     }
 

--- a/protokt-codegen/src/main/resources/companion.stg
+++ b/protokt-codegen/src/main/resources/companion.stg
@@ -33,8 +33,8 @@ companion object Deserializer : KtDeserializer\<<message.name>\>, (<message.name
                         <if (properties)>,<endif>
                         finishMap(unknown)
                     )
-                <deserialize:{d | <d.tag> -> <d.assignment.fieldName> = <\\>
-                <if ((!d.std || d.repeated || d.assignment.long))><\n><t()><endif><\\>
+                <deserialize:{d | <d.tag> -> <d.assignment.fieldName> =<\\>
+                <if ((!d.std || d.repeated || d.assignment.long))><\n><t()><else><\ ><endif><\\>
                 <d.assignment.value>}; separator="\n">
                 else -> unknown =
                     (unknown ?: mutableMapOf()).also {

--- a/protokt-codegen/src/main/resources/entry.stg
+++ b/protokt-codegen/src/main/resources/entry.stg
@@ -44,7 +44,7 @@ companion object Deserializer : KtDeserializer\<<name>\> {
 
         while (true) {
             when (deserializer.readTag()) {
-                0 -> return <name>(key, value <orDefault(value)>)
+                0 -> return <name>(key, value<orDefault(value)>)
                 <key.deserialize.tag> -> key = <key.deserialize.assignment>
                 <value.deserialize.tag> -> value = <value.deserialize.assignment>
             }
@@ -62,6 +62,6 @@ deserializeVar(p) ::= <%
 
 orDefault(p) ::= <%
     <if (isMessage.(p.messageType))>
-        ?: <value.propertyType> {}
+        <\ >?: <value.propertyType> {}
     <endif>
 %>

--- a/protokt-codegen/src/main/resources/message.stg
+++ b/protokt-codegen/src/main/resources/message.stg
@@ -127,7 +127,7 @@ private constructor(
     <companion()>
     <if (nested)>
 
-    <nested><\\>
+    <nested:{n | <n>}; separator="\n"><\\>
     <endif><\\>
 }
 

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -182,24 +182,36 @@ serializer.write(Tag(<tag>)).write(<box>)<\\>
 <endif>
 >>
 
-deserialize(field, read, lhs, options, packed) ::= <<
-<if (field.map)>
-(<lhs> ?: mutableMapOf()).apply {
-        deserializer.readRepeated(false) {
-            <read>
-                .let { put(it.key, it.value) }
-        }
-    }<\\>
-<elseif (field.repeated)>
-(<lhs> ?: mutableListOf()).apply {
-        deserializer.readRepeated(<packed>) {
-            add(<wrapDeserializeRead(options, deserializerRead(read))>)
-        }
-    }<\\>
-<else>
-<wrapDeserializeRead(options, deserializerRead(read))><\\>
-<endif>
->>
+deserialize(field, read, lhs, options, packed) ::= <%
+    <if (field.map)>
+        <deserializeMap()>
+    <elseif (field.repeated)>
+        (<lhs> ?: mutableListOf()).apply {<\n>
+            <t()>deserializer.readRepeated(<packed>) {<\n>
+                <t()><t()>add(<wrapDeserializeRead(options, deserializerRead(read))>)<\n>
+            <t()>}<\n>
+        }<\n>
+    <else>
+        <wrapDeserializeRead(options, deserializerRead(read))>
+    <endif>
+%>
+
+deserializeMap() ::= <%
+    (<lhs> ?: mutableMapOf()).apply {<\n>
+        <t()><t()>deserializer.readRepeated(false) {<\n>
+            <t()><t()><t()><read><\n>
+                <t()><t()><t()><t()>.let { put(
+                    <if (options.keyWrap)>
+                        <wrapField(options.keyWrap, deserializeMapKey())>
+                    <else>
+                        <deserializeMapKey()>
+                    <endif>
+                    , it.value) }<\n>
+        <t()><t()>}<\n>
+    <t()>}<\n>
+%>
+
+deserializeMapKey() ::= "it.key"
 
 deserializerRead(read) ::= "deserializer.<read>"
 

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -213,23 +213,31 @@ standard(field, any) ::= <%
     <endif>
 %>
 
-sizeof(name, field, type, options) ::= <<
-<if(field.map)><\\>
-sizeofMap(<name>, Tag(<field.number>)) { k, v ->
-        <type>.sizeof(k, v)
-    }<\\>
-<elseif(field.repeated && field.packed)><\\>
-sizeof(Tag(<field.number>)) +
-    <name>
-        .sumBy { sizeof(<box(field.type, iterationVar())>) }
-        .let { it + sizeof(UInt32(it)) }<\\>
-<elseif(field.repeated && !field.map)><\\>
-(sizeof(Tag(<field.number>)) * <name>.size) +
-        <name>.sumBy { sizeof(<box(field.type, options.fieldAccess)>) }<\\>
-<else><\\>
-sizeof(Tag(<field.number>)) + <options.fieldSizeof><\\>
-<endif>
->>
+sizeof(name, field, type, options) ::= <%
+    <if(field.map)>
+        sizeofMap(<name>, Tag(<field.number>)) { k, v -><\n>
+            <t()><t()><type>.sizeof(
+            <if (options.keyAccess)>
+                <accessField(options.keyAccess, sizeofMapKey())>
+            <else>
+                <sizeofMapKey()>
+            <endif>
+            , v)<\n>
+        <t()>}
+    <elseif(field.repeated && field.packed)>
+        sizeof(Tag(<field.number>)) +<\n>
+            <t()><t()><name><\n>
+                <t()><t()><t()>.sumBy { sizeof(<box(field.type, iterationVar())>) }<\n>
+                <t()><t()><t()>.let { it + sizeof(UInt32(it)) }
+    <elseif(field.repeated && !field.map)>
+        (sizeof(Tag(<field.number>)) * <name>.size) +<\n>
+            <t()><t()><name>.sumBy { sizeof(<box(field.type, options.fieldAccess)>) }
+    <else>
+        sizeof(Tag(<field.number>)) + <options.fieldSizeof>
+    <endif>
+%>
+
+sizeofMapKey() ::= "k"
 
 fieldSizeof(field, name) ::= <%
     sizeof(<box(field.type, name)>)

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -70,11 +70,11 @@ read(type, builder) ::= "<readFunctions.(type)>(<builder>)"
 
 box(type, def) ::= "<if (type.boxed)><type.boxer>(<def>)<else><def><endif>"
 
-boxMap(type, box, keyAccess) ::= <%
+boxMap(type, box, keyWrap) ::= <%
     <if (isMessage.(type))>
         <box>(
-        <if (keyAccess)>
-            <accessField(keyAccess, keyAccess())>
+        <if (keyWrap)>
+            <accessField(keyWrap, keyAccess())>
         <else>
             <keyAccess()>
         <endif>

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -227,15 +227,7 @@ standard(field, any) ::= <%
 
 sizeof(name, field, type, options) ::= <%
     <if(field.map)>
-        sizeofMap(<name>, Tag(<field.number>)) { k, v -><\n>
-            <t()><t()><type>.sizeof(
-            <if (options.keyAccess)>
-                <accessField(options.keyAccess, sizeofMapKey())>
-            <else>
-                <sizeofMapKey()>
-            <endif>
-            , v)<\n>
-        <t()>}
+        <sizeofMap()>
     <elseif(field.repeated && field.packed)>
         sizeof(Tag(<field.number>)) +<\n>
             <t()><t()><name><\n>
@@ -247,6 +239,18 @@ sizeof(name, field, type, options) ::= <%
     <else>
         sizeof(Tag(<field.number>)) + <options.fieldSizeof>
     <endif>
+%>
+
+sizeofMap() ::= <%
+    sizeofMap(<name>, Tag(<field.number>)) { k, v -><\n>
+        <t()><t()><type>.sizeof(
+        <if (options.keyAccess)>
+            <accessField(options.keyAccess, sizeofMapKey())>
+        <else>
+            <sizeofMapKey()>
+        <endif>
+        , v)<\n>
+    <t()>}
 %>
 
 sizeofMapKey() ::= "k"

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -187,10 +187,10 @@ deserialize(field, read, lhs, options, packed) ::= <%
         <deserializeMap()>
     <elseif (field.repeated)>
         (<lhs> ?: mutableListOf()).apply {<\n>
-            <t()>deserializer.readRepeated(<packed>) {<\n>
-                <t()><t()>add(<wrapDeserializeRead(options, deserializerRead(read))>)<\n>
-            <t()>}<\n>
-        }<\n>
+            <t()><t()>deserializer.readRepeated(<packed>) {<\n>
+                <t()><t()><t()>add(<wrapDeserializeRead(options, deserializerRead(read))>)<\n>
+            <t()><t()>}<\n>
+        <t()>}
     <else>
         <wrapDeserializeRead(options, deserializerRead(read))>
     <endif>
@@ -208,7 +208,7 @@ deserializeMap() ::= <%
                     <endif>
                     , it.value) }<\n>
         <t()><t()>}<\n>
-    <t()>}<\n>
+    <t()>}
 %>
 
 deserializeMapKey() ::= "it.key"

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -64,26 +64,44 @@ isBool ::= ["BOOL": true, default: false]
 
 isGeneratedType ::= ["MESSAGE": true, "ENUM": true, default: false]
 
-isBytes ::= ["BYTES": true, "STRING": true, default: false]
+isBytes ::= ["BYTES": true, default: false]
+
+isString ::= ["STRING": true, default: false]
 
 read(type, builder) ::= "<readFunctions.(type)>(<builder>)"
 
 box(type, def) ::= "<if (type.boxed)><type.boxer>(<def>)<else><def><endif>"
 
-boxMap(type, box, keyWrap) ::= <%
+boxMap(type, box, options) ::= <%
     <if (isMessage.(type))>
         <box>(
-        <if (keyWrap)>
-            <accessField(keyWrap, keyAccess())>
+        <if (options.keyWrap)>
+            <accessField(options.keyWrap, keyAccess())>
         <else>
             <keyAccess()>
         <endif>
-        , it.value)
+        ,<\ >
+        <if (options.valueWrap)>
+            <maybeConstructBytes(accessField(options.valueWrap, valueAccess()))>
+        <else>
+            <valueAccess()>
+        <endif>
+        )
     <else>
     <endif>
 %>
 
 keyAccess() ::= "it.key"
+
+valueAccess() ::= "it.value"
+
+maybeConstructBytes(arg) ::= <%
+    <if (isBytes.(options.valueType))>
+        Bytes(<arg>)
+    <else>
+        <arg>
+    <endif>
+%>
 
 deserializeType(p) ::= <%
     <if (p.repeated || p.map)>
@@ -147,7 +165,7 @@ defaultValue(field, type, name) ::= <%
 
 nonDefaultValue(field, name) ::= <%
     <if (field.repeated)>(<field.fieldName>.isNotEmpty())<\ >
-    <elseif (isBytes.(field.type))>(<name>.isNotEmpty())<\ >
+    <elseif (isBytes.(field.type) || isString.(field.type))>(<name>.isNotEmpty())<\ >
     <elseif (isMessage.(field.type))>(<field.fieldName> != null)<\ >
     <elseif (isEnum.(field.type))>(<name>.value != 0)<\ >
     <elseif (field.type.scalar)>
@@ -202,16 +220,20 @@ deserializeMap() ::= <%
             <t()><t()><t()><read><\n>
                 <t()><t()><t()><t()>.let { put(
                     <if (options.keyWrap)>
-                        <wrapField(options.keyWrap, deserializeMapKey())>
+                        <wrapField(options.keyWrap, keyAccess())>
                     <else>
-                        <deserializeMapKey()>
+                        <keyAccess()>
                     <endif>
-                    , it.value) }<\n>
+                    ,<\ >
+                    <if (options.valueWrap)>
+                        <wrapField(options.valueWrap, valueAccess(), options.valueType, true)>
+                    <else>
+                        <valueAccess()>
+                    <endif>
+                    ) }<\n>
         <t()><t()>}<\n>
     <t()>}
 %>
-
-deserializeMapKey() ::= "it.key"
 
 deserializerRead(read) ::= "deserializer.<read>"
 
@@ -249,11 +271,19 @@ sizeofMap() ::= <%
         <else>
             <sizeofMapKey()>
         <endif>
-        , v)<\n>
+        ,<\ >
+        <if (options.valueAccess)>
+            <maybeConstructBytes(accessField(options.valueAccess, sizeofMapValue()))>
+        <else>
+            <sizeofMapValue()>
+        <endif>
+        )<\n>
     <t()>}
 %>
 
 sizeofMapKey() ::= "k"
+
+sizeofMapValue() ::= "v"
 
 fieldSizeof(field, name) ::= <%
     sizeof(<box(field.type, name)>)

--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -70,7 +70,20 @@ read(type, builder) ::= "<readFunctions.(type)>(<builder>)"
 
 box(type, def) ::= "<if (type.boxed)><type.boxer>(<def>)<else><def><endif>"
 
-boxMap(type, box) ::= "<if (isMessage.(type))><box>(it.key, it.value)<else><endif>"
+boxMap(type, box, keyAccess) ::= <%
+    <if (isMessage.(type))>
+        <box>(
+        <if (keyAccess)>
+            <accessField(keyAccess, keyAccess())>
+        <else>
+            <keyAccess()>
+        <endif>
+        , it.value)
+    <else>
+    <endif>
+%>
+
+keyAccess() ::= "it.key"
 
 deserializeType(p) ::= <%
     <if (p.repeated || p.map)>

--- a/protokt-runtime/src/main/resources/protokt/protokt.proto
+++ b/protokt-runtime/src/main/resources/protokt/protokt.proto
@@ -22,74 +22,103 @@ import "google/protobuf/descriptor.proto";
 option java_package = "com.toasttab.protokt.ext";
 
 message ProtoktFileOptions {
+  // Specify the Kotlin package for the generated file. Precedence is given
+  // first to this Kotlin package, then to the Java package if enabled in
+  // the plugin options, and finally to the protobuf package.
   string kotlin_package = 1;
 }
 
-// Kotlin-specific options for files
 extend google.protobuf.FileOptions {
   ProtoktFileOptions file = 1072;
 }
 
 message ProtoktMessageOptions {
-  // Declares that the message class implements an interface
+  // Declares that the message class implements an interface. Scoping rules
+  // are the same as those for declaring wrapper types.
   string implements = 1;
 
   // Provides a message for deprecation
   string deprecation_message = 2;
 }
 
-// Kotlin-specific options for generated message classes
 extend google.protobuf.MessageOptions {
   ProtoktMessageOptions class = 1072;
 }
 
 message ProtoktFieldOptions {
-  // makes a message-type field not nullable in Kotlin code
-  // beware that deserialization will NPE if the field is missing from the protobuf payload
-  bool non_null = 1;
-
-  // Use a wrapper data class instead of a raw protobuf type.
+  // Makes a message-type field non-nullable in the generated Kotlin code.
+  // Beware that deserialization will NPE if the field is missing from the
+  // protobuf payload. Adding a non-null field to an existing message is a
+  // backwards-incompatible change.
   //
   // For example:
   //
   // message Foo {
-  //   string id = 1 [(protokt.property).wrap = "FooId"];
+  //   string id = 1 [(protokt.property).non_null = true];
+  // }
+  bool non_null = 1;
+
+  // Expose a wrapper class instead of a raw protobuf type.
+  //
+  // For example:
+  //
+  // message Foo {
+  //   string id = 1 [(protokt.property).wrap = "com.foo.FooId"];
   // }
   //
   // data class FooId(val value: String)
   //
   // will yield:
-  // data class Foo(val id: FooId) ...
+  // class Foo(val id: FooId) ...
   //
-  // For external types such as java.util.Date:
+  // If the Kotlin package (or Java package, if the Kotlin package is
+  // unspecified) of this file is the same as the package of the wrapper type,
+  // full qualification is optional.
   //
-  // message Foo {
-  //   int64 timestamp = 1 [(protokt.property).wrap = "java.util.Date"];
-  // }
-  //
-  // will yield:
-  // data class Foo(val timestamp: java.util.Date) ...
+  // This option can be applied to repeated fields.
   string wrap = 2;
 
-  // Maps a bytes field to BytesSlice. If being deserialized from a byte array,
+  // Maps a bytes field to BytesSlice. If deserialized from a byte array,
   // BytesSlice will point to the source array without copying the subarray.
   bool bytes_slice = 3;
 
   // Provides a message for deprecation
   string deprecation_message = 4;
+
+  // Expose a wrapper class instead of a raw protobuf type for the key type of
+  // a map.
+  //
+  // For example:
+  //
+  // message Foo {
+  //   map<string, int32> map = 1 [(protokt.property).key_wrap = "com.foo.FooId"];
+  // }
+  //
+  // data class FooId(val value: String)
+  //
+  // will yield:
+  // class Foo(val map: Map<FooId, String>) ...
+  //
+  // Scoping rules  are the same as those for declaring regular field wrapper types.
+  string key_wrap = 5;
 }
 
-// Kotlin-specific options for the properties of generated message classes
 extend google.protobuf.FieldOptions {
   ProtoktFieldOptions property = 1072;
 }
 
 message ProtoktOneofOptions {
+  // Makes a oneof field non-nullable in generated Kotlin code. Beware that
+  // deserialization will NPE if the field is missing from the protobuf payload.
+  // Adding a non-null field to an existing message is a backwards-incompatible
+  // change.
+  //
   // For example:
   //
   // message Message {
   //   oneof some_field_name {
   //     option (protokt.oneof).non_null = true;
+  //
   //     string id = 1;
   //   }
   // }
@@ -97,14 +126,14 @@ message ProtoktOneofOptions {
   bool non_null = 1;
 
   // Make the sealed class implement an interface, enforcing the presence of a
-  // property in each possible variant
+  // property in each possible variant. Scoping rules  are the same as those
+  // for declaring wrapper types.
   string implements = 2;
 
   // Provides a message for deprecation
   string deprecation_message = 3;
 }
 
-// Kotlin-specific options for the properties of generated Oneof classes
 extend google.protobuf.OneofOptions {
   ProtoktOneofOptions oneof = 1072;
 }

--- a/protokt-runtime/src/main/resources/protokt/protokt.proto
+++ b/protokt-runtime/src/main/resources/protokt/protokt.proto
@@ -101,6 +101,23 @@ message ProtoktFieldOptions {
   //
   // Scoping rules  are the same as those for declaring regular field wrapper types.
   string key_wrap = 5;
+
+  // Expose a wrapper class instead of a raw protobuf type for the value type of
+  // a map.
+  //
+  // For example:
+  //
+  // message Foo {
+  //   map<int32, strig> map = 1 [(protokt.property).value_wrap = "com.foo.FooId"];
+  // }
+  //
+  // data class FooId(val value: String)
+  //
+  // will yield:
+  // class Foo(val map: Map<Int, FooId>) ...
+  //
+  // Scoping rules  are the same as those for declaring regular field wrapper types.
+  string value_wrap = 6;
 }
 
 extend google.protobuf.FieldOptions {

--- a/testing/options/src/main/proto/com/toasttab/protokt/testing/options/wrapper_types.proto
+++ b/testing/options/src/main/proto/com/toasttab/protokt/testing/options/wrapper_types.proto
@@ -100,4 +100,8 @@ message MapWrapperModel {
   map<string, int32> map = 1 [
     (.protokt.property).key_wrap = "StringBox"
   ];
+
+  map<int32, int32> map_int = 2 [
+    (.protokt.property).key_wrap = "IntBox"
+  ];
 }

--- a/testing/options/src/main/proto/com/toasttab/protokt/testing/options/wrapper_types.proto
+++ b/testing/options/src/main/proto/com/toasttab/protokt/testing/options/wrapper_types.proto
@@ -95,3 +95,9 @@ message RepeatedWrapperModel {
     (.protokt.property).wrap = "java.util.UUID"
   ];
 }
+
+message MapWrapperModel {
+  map<string, int32> map = 1 [
+    (.protokt.property).key_wrap = "StringBox"
+  ];
+}

--- a/testing/options/src/main/proto/com/toasttab/protokt/testing/options/wrapper_types.proto
+++ b/testing/options/src/main/proto/com/toasttab/protokt/testing/options/wrapper_types.proto
@@ -23,7 +23,7 @@ import "google/protobuf/wrappers.proto";
 import "protokt/ext/inet_socket_address.proto";
 import "protokt/protokt.proto";
 
-message WrapperModel {
+message Wrappers {
   bytes id = 1 [
     (.protokt.property).wrap = "Id"
   ];
@@ -56,7 +56,7 @@ message WrapperModel {
   ];
 }
 
-message OneOfWrapperModel {
+message OneofWrappers {
   oneof wrapped_oneof {
     option (.protokt.oneof).non_null = true;
 
@@ -86,7 +86,7 @@ message OneOfWrapperModel {
   }
 }
 
-message RepeatedWrapperModel {
+message RepeatedWrappers {
   repeated bytes uuids = 1 [
     (.protokt.property).wrap = "java.util.UUID"
   ];
@@ -96,12 +96,40 @@ message RepeatedWrapperModel {
   ];
 }
 
-message MapWrapperModel {
-  map<string, int32> map = 1 [
+message MapWrappers {
+  map<string, int32> map_string_key_wrapped = 1 [
     (.protokt.property).key_wrap = "StringBox"
   ];
 
-  map<int32, int32> map_int = 2 [
+  map<int32, int32> map_int_key_wrapped = 2 [
     (.protokt.property).key_wrap = "IntBox"
+  ];
+
+  map<string, string> map_string_value_wrapped = 3 [
+    (.protokt.property).value_wrap = "StringBox"
+  ];
+
+  map<int32, int32> map_int_value_wrapped = 4 [
+    (.protokt.property).value_wrap = "IntBox"
+  ];
+
+  map<string, string> map_string_double_wrapped = 5 [
+    (.protokt.property).key_wrap = "StringBox",
+    (.protokt.property).value_wrap = "StringBox"
+  ];
+
+  map<int32, int32> map_int_double_wrapped = 6 [
+    (.protokt.property).key_wrap = "IntBox",
+    (.protokt.property).value_wrap = "IntBox"
+  ];
+
+  map<string, bytes> map_string_uuid = 7 [
+    (.protokt.property).key_wrap = "StringBox",
+    (.protokt.property).value_wrap = "java.util.UUID"
+  ];
+
+  map<string, .protokt.ext.InetSocketAddress> map_string_socket_address = 8 [
+    (.protokt.property).key_wrap = "StringBox",
+    (.protokt.property).value_wrap = "java.net.InetSocketAddress"
   ];
 }

--- a/testing/options/src/test/kotlin/com/toasttab/protokt/testing/options/WrapperTypesTest.kt
+++ b/testing/options/src/test/kotlin/com/toasttab/protokt/testing/options/WrapperTypesTest.kt
@@ -167,4 +167,36 @@ class WrapperTypesTest {
         assertThat(thrown).hasMessageThat()
             .isEqualTo("instant specified nonnull with (protokt.property).non_null but was null")
     }
+
+    @Test
+    fun `round trip preserves repeated wrapped types`() {
+        val list = listOf(UUID.randomUUID())
+
+        val obj =
+            RepeatedWrappers {
+                uuids = list
+                uuidsWrapped = list
+            }
+
+        assertThat(obj.uuids).isEqualTo(list)
+        assertThat(obj.uuidsWrapped).isEqualTo(list)
+
+        assertThat(RepeatedWrappers.deserialize(obj.serialize()))
+            .isEqualTo(obj)
+    }
+
+    @Test
+    fun `round trip preserves map wrapped types`() {
+        val map = mapOf(StringBox("some-string") to UUID.randomUUID())
+
+        val obj =
+            MapWrappers {
+                mapStringUuid = map
+            }
+
+        assertThat(obj.mapStringUuid).isEqualTo(map)
+
+        assertThat(MapWrappers.deserialize(obj.serialize()))
+            .isEqualTo(obj)
+    }
 }

--- a/testing/options/src/test/kotlin/com/toasttab/protokt/testing/options/WrapperTypesTest.kt
+++ b/testing/options/src/test/kotlin/com/toasttab/protokt/testing/options/WrapperTypesTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.assertThrows
 
 class WrapperTypesTest {
     private val model =
-        WrapperModel {
+        Wrappers {
             id = Id("asdf")
             ipAddress = InetAddress.getByAddress(byteArrayOf(0, 0, 0, 1))
             uuid = UUID.randomUUID()
@@ -38,113 +38,113 @@ class WrapperTypesTest {
 
     @Test
     fun `round trip should preserve model`() {
-        assertThat(WrapperModel.deserialize(model.serialize())).isEqualTo(model)
+        assertThat(Wrappers.deserialize(model.serialize())).isEqualTo(model)
     }
 
     @Test
     fun `round trip should preserve generic wrapper`() {
-        val deserialized = WrapperModel.deserialize(model.serialize())
+        val deserialized = Wrappers.deserialize(model.serialize())
 
         assertThat(deserialized.id).isEqualTo(model.id)
     }
 
     @Test
     fun `round trip should preserve ip address`() {
-        val deserialized = WrapperModel.deserialize(model.serialize())
+        val deserialized = Wrappers.deserialize(model.serialize())
 
         assertThat(deserialized.ipAddress).isEqualTo(model.ipAddress)
     }
 
     @Test
     fun `round trip should preserve uuid`() {
-        val deserialized = WrapperModel.deserialize(model.serialize())
+        val deserialized = Wrappers.deserialize(model.serialize())
 
         assertThat(deserialized.uuid).isEqualTo(model.uuid)
     }
 
     @Test
     fun `round trip should preserve socket address`() {
-        val deserialized = WrapperModel.deserialize(model.serialize())
+        val deserialized = Wrappers.deserialize(model.serialize())
 
         assertThat(deserialized.socketAddress).isEqualTo(model.socketAddress)
     }
 
     @Test
     fun `round trip should preserve instant`() {
-        val deserialized = WrapperModel.deserialize(model.serialize())
+        val deserialized = Wrappers.deserialize(model.serialize())
 
         assertThat(deserialized.instant).isEqualTo(model.instant)
     }
 
     @Test
     fun `round trip should preserve duration`() {
-        val deserialized = WrapperModel.deserialize(model.serialize())
+        val deserialized = Wrappers.deserialize(model.serialize())
 
         assertThat(deserialized.duration).isEqualTo(model.duration)
     }
 
     @Test
     fun `round trip should preserve generic wrapper oneOf`() {
-        val deserialized = OneOfWrapperModel.deserialize(
-            OneOfWrapperModel {
-                wrappedOneof = OneOfWrapperModel.WrappedOneof.IdOneof(model.id)
+        val deserialized = OneofWrappers.deserialize(
+            OneofWrappers {
+                wrappedOneof = OneofWrappers.WrappedOneof.IdOneof(model.id)
             }.serialize()
         )
 
         assertThat(
-            (deserialized.wrappedOneof as OneOfWrapperModel.WrappedOneof.IdOneof).idOneof
+            (deserialized.wrappedOneof as OneofWrappers.WrappedOneof.IdOneof).idOneof
         ).isEqualTo(model.id)
     }
 
     @Test
     fun `round trip should preserve uuid oneOf`() {
-        val deserialized = OneOfWrapperModel.deserialize(
-            OneOfWrapperModel {
-                wrappedOneof = OneOfWrapperModel.WrappedOneof.UuidOneof(model.uuid)
+        val deserialized = OneofWrappers.deserialize(
+            OneofWrappers {
+                wrappedOneof = OneofWrappers.WrappedOneof.UuidOneof(model.uuid)
             }.serialize()
         )
 
         assertThat(
-            (deserialized.wrappedOneof as OneOfWrapperModel.WrappedOneof.UuidOneof).uuidOneof
+            (deserialized.wrappedOneof as OneofWrappers.WrappedOneof.UuidOneof).uuidOneof
         ).isEqualTo(model.uuid)
     }
 
     @Test
     fun `round trip should preserve ip address oneOf`() {
-        val deserialized = OneOfWrapperModel.deserialize(
-            OneOfWrapperModel {
-                wrappedOneof = OneOfWrapperModel.WrappedOneof.IpAddressOneof(model.ipAddress)
+        val deserialized = OneofWrappers.deserialize(
+            OneofWrappers {
+                wrappedOneof = OneofWrappers.WrappedOneof.IpAddressOneof(model.ipAddress)
             }.serialize()
         )
 
         assertThat(
-            (deserialized.wrappedOneof as OneOfWrapperModel.WrappedOneof.IpAddressOneof).ipAddressOneof
+            (deserialized.wrappedOneof as OneofWrappers.WrappedOneof.IpAddressOneof).ipAddressOneof
         ).isEqualTo(model.ipAddress)
     }
 
     @Test
     fun `round trip should preserve instant oneOf`() {
-        val deserialized = OneOfWrapperModel.deserialize(
-            OneOfWrapperModel {
-                wrappedOneof = OneOfWrapperModel.WrappedOneof.InstantOneof(model.instant)
+        val deserialized = OneofWrappers.deserialize(
+            OneofWrappers {
+                wrappedOneof = OneofWrappers.WrappedOneof.InstantOneof(model.instant)
             }.serialize()
         )
 
         assertThat(
-            (deserialized.wrappedOneof as OneOfWrapperModel.WrappedOneof.InstantOneof).instantOneof
+            (deserialized.wrappedOneof as OneofWrappers.WrappedOneof.InstantOneof).instantOneof
         ).isEqualTo(model.instant)
     }
 
     @Test
     fun `round trip should preserve socket address oneOf`() {
-        val deserialized = OneOfWrapperModel.deserialize(
-            OneOfWrapperModel {
-                wrappedOneof = OneOfWrapperModel.WrappedOneof.SocketAddressOneof(model.socketAddress)
+        val deserialized = OneofWrappers.deserialize(
+            OneofWrappers {
+                wrappedOneof = OneofWrappers.WrappedOneof.SocketAddressOneof(model.socketAddress)
             }.serialize()
         )
 
         assertThat(
-            (deserialized.wrappedOneof as OneOfWrapperModel.WrappedOneof.SocketAddressOneof).socketAddressOneof
+            (deserialized.wrappedOneof as OneofWrappers.WrappedOneof.SocketAddressOneof).socketAddressOneof
         ).isEqualTo(model.socketAddress)
     }
 


### PR DESCRIPTION
This revealed that it seems to be a cleaner interface to Wrapper.kt to expose the converter as a nullable type than to try to pass through and replace field accesses. I'll probably revisit the existing wrapper type code and see if that cleans things up a bit, since it's not pretty.

Fixes #26.