### PR TITLE
Ensure runtime's binary compatibility with previous release

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinApiCompatibility.kt
+++ b/buildSrc/src/main/kotlin/KotlinApiCompatibility.kt
@@ -14,7 +14,6 @@
  */
 
 import kotlinx.validation.ApiCompareCompareTask
-import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
@@ -28,16 +27,11 @@ import org.gradle.kotlin.dsl.register
 fun Project.trackKotlinApiCompatibility(validate: Boolean = true) {
     apply(plugin = "binary-compatibility-validator")
 
-    configure<ApiValidationExtension> {
-        validationDisabled = !validate
-    }
-
     if (validate) {
         val apiDir = buildDir.resolve("reference-api")
 
         tasks.named<ApiCompareCompareTask>("apiCheck") {
             projectApiDir = apiDir
-
             dependsOn("downloadPreviousApiSignatures")
         }
 
@@ -54,6 +48,10 @@ fun Project.trackKotlinApiCompatibility(validate: Boolean = true) {
             }
 
             into(apiDir)
+        }
+    } else {
+        tasks.named<ApiCompareCompareTask>("apiCheck") {
+            enabled = false
         }
     }
 

--- a/extensions/protokt-extensions-api/build.gradle.kts
+++ b/extensions/protokt-extensions-api/build.gradle.kts
@@ -14,6 +14,7 @@
  */
 
 enablePublishing()
+trackKotlinApiCompatibility(validate = false)
 
 dependencies {
     compileOnly(libraries.protobuf)

--- a/extensions/protokt-extensions-proto-based/build.gradle.kts
+++ b/extensions/protokt-extensions-proto-based/build.gradle.kts
@@ -19,6 +19,7 @@ apply(plugin = "kotlin-kapt")
 
 localProtokt()
 enablePublishing()
+trackKotlinApiCompatibility(validate = false)
 
 dependencies {
     implementation(project(":extensions:protokt-extensions-api"))

--- a/extensions/protokt-extensions-simple/build.gradle.kts
+++ b/extensions/protokt-extensions-simple/build.gradle.kts
@@ -16,6 +16,7 @@
 apply(plugin = "kotlin-kapt")
 
 enablePublishing()
+trackKotlinApiCompatibility(validate = false)
 
 dependencies {
     implementation(project(":protokt-core"))

--- a/protokt-core/build.gradle.kts
+++ b/protokt-core/build.gradle.kts
@@ -21,6 +21,7 @@ localProtokt()
 pureKotlin()
 enablePublishing()
 compatibleWithAndroid()
+trackKotlinApiCompatibility(validate = false)
 
 dependencies {
     api(project(":extensions:protokt-extensions-api"))


### PR DESCRIPTION
Ensure backwards compatibility with previous release for `runtime`. Publish API descriptors for `extensions` and `core` (with plan to enable validation in the next release).