### PR TITLE
Remove non-existent reference

### DIFF
--- a/protokt-codegen/src/main/resources/renderers.stg
+++ b/protokt-codegen/src/main/resources/renderers.stg
@@ -172,7 +172,7 @@ nonDefaultValue(field, name) ::= <%
     <elseif (field.repeated)>
         (<field.fieldName>.isNotEmpty())<\ >
     <elseif (isBytes.(field.type) || isString.(field.type))>
-        (<proto2Check()><name>.isNotEmpty())<\ >
+        (<name>.isNotEmpty())<\ >
     <elseif (isMessage.(field.type))>
         (<field.fieldName> != null)<\ >
     <elseif (isEnum.(field.type))>


### PR DESCRIPTION
I'm not sure how this got in here. It's not broken since StringTemplate defaults to the empty string when a reference is undefined.