### PR TITLE
Upgrade gradle, fix implicit task dependency, and fix Java targeting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,4 +72,9 @@ subprojects {
             }
         }
     }
+
+    configure<JavaPluginExtension> {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 }

--- a/buildSrc/src/main/kotlin/RemotePublishing.kt
+++ b/buildSrc/src/main/kotlin/RemotePublishing.kt
@@ -110,6 +110,14 @@ fun Project.enablePublishing(defaultJars: Boolean = true) {
             withSourcesJar()
         }
 
+        afterEvaluate {
+            if (tasks.findByName("generateProto") != null) {
+                tasks.named("sourcesJar").configure {
+                    dependsOn("generateProto")
+                }
+            }
+        }
+
         tasks.register<Jar>("javadocJar") {
             from("$rootDir/README.md")
             archiveClassifier.set("javadoc")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The `.module` files were depending on Java 11 by default since that's what we use to run the publish task:

```
{
      "name": "apiElements",
      "attributes": {
        "org.gradle.category": "library",
        "org.gradle.dependency.bundling": "external",
        "org.gradle.jvm.version": 11,
        "org.gradle.libraryelements": "jar",
        "org.gradle.usage": "java-api",
        "org.jetbrains.kotlin.localToProject": "public",
        "org.jetbrains.kotlin.platform.type": "jvm"
      },
```

Also fixes this warning that appears newly in Gradle 7:
```
Execution optimizations have been disabled for task ':protokt-core:sourcesJar' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/andrewparmet/protokt/protokt-core/build/generated-sources/main/protokt'. Reason: Task ':protokt-core:sourcesJar' uses this output of task ':protokt-core:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```