### PR TITLE
update some dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,11 +27,11 @@ repositories {
 }
 
 dependencies {
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.5.1")
-    implementation("com.google.protobuf:protobuf-gradle-plugin:0.8.13")
-    implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2")
-    implementation("com.google.guava:guava:29.0-jre")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.12.4")
+    implementation("com.google.protobuf:protobuf-gradle-plugin:0.8.16")
+    implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0")
+    implementation("com.google.guava:guava:30.1.1-jre")
     implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.0")
-    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0")
+    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0")
     implementation(kotlin("gradle-plugin-api"))
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,18 +18,18 @@ import com.toasttab.protokt.gradle.DEFAULT_PROTOBUF_VERSION
 object versions {
     const val arrow = "0.10.5"
     const val autoService = "1.0-rc7"
-    const val grpc = "1.32.1"
+    const val grpc = "1.37.0"
     const val kollection = "0.7"
     const val kotlin = "1.3.72"
     const val kotlinxCoroutines = "1.3.7"
     const val protobuf = DEFAULT_PROTOBUF_VERSION
-    const val protobufPlugin = "0.8.13"
+    const val protobufPlugin = "0.8.16"
     const val stringTemplate = "4.3.1"
 
     // Test
-    const val jackson = "2.11.3"
-    const val junit = "5.7.0"
-    const val truth = "1.1"
+    const val jackson = "2.12.3"
+    const val junit = "5.7.1"
+    const val truth = "1.1.2"
 
     // Benchmarks
     const val datasets = "0.1.0"


### PR DESCRIPTION
Three dependencies are intertwined and must be updated together - Kotlin (to 1.4.x), Arrow (which pulls in Kotlin 1.3.x), and Gradle (which pulls in Kotlin 1.3.x before 6.8 and 1.4.x after).

That'll be a different PR.