### PR TITLE
Urlencode extension classpath entries 

### DIFF
--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -24,6 +24,8 @@ import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 import com.google.protobuf.gradle.remove
 import java.io.File
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginConvention
@@ -84,7 +86,7 @@ private fun extraClasspath(project: Project, task: GenerateProtoTask): String {
         extensions += project.configurations.getByName(TEST_EXTENSIONS)
     }
 
-    return extensions.asPath.replace(':', ';')
+    return extensions.joinToString(";") { URLEncoder.encode(it.path, StandardCharsets.UTF_8) }
 }
 
 private fun configureSources(project: Project, generatedSourcesPath: String) {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/ProtocolContext.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/ProtocolContext.kt
@@ -22,13 +22,18 @@ import com.toasttab.protokt.gradle.KOTLIN_EXTRA_CLASSPATH
 import com.toasttab.protokt.gradle.ONLY_GENERATE_GRPC
 import com.toasttab.protokt.gradle.RESPECT_JAVA_PACKAGE
 import com.toasttab.protokt.util.getProtoktVersion
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 class ProtocolContext(
     val fdp: FileDescriptorProto,
     val allPackagesByTypeName: Map<String, PPackage>,
     params: Map<String, String>
 ) {
-    val classpath = params.getOrDefault(KOTLIN_EXTRA_CLASSPATH, "").split(";")
+    val classpath = params.getOrDefault(KOTLIN_EXTRA_CLASSPATH, "").split(";").map {
+        URLDecoder.decode(it, StandardCharsets.UTF_8)
+    }
+
     val respectJavaPackage = respectJavaPackage(params)
     val generateGrpc = params.getValue(GENERATE_GRPC).toBoolean()
     val onlyGenerateGrpc = params.getValue(ONLY_GENERATE_GRPC).toBoolean()


### PR DESCRIPTION
This allows `:` in the classpath entries, which usually happens on Windows OSes but is not exclusive to them.

Related: https://github.com/google/protobuf-gradle-plugin/issues/210.