### PR TITLE
Don't qualify oneof type name when it doesn't share a name with its enclosing type

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -91,6 +91,7 @@ private constructor(
             PClass.fromName(fieldType).let {
                 // If a wrapper type is specified and it shares a name with the
                 // oneof, it must be fully qualified.
+                // See testing/options/src/main/proto/com/toasttab/protokt/testing/options/oneof_exercises.proto
                 if (unqualifiedType.simpleName == it.simpleName) {
                     it.possiblyQualify(ctx.pkg).qualifiedName
                 } else {
@@ -109,21 +110,25 @@ private constructor(
         val pClass = f.typePClass
 
         // Cannot strip qualifiers for field type in a different package
+        // See testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/oneof_packages.proto
         val requiresQualifiedTypeName = pClass.ppackage != ctx.pkg
 
         return if (requiresQualifiedTypeName) {
             pClass.renderName(ctx.pkg)
         } else {
-            if (oneofFieldTypeName == pClass.nestedName) {
-                // Oneof field name shares name of its type
-                if (oneofFieldTypeName == pClass.simpleName) {
-                    // Oneof field name shares name of its enclosing type
+            // See testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/oneof_exercises.proto
+            if (oneofFieldTypeName == pClass.simpleName) {
+                if (oneofFieldTypeName == pClass.nestedName) {
                     pClass.qualifiedName
+                } else {
+                    pClass.nestedName
+                }
+            } else {
+                if (oneofFieldTypeName == pClass.nestedName) {
+                    pClass.nestedName
                 } else {
                     pClass.simpleName
                 }
-            } else {
-                pClass.nestedName
             }
         }
     }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/OneofAnnotator.kt
@@ -124,11 +124,7 @@ private constructor(
                     pClass.nestedName
                 }
             } else {
-                if (oneofFieldTypeName == pClass.nestedName) {
-                    pClass.nestedName
-                } else {
-                    pClass.simpleName
-                }
+                pClass.simpleName
             }
         }
     }

--- a/testing/options/src/main/proto/com/toasttab/protokt/testing/options/oneof_exercises.proto
+++ b/testing/options/src/main/proto/com/toasttab/protokt/testing/options/oneof_exercises.proto
@@ -25,7 +25,7 @@ import "protokt/protokt.proto";
 
 message OneofExerciseModelWithWrapper {
   oneof oneof {
-    // Needs full qualification: com.toasttab.testing.options.CachingId
+    // Needs full qualification: com.toasttab.protokt.testing.options.CachingId
     bytes caching_id = 1 [
       (.protokt.property).wrap = "CachingId"
     ];

--- a/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/oneof_exercises.proto
+++ b/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/oneof_exercises.proto
@@ -15,7 +15,7 @@
 
 syntax = "proto3";
 
-package com.toasttab.protokt.testing.rt;
+package com.toasttab.protokt.testing.rt.oneof;
 
 // This file exercises oneofs whose names are the same as their
 // generated sealed class type names. If the code generator does
@@ -40,7 +40,7 @@ message OneofExerciseModel {
 
 message OneofExerciseModel2 {
   oneof oneof {
-    // Needs full qualification: com.toasttab.model.OneofExerciseModel
+    // Needs full qualification: com.toasttab.protokt.testing.rt.oneof.OneofExerciseModel
     OneofExerciseModel oneof_exercise_model = 1;
   }
 }

--- a/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/oneof_exercises.proto
+++ b/testing/runtime-tests/src/main/proto/com/toasttab/protokt/testing/rt/oneof/oneof_exercises.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast Inc.
+ * Copyright (c) 2020 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,32 @@
 
 syntax = "proto3";
 
-package com.toasttab.protokt.testing.options;
-
-import "protokt/protokt.proto";
+package com.toasttab.protokt.testing.rt;
 
 // This file exercises oneofs whose names are the same as their
 // generated sealed class type names. If the code generator does
 // not handle them properly then compilation will fail.
 
-message OneofExerciseModelWithWrapper {
+message OneofExerciseModel {
   oneof oneof {
-    // Needs full qualification: com.toasttab.testing.options.CachingId
-    bytes caching_id = 1 [
-      (.protokt.property).wrap = "CachingId"
-    ];
+    // Needs partial qualification: OneofExerciseModel.Model
+    Model model = 1;
+  }
+
+  oneof oneof2 {
+    // Does not need partial qualification: Model
+    // This will still compile if qualified but may show a warning in IDEs
+    Model not_named_model = 2;
+  }
+
+  message Model {
+    bytes id = 1;
+  }
+}
+
+message OneofExerciseModel2 {
+  oneof oneof {
+    // Needs full qualification: com.toasttab.model.OneofExerciseModel
+    OneofExerciseModel oneof_exercise_model = 1;
   }
 }


### PR DESCRIPTION
```proto
message OneofExerciseModel {
  oneof oneof {
    // Does not need partial qualification and is currently being qualified as OneofExerciseModel.Model
    // If its name was `model` instead of `not_named_model`, then it would need that qualification, as
    // it would share a name with the data class created to hold it.
    Model not_named_model = 1;
  }

  message Model {
    bytes id = 1;
  }
}
```