### PR TITLE
Run integration tests as a matrix job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,13 @@ parameters:
 executors:
   builder:
     parameters:
-      java: 
+      jdk:
         type: string
         default: "11.0"
     working_directory: ~/code
     docker:
-      - image: cimg/openjdk:<<parameters.java>>
+      - image: cimg/openjdk:<<parameters.jdk>>
     environment:
-      JAVA_OPTS: "-XX:MaxRAMPercentage=50"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
 commands:
@@ -77,14 +76,16 @@ jobs:
 
   integration:
     parameters:
-      java:
+      jdk:
         type: string
       kotlin:
         type: string
 
+    name: integration-jdk-<<parameters.jdk>-kotlin-<<parameters.kotlin>>
+
     executor: 
       name: builder
-      java: <<parameters.java>>
+      jdk: <<parameters.jdk>>
 
     steps:
       - checkout
@@ -117,7 +118,7 @@ workflows:
             - build
           matrix:
             parameters:
-              java: ["8.0", "11.0"]
+              jdk: ["8.0", "11.0"]
               kotlin: ["1.5.0", "1.4.32"]
       - release:
           context: OSS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,13 @@ parameters:
 
 executors:
   builder:
+    parameters:
+      java: 
+        type: string
+        default: "11.0"
     working_directory: ~/code
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:<<parameters.java>>
     environment:
       JAVA_OPTS: "-XX:MaxRAMPercentage=50"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -44,21 +48,18 @@ jobs:
           name: Build and test
           command: ./gradlew clean check publishToIntegrationRepository --stacktrace
 
-      - run:
-          name: Integration tests with Kotlin 1.4
-          command: cd gradle-plugin-integration-test && ./gradlew clean build -Dkotlin.version=1.4.32 -Dkotlin.api.version=1.4 --stacktrace
+      - persist_to_workspace:
+          root: build/repos
+          paths: 
+            - integration
 
-      - run:
-          name: Integration tests with Kotlin 1.5
-          command: cd gradle-plugin-integration-test && ./gradlew clean build -Dkotlin.version=1.5.0 -Dkotlin.api.version=1.5 --stacktrace
-
-      - when:
-          condition:
-            equal: [ true, << pipeline.parameters.benchmarks >> ]
-          steps:
-            run:
-              name: Benchmarks
-              command: ./gradlew benchmarks:run
+      # - when:
+      #     condition:
+      #       equal: [ true, << pipeline.parameters.benchmarks >> ]
+      #     steps:
+      #       run:
+      #         name: Benchmarks
+      #         command: ./gradlew benchmarks:run
 
       - write_cache
 
@@ -74,6 +75,27 @@ jobs:
       - store_artifacts:
           path: ~/test-results/junit
 
+  integration:
+    parameters:
+      java:
+        type: string
+      kotlin:
+        type: string
+
+    executor: 
+      name: builder
+      java: <<parameters.java>>
+
+    steps:
+      - checkout
+      - read_cache
+
+      - attach_workspace:
+        at: build/repos
+
+      - run:
+          name: Integration tests
+          command: cd gradle-plugin-integration-test && ./gradlew clean build -Dkotlin.version=<<parameters.kotlin>> --stacktrace
 
   release:
     executor: builder
@@ -86,9 +108,15 @@ jobs:
 
 workflows:
   version: 2.1
+
   build:
     jobs:
       - build
+      - integration:
+        matrix:
+          parameters:
+            java: ["8.0", "11.0"]
+            kotlin: ["1.5.0", "1.4.32"]
       - release:
           context: OSS
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,13 +52,13 @@ jobs:
           paths: 
             - integration
 
-      # - when:
-      #     condition:
-      #       equal: [ true, << pipeline.parameters.benchmarks >> ]
-      #     steps:
-      #       run:
-      #         name: Benchmarks
-      #         command: ./gradlew benchmarks:run
+      - when:
+         condition:
+           equal: [ true, << pipeline.parameters.benchmarks >> ]
+         steps:
+           run:
+             name: Benchmarks
+             command: ./gradlew benchmarks:run
 
       - write_cache
 
@@ -112,6 +112,7 @@ workflows:
     jobs:
       - build
       - integration:
+          name: integration-jdk-<<matrix.jdk>>-kotlin-<<matrix.kotlin>>
           requires:
             - build
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - read_cache
 
       - attach_workspace:
-        at: build/repos
+          at: build/repos
 
       - run:
           name: Integration tests
@@ -113,10 +113,10 @@ workflows:
     jobs:
       - build
       - integration:
-        matrix:
-          parameters:
-            java: ["8.0", "11.0"]
-            kotlin: ["1.5.0", "1.4.32"]
+          matrix:
+            parameters:
+              java: ["8.0", "11.0"]
+              kotlin: ["1.5.0", "1.4.32"]
       - release:
           context: OSS
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,8 @@ workflows:
     jobs:
       - build
       - integration:
+          requires:
+            - build
           matrix:
             parameters:
               java: ["8.0", "11.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,6 @@ jobs:
       kotlin:
         type: string
 
-    name: integration-jdk-<<parameters.jdk>-kotlin-<<parameters.kotlin>>
-
     executor: 
       name: builder
       jdk: <<parameters.jdk>>

--- a/gradle-plugin-integration-test/build.gradle.kts
+++ b/gradle-plugin-integration-test/build.gradle.kts
@@ -14,6 +14,7 @@
  */
 
 import com.toasttab.protokt.gradle.protoktExtensions
+import org.gradle.util.VersionNumber
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -55,8 +56,9 @@ tasks {
             allWarningsAsErrors = true
             jvmTarget = "1.8"
 
-            apiVersion = System.getProperty("kotlin.api.version", "1.4")
-            languageVersion = apiVersion
+            apiVersion = System.getProperty("kotlin.version")?.let { v ->
+                VersionNumber.parse(v).run { "$major.$minor" }
+            } ?: "1.4"
         }
     }
 


### PR DESCRIPTION
This change splits integration tests into a separate matrix job in the workflow. In particular, we will now verify that the plugin / codegen run on java 8 (see https://github.com/open-toast/protokt/pull/112).

<img width="724" alt="Screen Shot 2021-05-21 at 11 30 00 AM" src="https://user-images.githubusercontent.com/772933/119162217-2066d380-ba28-11eb-9558-e7cd5bd83050.png">

<img width="841" alt="Screen Shot 2021-05-21 at 11 29 40 AM" src="https://user-images.githubusercontent.com/772933/119162235-2492f100-ba28-11eb-85d4-383e027086c8.png">

We will consider adding other OSes and different Gradle versions into the matrix.