### PR TITLE
Publish the public API as an artifact

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,5 +32,6 @@ dependencies {
     implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2")
     implementation("com.google.guava:guava:29.0-jre")
     implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.0")
+    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0")
     implementation(kotlin("gradle-plugin-api"))
 }

--- a/buildSrc/src/main/kotlin/KotlinApiCompatibility.kt
+++ b/buildSrc/src/main/kotlin/KotlinApiCompatibility.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+
+fun Project.trackKotlinApiCompatibility() {
+    apply(plugin = "binary-compatibility-validator")
+
+    tasks.named("apiCheck") {
+        enabled = false
+    }
+
+    configure<PublishingExtension> {
+        publications {
+            create<MavenPublication>("api") {
+                artifact("$buildDir/api/${project.name}.api") {
+                    extension = "api"
+                    classifier = "ktapi"
+                    builtBy(tasks.named("apiDump"))
+                }
+
+                artifactId = project.name
+                version = "${project.version}"
+                groupId = "$group"
+            }
+        }
+    }
+}

--- a/protokt-runtime/build.gradle.kts
+++ b/protokt-runtime/build.gradle.kts
@@ -15,6 +15,7 @@
 
 enablePublishing()
 compatibleWithAndroid()
+trackKotlinApiCompatibility()
 
 dependencies {
     compileOnly(libraries.protobuf)


### PR DESCRIPTION
This is step 1 of enforcing backwards compatibility of the runtime. Apply the [Binary compatibility validator](https://github.com/Kotlin/binary-compatibility-validator) plugin and publish its output as an artifact.