### PR TITLE
Verify extension modules' api compatibility

### DIFF
--- a/extensions/protokt-extensions-api/build.gradle.kts
+++ b/extensions/protokt-extensions-api/build.gradle.kts
@@ -14,7 +14,7 @@
  */
 
 enablePublishing()
-trackKotlinApiCompatibility(validate = false)
+trackKotlinApiCompatibility()
 
 dependencies {
     compileOnly(libraries.protobuf)

--- a/extensions/protokt-extensions-proto-based/build.gradle.kts
+++ b/extensions/protokt-extensions-proto-based/build.gradle.kts
@@ -19,7 +19,7 @@ apply(plugin = "kotlin-kapt")
 
 localProtokt()
 enablePublishing()
-trackKotlinApiCompatibility(validate = false)
+trackKotlinApiCompatibility()
 
 dependencies {
     implementation(project(":extensions:protokt-extensions-api"))

--- a/extensions/protokt-extensions-simple/build.gradle.kts
+++ b/extensions/protokt-extensions-simple/build.gradle.kts
@@ -16,7 +16,7 @@
 apply(plugin = "kotlin-kapt")
 
 enablePublishing()
-trackKotlinApiCompatibility(validate = false)
+trackKotlinApiCompatibility()
 
 dependencies {
     implementation(project(":protokt-core"))

--- a/protokt-core/build.gradle.kts
+++ b/protokt-core/build.gradle.kts
@@ -21,7 +21,7 @@ localProtokt()
 pureKotlin()
 enablePublishing()
 compatibleWithAndroid()
-trackKotlinApiCompatibility(validate = false)
+trackKotlinApiCompatibility()
 
 dependencies {
     api(project(":extensions:protokt-extensions-api"))


### PR DESCRIPTION
In previous versions, we added validation for the `runtime` module and started publishing api descriptors for the extension modules.