### PR TITLE
Add working gRPC examples for both Java and Kotlin gRPC bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ is represented as `String?`, etc.
 CodedOutputStream for best performance
 - gRPC [method descriptor and service descriptor generation](#grpc-code-generation)
 for use with [grpc-java](#integrating-with-grpcs-java-api) or 
-[grpc-kotlin](#integrating-with-grpcs-kotlin-api)
+[grpc-kotlin](#integrating-with-grpcs-kotlin-api) (see examples  in [examples](examples))
 
 #### Not yet implemented
 
@@ -906,9 +906,6 @@ fun checkHealth(): HealthCheckResponse =
 
 #### Integrating with gRPC's Kotlin API
 
-At the time of writing grpc-kotlin is still experimental. These examples
-compile against grpc-kotlin 0.1.4. Its APIs are subject to change.
-
 To use the coroutine-based implementations provided by grpc-kotlin:
 
 ```kotlin
@@ -967,10 +964,10 @@ plugins {
 
 ### Command line code generation
 
-```bash
-protokt$ ./gradlew assemble
+```sh
+protokt % ./gradlew assemble
 
-protokt$ protoc \
+protokt % protoc \
     --plugin=protoc-gen-custom=protokt-codegen/build/install/protoc-gen-protokt/bin/protoc-gen-protokt \
     --custom_out=<output-directory> \
     -I<path-to-proto-file-containing-directory> \
@@ -981,8 +978,8 @@ protokt$ protoc \
 For example, to generate files in `protokt/foo` from a file called `test.proto`
 located at `protokt/test.proto`:
 
-```bash
-protokt$ protoc \
+```sh
+protokt % protoc \
     --plugin=protoc-gen-custom=protokt-codegen/build/install/protoc-gen-protokt/bin/protoc-gen-protokt \
     --custom_out=foo \
     -I. \

--- a/benchmarks/protobuf-java/build.gradle.kts
+++ b/benchmarks/protobuf-java/build.gradle.kts
@@ -34,7 +34,7 @@ protobuf {
 
 dependencies {
     implementation(project(":benchmarks:util"))
-    implementation(libraries.protobuf)
+    implementation(libraries.protobufJava)
 
     protobuf(project(":benchmarks:schema"))
 }

--- a/benchmarks/protokt/build.gradle.kts
+++ b/benchmarks/protokt/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     protobuf(project(":benchmarks:schema"))
 
     implementation(libraries.kotlinReflect)
-    implementation(libraries.protobuf)
+    implementation(libraries.protobufJava)
     implementation(project(":benchmarks:util"))
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,8 @@ import com.toasttab.protokt.gradle.DEFAULT_PROTOBUF_VERSION
 object versions {
     const val arrow = "0.13.2"
     const val autoService = "1.0-rc7"
-    const val grpc = "1.37.0"
+    const val grpc = "1.38.0"
+    const val grpcKotlin = "1.1.0"
     const val kollection = "0.7"
     const val kotlin = "1.4.32"
     const val kotlinxCoroutines = "1.3.9"
@@ -47,6 +48,8 @@ object libraries {
     const val autoService = "com.google.auto.service:auto-service:${versions.autoService}"
     const val autoServiceAnnotations = "com.google.auto.service:auto-service-annotations:${versions.autoService}"
 
+    const val grpcKotlin = "io.grpc:grpc-kotlin-stub:${versions.grpcKotlin}"
+    const val grpcNetty = "io.grpc:grpc-netty:${versions.grpc}"
     const val grpcStub = "io.grpc:grpc-stub:${versions.grpc}"
 
     const val kollection = "com.github.andrewoma.dexx:kollection:${versions.kollection}"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -59,7 +59,7 @@ object libraries {
     const val kotlinxCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinxCoroutines}"
 
     const val protobufPlugin = "com.google.protobuf:protobuf-gradle-plugin:${versions.protobufPlugin}"
-    const val protobuf = "com.google.protobuf:protobuf-java:${versions.protobuf}"
+    const val protobufJava = "com.google.protobuf:protobuf-java:${versions.protobuf}"
     const val protoc = "com.google.protobuf:protoc:${versions.protobuf}"
 
     const val stringTemplate = "org.antlr:ST4:${versions.stringTemplate}"

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,11 +8,11 @@ This directory contains several Protokt gRPC examples.
 
 The example sources are organized into the following top-level folders:
 
-- [protos][]: `.proto` files (shared across examples)
-- [grpc-java][]: implementation of client and server using grpc-java bindings
-- [grpc-java-lite][]: implementation of client using grpc-java bindings and protokt-lite (TODO)
-- [grpc-kotlin][]: implementation of client and server using grpc-kotlin bindings
-- [grpc-kotlin-lite][]: implementation of client using grpc-kotlin bindings and protokt-lite (TODO)
+- [protos](protos): `.proto` files (shared across examples)
+- [grpc-java](grpc-java): implementation of client and server using grpc-java bindings
+- [grpc-java-lite](grpc-java-lite): implementation of client using grpc-java bindings and protokt-lite (TODO)
+- [grpc-kotlin](grpc-kotlin): implementation of client and server using grpc-kotlin bindings
+- [grpc-kotlin-lite](grpc-kotlin-lite): implementation of client using grpc-kotlin bindings and protokt-lite (TODO)
 
 ## Instructions for running examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,61 @@
+# Protokt gRPC examples
+
+## Examples
+
+This directory contains several Protokt gRPC examples.
+
+## File organization
+
+The example sources are organized into the following top-level folders:
+
+- [protos][]: `.proto` files (shared across examples)
+- [grpc-java][]: implementation of client and server using grpc-java bindings
+- [grpc-java-lite][]: implementation of client using grpc-java bindings and protokt-lite (TODO)
+- [grpc-kotlin][]: implementation of client and server using grpc-kotlin bindings
+- [grpc-kotlin-lite][]: implementation of client using grpc-kotlin bindings and protokt-lite (TODO)
+
+## Instructions for running examples
+
+### Animals
+
+Start a server, either grpc-java- or grpc-kotlin-based:
+
+```sh
+protokt % ./gradlew :examples:grpc-[java|kotlin]:AnimalsServer
+```
+
+In another console, run either client against the "dog", "pig", and "sheep" services:
+
+```sh
+protokt % ./gradlew :examples:grpc-[java|kotlin]:AnimalsClient --args=dog
+protokt % ./gradlew :examples:grpc-[java|kotlin]:AnimalsClient --args=pig
+protokt % ./gradlew :examples:grpc-[java|kotlin]:AnimalsClient --args=sheep
+```
+
+### Greeter
+
+Start a server, either grpc-java- or grpc-kotlin-based:
+
+```sh
+protokt % ./gradlew :examples:grpc-[java|kotlin]:HelloWorldServer
+```
+
+In another console, run either client:
+
+```sh
+protokt % ./gradlew :examples:grpc-[java|kotlin]:HelloWorldClient
+```
+
+### Route Guide
+
+Start a server, either grpc-java- or grpc-kotlin-based:
+
+```sh
+protokt % ./gradlew :examples:grpc-[java|kotlin]:RouteGuideServer
+```
+
+In another console, run either client:
+
+```sh
+protokt % ./gradlew :examples:grpc-[java|kotlin]:RouteGuideClient
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ protokt % ./gradlew :examples:grpc-[java|kotlin]:AnimalsClient --args=sheep
 
 ### Greeter
 
-Start a server, either grpc-java- or grpc-kotlin-based:
+Start a server, either based on grpc-java or grpc-kotlin bindings:
 
 ```sh
 protokt % ./gradlew :examples:grpc-[java|kotlin]:HelloWorldServer
@@ -48,7 +48,7 @@ protokt % ./gradlew :examples:grpc-[java|kotlin]:HelloWorldClient
 
 ### Route Guide
 
-Start a server, either grpc-java- or grpc-kotlin-based:
+Start a server, either based on grpc-java or grpc-kotlin bindings:
 
 ```sh
 protokt % ./gradlew :examples:grpc-[java|kotlin]:RouteGuideServer

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 ## Examples
 
-This directory contains several Protokt gRPC examples.
+This directory contains several protokt gRPC examples.
 
 ## File organization
 
@@ -18,7 +18,7 @@ The example sources are organized into the following top-level folders:
 
 ### Animals
 
-Start a server, either grpc-java- or grpc-kotlin-based:
+Start a server, either based on grpc-java or grpc-kotlin bindings:
 
 ```sh
 protokt % ./gradlew :examples:grpc-[java|kotlin]:AnimalsServer

--- a/examples/grpc-java/build.gradle.kts
+++ b/examples/grpc-java/build.gradle.kts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    application
+}
+
+dependencies {
+    implementation(project(":examples:protos"))
+    implementation(project(":protokt-runtime-grpc"))
+    implementation(libraries.grpcStub)
+
+    runtimeOnly(libraries.grpcNetty)
+    runtimeOnly(libraries.protobufJava)
+}
+
+tasks.register<JavaExec>("HelloWorldServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.helloworld.HelloWorldServerKt"
+}
+
+tasks.register<JavaExec>("RouteGuideServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.routeguide.RouteGuideServerKt"
+}
+
+tasks.register<JavaExec>("AnimalsServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.animals.AnimalsServerKt"
+}
+
+tasks.register<JavaExec>("HelloWorldClient") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.helloworld.HelloWorldClientKt"
+}
+
+tasks.register<JavaExec>("RouteGuideClient") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.routeguide.RouteGuideClientKt"
+}
+
+tasks.register<JavaExec>("AnimalsClient") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.animals.AnimalsClientKt"
+}
+
+val helloWorldServerStartScripts = tasks.register<CreateStartScripts>("helloWorldServerStartScripts") {
+    mainClassName = "io.grpc.examples.helloworld.HelloWorldServerKt"
+    applicationName = "hello-world-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val routeGuideServerStartScripts = tasks.register<CreateStartScripts>("routeGuideServerStartScripts") {
+    mainClassName = "io.grpc.examples.routeguide.RouteGuideServerKt"
+    applicationName = "route-guide-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val animalsServerStartScripts = tasks.register<CreateStartScripts>("animalsServerStartScripts") {
+    mainClassName = "io.grpc.examples.animals.AnimalsServerKt"
+    applicationName = "animals-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val helloWorldClientStartScripts = tasks.register<CreateStartScripts>("helloWorldClientStartScripts") {
+    mainClassName = "io.grpc.examples.helloworld.HelloWorldClientKt"
+    applicationName = "hello-world-client"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val routeGuideClientStartScripts = tasks.register<CreateStartScripts>("routeGuideClientStartScripts") {
+    mainClassName = "io.grpc.examples.routeguide.RouteGuideClientKt"
+    applicationName = "route-guide-client"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val animalsClientStartScripts = tasks.register<CreateStartScripts>("animalsClientStartScripts") {
+    mainClassName = "io.grpc.examples.animals.AnimalsClientKt"
+    applicationName = "route-guide-client"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+tasks.named("startScripts") {
+    dependsOn(helloWorldServerStartScripts)
+    dependsOn(routeGuideServerStartScripts)
+    dependsOn(animalsServerStartScripts)
+
+    dependsOn(helloWorldClientStartScripts)
+    dependsOn(routeGuideClientStartScripts)
+    dependsOn(animalsClientStartScripts)
+}

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
@@ -23,7 +23,9 @@ import io.grpc.stub.ClientCalls
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 
-class AnimalsClient(private val channel: ManagedChannel) : Closeable {
+class AnimalsClient(
+    private val channel: ManagedChannel
+) : Closeable {
     fun bark() {
         val request = BarkRequest { }
         val response = unaryCall(DogGrpc.barkMethod, request)

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.animals
+
+import io.grpc.CallOptions
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.MethodDescriptor
+import io.grpc.stub.ClientCalls
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+class AnimalsClient(private val channel: ManagedChannel) : Closeable {
+    fun bark() {
+        val request = BarkRequest { }
+        val response = unaryCall(DogGrpc.barkMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    fun oink() {
+        val request = OinkRequest { }
+        val response = unaryCall(PigGrpc.oinkMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    fun baa() {
+        val request = BaaRequest { }
+        val response = unaryCall(SheepGrpc.baaMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    private fun <T, R> unaryCall(method: MethodDescriptor<T, R>, request: T): R =
+        ClientCalls.blockingUnaryCall(
+            channel,
+            method,
+            CallOptions.DEFAULT,
+            request
+        )
+
+    override fun close() {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+    }
+}
+
+/**
+ * Talk to the animals. Fluent in dog, pig and sheep.
+ */
+fun main(args: Array<String>) {
+    val usage = "usage: ./gradlew :examples:grpc-kotlin:AnimalsClient --args={dog|pig|sheep}"
+
+    if (args.isEmpty()) {
+        println("No animals specified.")
+        println(usage)
+    }
+
+    val port = 50051
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
+
+    val client = AnimalsClient(channel)
+
+    args.forEach {
+        when (it) {
+            "dog" -> client.bark()
+            "pig" -> client.oink()
+            "sheep" -> client.baa()
+            else -> {
+                println("Unknown animal type: \"$it\". Try \"dog\", \"pig\" or \"sheep\".")
+                println(usage)
+            }
+        }
+    }
+}

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -21,7 +21,9 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.stub.ServerCalls
 import io.grpc.stub.StreamObserver
 
-class AnimalsServer constructor(private val port: Int) {
+class AnimalsServer(
+    private val port: Int
+) {
     private val server =
         ServerBuilder
             .forPort(port)

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -18,7 +18,7 @@ package io.grpc.examples.animals
 import io.grpc.BindableService
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
-import io.grpc.stub.ServerCalls
+import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 
 class AnimalsServer(
@@ -55,7 +55,7 @@ class AnimalsServer(
     private class DogService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(DogGrpc.serviceDescriptor)
-                .addMethod(DogGrpc.barkMethod, ServerCalls.asyncUnaryCall(::bark))
+                .addMethod(DogGrpc.barkMethod, asyncUnaryCall(::bark))
                 .build()
 
         fun bark(
@@ -70,7 +70,7 @@ class AnimalsServer(
     private class PigService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(PigGrpc.serviceDescriptor)
-                .addMethod(PigGrpc.oinkMethod, ServerCalls.asyncUnaryCall(::oink))
+                .addMethod(PigGrpc.oinkMethod, asyncUnaryCall(::oink))
                 .build()
 
         fun oink(
@@ -85,7 +85,7 @@ class AnimalsServer(
     private class SheepService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(SheepGrpc.serviceDescriptor)
-                .addMethod(SheepGrpc.baaMethod, ServerCalls.asyncUnaryCall(::baa))
+                .addMethod(SheepGrpc.baaMethod, asyncUnaryCall(::baa))
                 .build()
 
         fun baa(

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -15,10 +15,11 @@
 
 package io.grpc.examples.animals
 
+import io.grpc.BindableService
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
-import io.grpc.kotlin.AbstractCoroutineServerImpl
-import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
+import io.grpc.stub.ServerCalls
+import io.grpc.stub.StreamObserver
 
 class AnimalsServer constructor(private val port: Int) {
     private val server =
@@ -33,11 +34,11 @@ class AnimalsServer constructor(private val port: Int) {
         server.start()
         println("Server started, listening on $port")
         Runtime.getRuntime().addShutdownHook(
-                Thread {
-                    println("*** shutting down gRPC server since JVM is shutting down")
-                    this@AnimalsServer.stop()
-                    println("*** server shut down")
-                }
+            Thread {
+                println("*** shutting down gRPC server since JVM is shutting down")
+                this@AnimalsServer.stop()
+                println("*** server shut down")
+            }
         )
     }
 
@@ -49,34 +50,49 @@ class AnimalsServer constructor(private val port: Int) {
         server.awaitTermination()
     }
 
-    private class DogService : AbstractCoroutineServerImpl() {
+    private class DogService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(DogGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, DogGrpc.barkMethod, ::bark))
+                .addMethod(DogGrpc.barkMethod, ServerCalls.asyncUnaryCall(::bark))
                 .build()
 
-        /* suspend */ fun bark(@Suppress("UNUSED_PARAMETER") request: BarkRequest) =
-            BarkReply { message = "Bark!" }
+        fun bark(
+            @Suppress("UNUSED_PARAMETER") request: BarkRequest,
+            responseObserver: StreamObserver<BarkReply>
+        ) {
+            responseObserver.onNext(BarkReply { message = "Bark!" })
+            responseObserver.onCompleted()
+        }
     }
 
-    private class PigService : AbstractCoroutineServerImpl() {
+    private class PigService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(PigGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, PigGrpc.oinkMethod, ::oink))
+                .addMethod(PigGrpc.oinkMethod, ServerCalls.asyncUnaryCall(::oink))
                 .build()
 
-        /* suspend */ fun oink(@Suppress("UNUSED_PARAMETER") request: OinkRequest) =
-            OinkReply { message = "Oink!" }
+        fun oink(
+            @Suppress("UNUSED_PARAMETER") request: OinkRequest,
+            responseObserver: StreamObserver<OinkReply>
+        ) {
+            responseObserver.onNext(OinkReply { message = "Oink!" })
+            responseObserver.onCompleted()
+        }
     }
 
-    private class SheepService : AbstractCoroutineServerImpl() {
+    private class SheepService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(SheepGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, SheepGrpc.baaMethod, ::baa))
+                .addMethod(SheepGrpc.baaMethod, ServerCalls.asyncUnaryCall(::baa))
                 .build()
 
-        /* suspend */ fun baa(@Suppress("UNUSED_PARAMETER") request: BaaRequest) =
-            BaaReply { message = "Baa!" }
+        fun baa(
+            @Suppress("UNUSED_PARAMETER") request: BaaRequest,
+            responseObserver: StreamObserver<BaaReply>
+        ) {
+            responseObserver.onNext(BaaReply { message = "Baa!" })
+            responseObserver.onCompleted()
+        }
     }
 }
 

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.helloworld
+
+import io.grpc.CallOptions
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.stub.ClientCalls
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+class HelloWorldClient(
+    private val channel: ManagedChannel
+) : Closeable {
+    fun greet(name: String) {
+        val request = HelloRequest { this.name = name }
+        val response =
+            ClientCalls.blockingUnaryCall(
+                channel,
+                GreeterGrpc.sayHelloMethod,
+                CallOptions.DEFAULT,
+                request
+            )
+        println("Received: ${response.message}")
+    }
+
+    override fun close() {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+    }
+}
+
+/**
+ * Greeter, uses first argument as name to greet if present;
+ * greets "world" otherwise.
+ */
+fun main(args: Array<String>) {
+    val port = 50051
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
+
+    val client = HelloWorldClient(channel)
+
+    val user = args.singleOrNull() ?: "world"
+    client.greet(user)
+}

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.helloworld
+
+import io.grpc.BindableService
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.ServerCalls
+import io.grpc.stub.StreamObserver
+
+class HelloWorldServer(
+    private val port: Int
+) {
+    private val server =
+        ServerBuilder
+            .forPort(port)
+            .addService(HelloWorldService())
+            .build()
+
+    fun start() {
+        server.start()
+        println("Server started, listening on $port")
+        Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    println("*** shutting down gRPC server since JVM is shutting down")
+                    this@HelloWorldServer.stop()
+                    println("*** server shut down")
+                }
+        )
+    }
+
+    private fun stop() {
+        server.shutdown()
+    }
+
+    fun blockUntilShutdown() {
+        server.awaitTermination()
+    }
+
+    private class HelloWorldService : BindableService {
+        override fun bindService() =
+            ServerServiceDefinition.builder(GreeterGrpc.serviceDescriptor)
+                .addMethod(GreeterGrpc.sayHelloMethod, ServerCalls.asyncUnaryCall(::sayHello))
+                .build()
+
+        fun sayHello(request: HelloRequest, responseObserver: StreamObserver<HelloReply>) {
+            responseObserver.onNext(HelloReply { message = "Hello ${request.name}" })
+            responseObserver.onCompleted()
+        }
+    }
+}
+
+fun main() {
+    val port = System.getenv("PORT")?.toInt() ?: 50051
+    val server = HelloWorldServer(port)
+    server.start()
+    server.blockUntilShutdown()
+}

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -18,7 +18,7 @@ package io.grpc.examples.helloworld
 import io.grpc.BindableService
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
-import io.grpc.stub.ServerCalls
+import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 
 class HelloWorldServer(
@@ -53,7 +53,7 @@ class HelloWorldServer(
     private class HelloWorldService : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(GreeterGrpc.serviceDescriptor)
-                .addMethod(GreeterGrpc.sayHelloMethod, ServerCalls.asyncUnaryCall(::sayHello))
+                .addMethod(GreeterGrpc.sayHelloMethod, asyncUnaryCall(::sayHello))
                 .build()
 
         fun sayHello(request: HelloRequest, responseObserver: StreamObserver<HelloReply>) {

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -34,11 +34,11 @@ class HelloWorldServer(
         server.start()
         println("Server started, listening on $port")
         Runtime.getRuntime().addShutdownHook(
-                Thread {
-                    println("*** shutting down gRPC server since JVM is shutting down")
-                    this@HelloWorldServer.stop()
-                    println("*** server shut down")
-                }
+            Thread {
+                println("*** shutting down gRPC server since JVM is shutting down")
+                this@HelloWorldServer.stop()
+                println("*** server shut down")
+            }
         )
     }
 

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -18,10 +18,13 @@ package io.grpc.examples.routeguide
 import com.google.common.base.Stopwatch
 import com.google.common.base.Ticker
 import io.grpc.BindableService
-import io.grpc.Server
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
 import io.grpc.Status
+import io.grpc.examples.routeguide.RouteGuideGrpc.getFeatureMethod
+import io.grpc.examples.routeguide.RouteGuideGrpc.listFeaturesMethod
+import io.grpc.examples.routeguide.RouteGuideGrpc.recordRouteMethod
+import io.grpc.examples.routeguide.RouteGuideGrpc.routeChatMethod
 import io.grpc.stub.ServerCalls.asyncBidiStreamingCall
 import io.grpc.stub.ServerCalls.asyncClientStreamingCall
 import io.grpc.stub.ServerCalls.asyncServerStreamingCall
@@ -35,13 +38,16 @@ import java.util.logging.Logger
 private val logger = Logger.getLogger(RouteGuideServer::class.java.simpleName)
 
 /**
- * Kotlin adaptation of RouteGuideServer from the Java gRPC example.
+ * Protokt adaptation of RouteGuideServer from the Java gRPC example.
  */
 class RouteGuideServer(
-    val port: Int,
-    val features: Collection<Feature> = Database.features(),
-    val server: Server = ServerBuilder.forPort(port).addService(RouteGuideService(features)).build()
+    private val port: Int
 ) {
+    private val server =
+        ServerBuilder.forPort(port)
+            .addService(RouteGuideService(Database.features()))
+            .build()
+
     fun start() {
         server.start()
         println("Server started, listening on $port")
@@ -68,10 +74,10 @@ class RouteGuideServer(
     ) : BindableService {
         override fun bindService() =
             ServerServiceDefinition.builder(RouteGuideGrpc.serviceDescriptor)
-                .addMethod(RouteGuideGrpc.getFeatureMethod, asyncUnaryCall(::getFeature))
-                .addMethod(RouteGuideGrpc.listFeaturesMethod, asyncServerStreamingCall(::listFeatures))
-                .addMethod(RouteGuideGrpc.recordRouteMethod, asyncClientStreamingCall(::recordRoute))
-                .addMethod(RouteGuideGrpc.routeChatMethod, asyncBidiStreamingCall(::routeChat))
+                .addMethod(getFeatureMethod, asyncUnaryCall(::getFeature))
+                .addMethod(listFeaturesMethod, asyncServerStreamingCall(::listFeatures))
+                .addMethod(recordRouteMethod, asyncClientStreamingCall(::recordRoute))
+                .addMethod(routeChatMethod, asyncBidiStreamingCall(::routeChat))
                 .build()
 
         private val routeNotes = ConcurrentHashMap<Point, MutableList<RouteNote>>()

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.routeguide
+
+import com.google.common.base.Stopwatch
+import com.google.common.base.Ticker
+import io.grpc.BindableService
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+import io.grpc.Status
+import io.grpc.stub.ServerCalls.asyncBidiStreamingCall
+import io.grpc.stub.ServerCalls.asyncClientStreamingCall
+import io.grpc.stub.ServerCalls.asyncServerStreamingCall
+import io.grpc.stub.ServerCalls.asyncUnaryCall
+import io.grpc.stub.StreamObserver
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+
+private val logger = Logger.getLogger(RouteGuideServer::class.java.simpleName)
+
+/**
+ * Kotlin adaptation of RouteGuideServer from the Java gRPC example.
+ */
+class RouteGuideServer(
+    val port: Int,
+    val features: Collection<Feature> = Database.features(),
+    val server: Server = ServerBuilder.forPort(port).addService(RouteGuideService(features)).build()
+) {
+    fun start() {
+        server.start()
+        println("Server started, listening on $port")
+        Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    println("*** shutting down gRPC server since JVM is shutting down")
+                    this@RouteGuideServer.stop()
+                    println("*** server shut down")
+                }
+        )
+    }
+
+    fun stop() {
+        server.shutdown()
+    }
+
+    fun blockUntilShutdown() {
+        server.awaitTermination()
+    }
+
+    class RouteGuideService(
+        val features: Collection<Feature>,
+        val ticker: Ticker = Ticker.systemTicker()
+    ) : BindableService {
+        override fun bindService() =
+            ServerServiceDefinition.builder(RouteGuideGrpc.serviceDescriptor)
+                .addMethod(RouteGuideGrpc.getFeatureMethod, asyncUnaryCall(::getFeature))
+                .addMethod(RouteGuideGrpc.listFeaturesMethod, asyncServerStreamingCall(::listFeatures))
+                .addMethod(RouteGuideGrpc.recordRouteMethod, asyncClientStreamingCall(::recordRoute))
+                .addMethod(RouteGuideGrpc.routeChatMethod, asyncBidiStreamingCall(::routeChat))
+                .build()
+
+        private val routeNotes = ConcurrentHashMap<Point, MutableList<RouteNote>>()
+
+        fun getFeature(request: Point, responseObserver: StreamObserver<Feature>) {
+            responseObserver.onNext(getFeature(request))
+            responseObserver.onCompleted()
+        }
+
+        private fun getFeature(request: Point) =
+            // No feature was found, return an unnamed feature.
+            features.find { it.location == request } ?: Feature { location = request }
+
+        fun listFeatures(request: Rectangle, responseObserver: StreamObserver<Feature>) {
+            features.filter { it.exists() && it.location!! in request }.forEach(responseObserver::onNext)
+            responseObserver.onCompleted()
+        }
+
+        fun recordRoute(responseObserver: StreamObserver<RouteSummary>): StreamObserver<Point> {
+            var pointCount = 0
+            var featureCount = 0
+            var distance = 0
+            var previous: Point? = null
+            val stopwatch = Stopwatch.createStarted(ticker)
+            return object : StreamObserver<Point> {
+                override fun onNext(request: Point) {
+                    pointCount++
+                    if (getFeature(request).exists()) {
+                        featureCount++
+                    }
+                    val prev = previous
+                    if (prev != null) {
+                        distance += prev distanceTo request
+                    }
+                    previous = request
+                }
+
+                override fun onError(t: Throwable) {
+                    logger.info { "RecordRoute failed: ${Status.fromThrowable(t)}" }
+                }
+
+                override fun onCompleted() {
+                    responseObserver.onNext(
+                        RouteSummary {
+                            this.pointCount = pointCount
+                            this.featureCount = featureCount
+                            this.distance = distance
+                            this.elapsedTime = Durations.fromMicros(stopwatch.elapsed(TimeUnit.MICROSECONDS))
+                        }
+                    )
+                    responseObserver.onCompleted()
+                }
+            }
+        }
+
+        fun routeChat(responseObserver: StreamObserver<RouteNote>) =
+            object : StreamObserver<RouteNote> {
+                override fun onNext(note: RouteNote) {
+                    val notes: MutableList<RouteNote> = routeNotes.computeIfAbsent(note.location!!) {
+                        Collections.synchronizedList(mutableListOf<RouteNote>())
+                    }
+                    for (prevNote in notes.toTypedArray()) { // thread-safe snapshot
+                        responseObserver.onNext(prevNote)
+                    }
+                    notes += note
+                }
+
+                override fun onError(t: Throwable) {
+                    logger.info { "RouteChat failed: ${Status.fromThrowable(t)}" }
+                }
+
+                override fun onCompleted() {
+                    responseObserver.onCompleted()
+                }
+            }
+    }
+}
+
+fun main() {
+    val port = 8980
+    val server = RouteGuideServer(port)
+    server.start()
+    server.blockUntilShutdown()
+}

--- a/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-java/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -46,11 +46,11 @@ class RouteGuideServer(
         server.start()
         println("Server started, listening on $port")
         Runtime.getRuntime().addShutdownHook(
-                Thread {
-                    println("*** shutting down gRPC server since JVM is shutting down")
-                    this@RouteGuideServer.stop()
-                    println("*** server shut down")
-                }
+            Thread {
+                println("*** shutting down gRPC server since JVM is shutting down")
+                this@RouteGuideServer.stop()
+                println("*** server shut down")
+            }
         )
     }
 

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libraries.grpcStub)
 
     runtimeOnly(libraries.grpcNetty)
+    runtimeOnly(libraries.protobufJava)
 }
 
 tasks.register<JavaExec>("HelloWorldServer") {
@@ -42,6 +43,24 @@ tasks.register<JavaExec>("AnimalsServer") {
     dependsOn("classes")
     classpath = sourceSets["main"].runtimeClasspath
     main = "io.grpc.examples.animals.AnimalsServerKt"
+}
+
+tasks.register<JavaExec>("HelloWorldClient") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.helloworld.HelloWorldClientKt"
+}
+
+tasks.register<JavaExec>("RouteGuideClient") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.routeguide.RouteGuideClientKt"
+}
+
+tasks.register<JavaExec>("AnimalsClient") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.animals.AnimalsClientKt"
 }
 
 val helloWorldServerStartScripts = tasks.register<CreateStartScripts>("helloWorldServerStartScripts") {
@@ -65,8 +84,33 @@ val animalsServerStartScripts = tasks.register<CreateStartScripts>("animalsServe
     classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
 }
 
+val helloWorldClientStartScripts = tasks.register<CreateStartScripts>("helloWorldClientStartScripts") {
+    mainClassName = "io.grpc.examples.helloworld.HelloWorldClientKt"
+    applicationName = "hello-world-client"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val routeGuideClientStartScripts = tasks.register<CreateStartScripts>("routeGuideClientStartScripts") {
+    mainClassName = "io.grpc.examples.routeguide.RouteGuideClientKt"
+    applicationName = "route-guide-client"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val animalsClientStartScripts = tasks.register<CreateStartScripts>("animalsClientStartScripts") {
+    mainClassName = "io.grpc.examples.animals.AnimalsClientKt"
+    applicationName = "route-guide-client"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
 tasks.named("startScripts") {
     dependsOn(helloWorldServerStartScripts)
     dependsOn(routeGuideServerStartScripts)
     dependsOn(animalsServerStartScripts)
+
+    dependsOn(helloWorldClientStartScripts)
+    dependsOn(routeGuideClientStartScripts)
+    dependsOn(animalsClientStartScripts)
 }

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(project(":protokt-runtime-grpc"))
     implementation(libraries.grpcKotlin)
     implementation(libraries.grpcStub)
+    implementation(libraries.kotlinxCoroutinesCore)
 
     runtimeOnly(libraries.grpcNetty)
     runtimeOnly(libraries.protobufJava)

--- a/examples/grpc-kotlin/build.gradle.kts
+++ b/examples/grpc-kotlin/build.gradle.kts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    application
+}
+
+dependencies {
+    implementation(project(":examples:protos"))
+    implementation(project(":protokt-runtime-grpc"))
+    implementation(libraries.grpcKotlin)
+    implementation(libraries.grpcStub)
+
+    runtimeOnly(libraries.grpcNetty)
+}
+
+tasks.register<JavaExec>("HelloWorldServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.helloworld.HelloWorldServerKt"
+}
+
+tasks.register<JavaExec>("RouteGuideServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.routeguide.RouteGuideServerKt"
+}
+
+tasks.register<JavaExec>("AnimalsServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "io.grpc.examples.animals.AnimalsServerKt"
+}
+
+val helloWorldServerStartScripts = tasks.register<CreateStartScripts>("helloWorldServerStartScripts") {
+    mainClassName = "io.grpc.examples.helloworld.HelloWorldServerKt"
+    applicationName = "hello-world-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val routeGuideServerStartScripts = tasks.register<CreateStartScripts>("routeGuideServerStartScripts") {
+    mainClassName = "io.grpc.examples.routeguide.RouteGuideServerKt"
+    applicationName = "route-guide-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+val animalsServerStartScripts = tasks.register<CreateStartScripts>("animalsServerStartScripts") {
+    mainClassName = "io.grpc.examples.animals.AnimalsServerKt"
+    applicationName = "animals-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+tasks.named("startScripts") {
+    dependsOn(helloWorldServerStartScripts)
+    dependsOn(routeGuideServerStartScripts)
+    dependsOn(animalsServerStartScripts)
+}

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.animals
+
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.kotlin.ClientCalls
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+class AnimalsClient(private val channel: ManagedChannel) : Closeable {
+    suspend fun bark() {
+        val request = BarkRequest { }
+        val response = ClientCalls.unaryRpc(channel, DogGrpc.barkMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    suspend fun oink() {
+        val request = OinkRequest { }
+        val response = ClientCalls.unaryRpc(channel, PigGrpc.oinkMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    suspend fun baa() {
+        val request = BaaRequest { }
+        val response = ClientCalls.unaryRpc(channel, SheepGrpc.baaMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    override fun close() {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+    }
+}
+
+/**
+ * Talk to the animals. Fluent in dog, pig and sheep.
+ */
+suspend fun main(args: Array<String>) {
+    val usage = "usage: ./gradlew :examples:grpc-kotlin:AnimalsClient --args={dog|pig|sheep}"
+
+    if (args.isEmpty()) {
+        println("No animals specified.")
+        println(usage)
+    }
+
+    val port = 50051
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
+
+    val client = AnimalsClient(channel)
+
+    args.forEach {
+        when (it) {
+            "dog" -> client.bark()
+            "pig" -> client.oink()
+            "sheep" -> client.baa()
+            else -> {
+                println("Unknown animal type: \"$it\". Try \"dog\", \"pig\" or \"sheep\".")
+                println(usage)
+            }
+        }
+    }
+}

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsClient.kt
@@ -21,7 +21,9 @@ import io.grpc.kotlin.ClientCalls
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 
-class AnimalsClient(private val channel: ManagedChannel) : Closeable {
+class AnimalsClient(
+    private val channel: ManagedChannel
+) : Closeable {
     suspend fun bark() {
         val request = BarkRequest { }
         val response = ClientCalls.unaryRpc(channel, DogGrpc.barkMethod, request)

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -17,6 +17,9 @@ package io.grpc.examples.animals
 
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
+import io.grpc.examples.animals.DogGrpc.barkMethod
+import io.grpc.examples.animals.PigGrpc.oinkMethod
+import io.grpc.examples.animals.SheepGrpc.baaMethod
 import io.grpc.kotlin.AbstractCoroutineServerImpl
 import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
 
@@ -54,30 +57,30 @@ class AnimalsServer(
     private class DogService : AbstractCoroutineServerImpl() {
         override fun bindService() =
             ServerServiceDefinition.builder(DogGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, DogGrpc.barkMethod, ::bark))
+                .addMethod(unaryServerMethodDefinition(context, barkMethod, ::bark))
                 .build()
 
-        /* suspend */ fun bark(@Suppress("UNUSED_PARAMETER") request: BarkRequest) =
+        suspend fun bark(@Suppress("UNUSED_PARAMETER") request: BarkRequest) =
             BarkReply { message = "Bark!" }
     }
 
     private class PigService : AbstractCoroutineServerImpl() {
         override fun bindService() =
             ServerServiceDefinition.builder(PigGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, PigGrpc.oinkMethod, ::oink))
+                .addMethod(unaryServerMethodDefinition(context, oinkMethod, ::oink))
                 .build()
 
-        /* suspend */ fun oink(@Suppress("UNUSED_PARAMETER") request: OinkRequest) =
+        suspend fun oink(@Suppress("UNUSED_PARAMETER") request: OinkRequest) =
             OinkReply { message = "Oink!" }
     }
 
     private class SheepService : AbstractCoroutineServerImpl() {
         override fun bindService() =
             ServerServiceDefinition.builder(SheepGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, SheepGrpc.baaMethod, ::baa))
+                .addMethod(unaryServerMethodDefinition(context, baaMethod, ::baa))
                 .build()
 
-        /* suspend */ fun baa(@Suppress("UNUSED_PARAMETER") request: BaaRequest) =
+        suspend fun baa(@Suppress("UNUSED_PARAMETER") request: BaaRequest) =
             BaaReply { message = "Baa!" }
     }
 }

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -20,7 +20,9 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.kotlin.AbstractCoroutineServerImpl
 import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
 
-class AnimalsServer constructor(private val port: Int) {
+class AnimalsServer(
+    private val port: Int
+) {
     private val server =
         ServerBuilder
             .forPort(port)

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -35,11 +35,11 @@ class AnimalsServer(
         server.start()
         println("Server started, listening on $port")
         Runtime.getRuntime().addShutdownHook(
-                Thread {
-                    println("*** shutting down gRPC server since JVM is shutting down")
-                    this@AnimalsServer.stop()
-                    println("*** server shut down")
-                }
+            Thread {
+                println("*** shutting down gRPC server since JVM is shutting down")
+                this@AnimalsServer.stop()
+                println("*** server shut down")
+            }
         )
     }
 

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/animals/AnimalsServer.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.animals
+
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+import io.grpc.kotlin.AbstractCoroutineServerImpl
+import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
+
+class AnimalsServer constructor(private val port: Int) {
+    private val server =
+        ServerBuilder
+            .forPort(port)
+            .addService(DogService())
+            .addService(PigService())
+            .addService(SheepService())
+            .build()
+
+    fun start() {
+        server.start()
+        println("Server started, listening on $port")
+        Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    println("*** shutting down gRPC server since JVM is shutting down")
+                    this@AnimalsServer.stop()
+                    println("*** server shut down")
+                }
+        )
+    }
+
+    private fun stop() {
+        server.shutdown()
+    }
+
+    fun blockUntilShutdown() {
+        server.awaitTermination()
+    }
+
+    private class DogService : AbstractCoroutineServerImpl() {
+        override fun bindService() =
+            ServerServiceDefinition.builder(DogGrpc.serviceDescriptor)
+                .addMethod(unaryServerMethodDefinition(context, DogGrpc.barkMethod, ::bark))
+                .build()
+
+        /* suspend */ fun bark(@Suppress("UNUSED_PARAMETER") request: BarkRequest) =
+            BarkReply { message = "Bark!" }
+    }
+
+    private class PigService : AbstractCoroutineServerImpl() {
+        override fun bindService() =
+            ServerServiceDefinition.builder(PigGrpc.serviceDescriptor)
+                .addMethod(unaryServerMethodDefinition(context, PigGrpc.oinkMethod, ::oink))
+                .build()
+
+        /* suspend */ fun oink(@Suppress("UNUSED_PARAMETER") request: OinkRequest) =
+            OinkReply { message = "Oink!" }
+    }
+
+    private class SheepService : AbstractCoroutineServerImpl() {
+        override fun bindService() =
+            ServerServiceDefinition.builder(SheepGrpc.serviceDescriptor)
+                .addMethod(unaryServerMethodDefinition(context, SheepGrpc.baaMethod, ::baa))
+                .build()
+
+
+        /* suspend */ fun baa(@Suppress("UNUSED_PARAMETER") request: BaaRequest) =
+            BaaReply { message = "Baa!" }
+    }
+}
+
+fun main() {
+    val port = 50051
+    val server = AnimalsServer(port)
+    server.start()
+    server.blockUntilShutdown()
+}

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.helloworld
+
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.kotlin.ClientCalls
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+class HelloWorldClient(
+    private val channel: ManagedChannel
+) : Closeable {
+    suspend fun greet(name: String) {
+        val request = HelloRequest { this.name = name }
+        val response = ClientCalls.unaryRpc(channel, GreeterGrpc.sayHelloMethod, request)
+        println("Received: ${response.message}")
+    }
+
+    override fun close() {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+    }
+}
+
+/**
+ * Greeter, uses first argument as name to greet if present;
+ * greets "world" otherwise.
+ */
+suspend fun main(args: Array<String>) {
+    val port = 50051
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
+
+    val client = HelloWorldClient(channel)
+
+    val user = args.singleOrNull() ?: "world"
+    client.greet(user)
+}

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldClient.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.helloworld
+
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+import io.grpc.kotlin.AbstractCoroutineServerImpl
+import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
+
+class HelloWorldServer(
+    private val port: Int
+) {
+    private val server =
+        ServerBuilder
+            .forPort(port)
+            .addService(HelloWorldService())
+            .build()
+
+    fun start() {
+        server.start()
+        println("Server started, listening on $port")
+        Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    println("*** shutting down gRPC server since JVM is shutting down")
+                    this@HelloWorldServer.stop()
+                    println("*** server shut down")
+                }
+        )
+    }
+
+    private fun stop() {
+        server.shutdown()
+    }
+
+    fun blockUntilShutdown() {
+        server.awaitTermination()
+    }
+
+    private class HelloWorldService : AbstractCoroutineServerImpl() {
+        override fun bindService() =
+            ServerServiceDefinition.builder(GreeterGrpc.serviceDescriptor)
+                .addMethod(unaryServerMethodDefinition(context, GreeterGrpc.sayHelloMethod, ::sayHello))
+                .build()
+
+        /* suspend */ fun sayHello(request: HelloRequest) =
+            HelloReply { message = "Hello ${request.name}" }
+    }
+}
+
+fun main() {
+    val port = System.getenv("PORT")?.toInt() ?: 50051
+    val server = HelloWorldServer(port)
+    server.start()
+    server.blockUntilShutdown()
+}

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -33,11 +33,11 @@ class HelloWorldServer(
         server.start()
         println("Server started, listening on $port")
         Runtime.getRuntime().addShutdownHook(
-                Thread {
-                    println("*** shutting down gRPC server since JVM is shutting down")
-                    this@HelloWorldServer.stop()
-                    println("*** server shut down")
-                }
+            Thread {
+                println("*** shutting down gRPC server since JVM is shutting down")
+                this@HelloWorldServer.stop()
+                println("*** server shut down")
+            }
         )
     }
 

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -17,6 +17,7 @@ package io.grpc.examples.helloworld
 
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
+import io.grpc.examples.helloworld.GreeterGrpc.sayHelloMethod
 import io.grpc.kotlin.AbstractCoroutineServerImpl
 import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
 
@@ -52,10 +53,10 @@ class HelloWorldServer(
     private class HelloWorldService : AbstractCoroutineServerImpl() {
         override fun bindService() =
             ServerServiceDefinition.builder(GreeterGrpc.serviceDescriptor)
-                .addMethod(unaryServerMethodDefinition(context, GreeterGrpc.sayHelloMethod, ::sayHello))
+                .addMethod(unaryServerMethodDefinition(context, sayHelloMethod, ::sayHello))
                 .build()
 
-        /* suspend */ fun sayHello(request: HelloRequest) =
+        suspend fun sayHello(request: HelloRequest) =
             HelloReply { message = "Hello ${request.name}" }
     }
 }

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.routeguide
+
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.kotlin.ClientCalls
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.random.nextLong
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+
+class RouteGuideClient(
+    private val channel: ManagedChannel
+) : Closeable {
+    private val random = Random(314159)
+
+    override fun close() {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+    }
+
+    suspend fun getFeature(latitude: Int, longitude: Int) {
+        println("*** GetFeature: lat=$latitude lon=$longitude")
+
+        val request = point(latitude, longitude)
+        val feature = ClientCalls.unaryRpc(channel, RouteGuideGrpc.getFeatureMethod, request)
+
+        if (feature.exists()) {
+            println("Found feature called \"${feature.name}\" at ${feature.location?.toStr()}")
+        } else {
+            println("Found no feature at ${request.toStr()}")
+        }
+    }
+
+    suspend fun listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int) {
+        println("*** ListFeatures: lowLat=$lowLat lowLon=$lowLon hiLat=$hiLat liLon=$hiLon")
+
+        val request =
+            Rectangle {
+                lo = point(lowLat, lowLon)
+                hi = point(hiLat, hiLon)
+            }
+        var i = 1
+        ClientCalls.serverStreamingRpc(
+            channel,
+            RouteGuideGrpc.listFeaturesMethod,
+            request
+        ).collect { feature ->
+            println("Result #${i++}: $feature")
+        }
+    }
+
+    suspend fun recordRoute(points: Flow<Point>) {
+        println("*** RecordRoute")
+        val summary = ClientCalls.clientStreamingRpc(channel, RouteGuideGrpc.recordRouteMethod, points)
+        println("Finished trip with ${summary.pointCount} points.")
+        println("Passed ${summary.featureCount} features.")
+        println("Travelled ${summary.distance} meters.")
+        val duration = summary.elapsedTime?.seconds
+        println("It took $duration seconds.")
+    }
+
+    fun generateRoutePoints(features: List<Feature>, numPoints: Int): Flow<Point> = flow {
+        for (i in 1..numPoints) {
+            val feature = features.random(random)
+            println("Visiting point ${feature.location?.toStr()}")
+            emit(feature.location!!)
+            delay(timeMillis = random.nextLong(500L..1500L))
+        }
+    }
+
+    suspend fun routeChat() {
+        println("*** RouteChat")
+        val requests = generateOutgoingNotes()
+        ClientCalls.bidiStreamingRpc(
+            channel,
+            RouteGuideGrpc.routeChatMethod,
+            requests
+        ).collect { note ->
+            println("Got message \"${note.message}\" at ${note.location?.toStr()}")
+        }
+        println("Finished RouteChat")
+    }
+
+    private fun generateOutgoingNotes(): Flow<RouteNote> = flow {
+        val notes = listOf(
+                RouteNote {
+                    message = "First message"
+                    location = point(0, 0)
+                },
+                RouteNote {
+                    message = "Second message"
+                    location = point(0, 0)
+                },
+                RouteNote {
+                    message = "Third message"
+                    location = point(10000000, 0)
+                },
+                RouteNote {
+                    message = "Fourth message"
+                    location = point(10000000, 10000000)
+                },
+                RouteNote {
+                    message = "Last message"
+                    location = point(0, 0)
+                }
+        )
+        for (note in notes) {
+            println("Sending message \"${note.message}\" at ${note.location?.toStr()}")
+            emit(note)
+            delay(500)
+        }
+    }
+}
+
+suspend fun main() {
+    val features = Database.features()
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", 8980).usePlaintext().build()
+
+    RouteGuideClient(channel).use {
+        it.getFeature(409146138, -746188906)
+        it.getFeature(0, 0)
+        it.listFeatures(400000000, -750000000, 420000000, -730000000)
+        it.recordRoute(it.generateRoutePoints(features, 10))
+        it.routeChat()
+    }
+}
+
+private fun point(lat: Int, lon: Int) =
+    Point {
+        latitude = lat
+        longitude = lon
+    }

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.routeguide
+
+import com.google.common.base.Stopwatch
+import com.google.common.base.Ticker
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+import io.grpc.kotlin.AbstractCoroutineServerImpl
+import io.grpc.kotlin.ServerCalls.bidiStreamingServerMethodDefinition
+import io.grpc.kotlin.ServerCalls.clientStreamingServerMethodDefinition
+import io.grpc.kotlin.ServerCalls.serverStreamingServerMethodDefinition
+import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Kotlin adaptation of RouteGuideServer from the Java gRPC example.
+ */
+class RouteGuideServer(
+    val port: Int,
+    val features: Collection<Feature> = Database.features(),
+    val server: Server = ServerBuilder.forPort(port).addService(RouteGuideService(features)).build()
+) {
+
+    fun start() {
+        server.start()
+        println("Server started, listening on $port")
+        Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    println("*** shutting down gRPC server since JVM is shutting down")
+                    this@RouteGuideServer.stop()
+                    println("*** server shut down")
+                }
+        )
+    }
+
+    fun stop() {
+        server.shutdown()
+    }
+
+    fun blockUntilShutdown() {
+        server.awaitTermination()
+    }
+
+    class RouteGuideService(
+        val features: Collection<Feature>,
+        val ticker: Ticker = Ticker.systemTicker()
+    ) : AbstractCoroutineServerImpl() {
+        override fun bindService() =
+            ServerServiceDefinition.builder(RouteGuideGrpc.serviceDescriptor)
+                .addMethod(unaryServerMethodDefinition(context, RouteGuideGrpc.getFeatureMethod, ::getFeature))
+                .addMethod(serverStreamingServerMethodDefinition(context, RouteGuideGrpc.listFeaturesMethod, ::listFeatures))
+                .addMethod(clientStreamingServerMethodDefinition(context, RouteGuideGrpc.recordRouteMethod, ::recordRoute))
+                .addMethod(bidiStreamingServerMethodDefinition(context, RouteGuideGrpc.routeChatMethod, ::routeChat))
+                .build()
+
+        private val routeNotes = ConcurrentHashMap<Point, MutableList<RouteNote>>()
+
+        /* suspend */ fun getFeature(request: Point): Feature =
+            // No feature was found, return an unnamed feature.
+            features.find { it.location == request } ?: Feature { location = request }
+
+        fun listFeatures(request: Rectangle): Flow<Feature> =
+                features.asFlow().filter { it.exists() && it.location!! in request }
+
+        suspend fun recordRoute(requests: Flow<Point>): RouteSummary {
+            var pointCount = 0
+            var featureCount = 0
+            var distance = 0
+            var previous: Point? = null
+            val stopwatch = Stopwatch.createStarted(ticker)
+            requests.collect { request ->
+                pointCount++
+                if (getFeature(request).exists()) {
+                    featureCount++
+                }
+                val prev = previous
+                if (prev != null) {
+                    distance += prev distanceTo request
+                }
+                previous = request
+            }
+            return RouteSummary {
+                this.pointCount = pointCount
+                this.featureCount = featureCount
+                this.distance = distance
+                this.elapsedTime = Durations.fromMicros(stopwatch.elapsed(TimeUnit.MICROSECONDS))
+            }
+        }
+
+        fun routeChat(requests: Flow<RouteNote>): Flow<RouteNote> = flow {
+            requests.collect { note ->
+                val notes: MutableList<RouteNote> = routeNotes.computeIfAbsent(note.location!!) {
+                    Collections.synchronizedList(mutableListOf<RouteNote>())
+                }
+                for (prevNote in notes.toTypedArray()) { // thread-safe snapshot
+                    emit(prevNote)
+                }
+                notes += note
+            }
+        }
+    }
+}
+
+fun main() {
+    val port = 8980
+    val server = RouteGuideServer(port)
+    server.start()
+    server.blockUntilShutdown()
+}

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -35,14 +35,13 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 
 /**
- * Kotlin adaptation of RouteGuideServer from the Java gRPC example.
+ * Kotlin adaptation of RouteGuideServer from the Kotlin gRPC example.
  */
 class RouteGuideServer(
     val port: Int,
     val features: Collection<Feature> = Database.features(),
     val server: Server = ServerBuilder.forPort(port).addService(RouteGuideService(features)).build()
 ) {
-
     fun start() {
         server.start()
         println("Server started, listening on $port")

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2021 Toast Inc.
+ * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -46,11 +46,11 @@ class RouteGuideServer(
         server.start()
         println("Server started, listening on $port")
         Runtime.getRuntime().addShutdownHook(
-                Thread {
-                    println("*** shutting down gRPC server since JVM is shutting down")
-                    this@RouteGuideServer.stop()
-                    println("*** server shut down")
-                }
+            Thread {
+                println("*** shutting down gRPC server since JVM is shutting down")
+                this@RouteGuideServer.stop()
+                println("*** server shut down")
+            }
         )
     }
 
@@ -81,7 +81,7 @@ class RouteGuideServer(
             features.find { it.location == request } ?: Feature { location = request }
 
         fun listFeatures(request: Rectangle): Flow<Feature> =
-                features.asFlow().filter { it.exists() && it.location!! in request }
+            features.asFlow().filter { it.exists() && it.location!! in request }
 
         suspend fun recordRoute(requests: Flow<Point>): RouteSummary {
             var pointCount = 0

--- a/examples/protos/build.gradle.kts
+++ b/examples/protos/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.toasttab.protokt.gradle.protokt
+
+localProtokt()
+pureKotlin()
+
+protokt {
+    generateGrpc = true
+}
+
+dependencies {
+    implementation(project(":protokt-runtime-grpc"))
+    implementation(libraries.grpcStub)
+}

--- a/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Database.kt
@@ -13,17 +13,16 @@
  * limitations under the License.
  */
 
-import com.toasttab.protokt.gradle.protokt
+package io.grpc.examples.routeguide
 
-localProtokt()
-pureKotlin()
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 
-protokt {
-    generateGrpc = true
-}
-
-dependencies {
-    implementation(project(":protokt-runtime-grpc"))
-    implementation(libraries.grpcStub)
-    implementation(libraries.jackson)
+object Database {
+    fun features(): List<Feature> {
+        return javaClass.getResourceAsStream("route_guide_db.json").use {
+            ObjectMapper().registerModule(KotlinModule()).readValue<FeatureDatabase>(it!!.reader())
+        }.feature
+    }
 }

--- a/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Durations.kt
+++ b/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Durations.kt
@@ -13,17 +13,17 @@
  * limitations under the License.
  */
 
-import com.toasttab.protokt.gradle.protokt
+package io.grpc.examples.routeguide
 
-localProtokt()
-pureKotlin()
+import com.toasttab.protokt.Duration
 
-protokt {
-    generateGrpc = true
-}
+private const val MICROS_PER_SECOND = 1000000
+private const val NANOS_PER_MICROSECOND = 1000
 
-dependencies {
-    implementation(project(":protokt-runtime-grpc"))
-    implementation(libraries.grpcStub)
-    implementation(libraries.jackson)
+object Durations {
+    fun fromMicros(microseconds: Long) =
+        Duration {
+            seconds = microseconds / MICROS_PER_SECOND
+            nanos = (microseconds % MICROS_PER_SECOND * NANOS_PER_MICROSECOND).toInt()
+        }
 }

--- a/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Points.kt
+++ b/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Points.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.routeguide
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+private const val EARTH_RADIUS_IN_M = 6371000
+
+private fun Int.toRadians() = Math.toRadians(toDouble())
+
+infix fun Point.distanceTo(other: Point): Int {
+    val lat1 = latitude.toRadians()
+    val long1 = longitude.toRadians()
+    val lat2 = other.latitude.toRadians()
+    val long2 = other.latitude.toRadians()
+
+    val dLat = lat2 - lat1
+    val dLong = long2 - long1
+
+    val a = sin(dLat / 2).pow(2) + cos(lat1) * cos(lat2) * sin(dLong / 2).pow(2)
+    val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return (EARTH_RADIUS_IN_M * c).roundToInt()
+}
+
+operator fun Rectangle.contains(p: Point): Boolean {
+    val lowLong = minOf(lo!!.longitude, hi!!.longitude)
+    val hiLong = maxOf(lo.longitude, hi.longitude)
+    val lowLat = minOf(lo.latitude, hi.latitude)
+    val hiLat = maxOf(lo.latitude, hi.latitude)
+    return p.longitude in lowLong..hiLong && p.latitude in lowLat..hiLat
+}
+
+private fun Int.normalizeCoordinate(): Double = this / 1.0e7
+
+fun Point.toStr(): String {
+    val lat = latitude.normalizeCoordinate()
+    val long = longitude.normalizeCoordinate()
+    return "$lat, $long"
+}
+
+fun Feature.exists(): Boolean = name.isNotEmpty()

--- a/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Points.kt
+++ b/examples/protos/src/main/kotlin/io/grpc/examples/routeguide/Points.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 gRPC authors.
+ * Copyright 2021 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/protos/src/main/proto/animals/dog.proto
+++ b/examples/protos/src/main/proto/animals/dog.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.animals";
+option java_outer_classname = "DogProto";
+
+package animals;
+
+service Dog {
+  rpc Bark (BarkRequest) returns (BarkReply) {}
+}
+
+message BarkRequest {
+}
+
+message BarkReply {
+  string message = 1;
+}

--- a/examples/protos/src/main/proto/animals/pig.proto
+++ b/examples/protos/src/main/proto/animals/pig.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.animals";
+option java_outer_classname = "PigProto";
+
+package animals;
+
+service Pig {
+  rpc Oink (OinkRequest) returns (OinkReply) {}
+}
+
+message OinkRequest {
+}
+
+message OinkReply {
+  string message = 1;
+}

--- a/examples/protos/src/main/proto/animals/sheep.proto
+++ b/examples/protos/src/main/proto/animals/sheep.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.animals";
+option java_outer_classname = "SheepProto";
+
+package animals;
+
+service Sheep {
+  rpc Baa (BaaRequest) returns (BaaReply) {}
+}
+
+message BaaRequest {
+}
+
+message BaaReply {
+  string message = 1;
+}

--- a/examples/protos/src/main/proto/helloworld/hello_world.proto
+++ b/examples/protos/src/main/proto/helloworld/hello_world.proto
@@ -1,0 +1,36 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/examples/protos/src/main/proto/io/grpc/examples/route_guide.proto
+++ b/examples/protos/src/main/proto/io/grpc/examples/route_guide.proto
@@ -1,0 +1,115 @@
+// Copyright 2020 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package io.grpc.examples.routeguide;
+
+import "google/protobuf/duration.proto";
+
+option java_multiple_files = true;
+
+// Interface exported by the server.
+service RouteGuide {
+  // A simple RPC.
+  //
+  // Obtains the feature at a given position.
+  //
+  // A feature with an empty name is returned if there's no feature at the given
+  // position.
+  rpc GetFeature(Point) returns (Feature);
+
+  // A server-to-client streaming RPC.
+  //
+  // Obtains the Features available within the given Rectangle.  Results are
+  // streamed rather than returned at once (e.g. in a response message with a
+  // repeated field), as the rectangle may cover a large area and contain a
+  // huge number of features.
+  rpc ListFeatures(Rectangle) returns (stream Feature);
+
+  // A client-to-server streaming RPC.
+  //
+  // Accepts a stream of Points on a route being traversed, returning a
+  // RouteSummary when traversal is completed.
+  rpc RecordRoute(stream Point) returns (RouteSummary);
+
+  // A Bidirectional streaming RPC.
+  //
+  // Accepts a stream of RouteNotes sent while a route is being traversed,
+  // while receiving other RouteNotes (e.g. from other users).
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote);
+}
+
+// Points are represented as latitude-longitude pairs in the E7 representation
+// (degrees multiplied by 10**7 and rounded to the nearest integer).
+// Latitudes should be in the range +/- 90 degrees and longitude should be in
+// the range +/- 180 degrees (inclusive).
+message Point {
+  int32 latitude = 1;
+  int32 longitude = 2;
+}
+
+// A latitude-longitude rectangle, represented as two diagonally opposite
+// points "lo" and "hi".
+message Rectangle {
+  // One corner of the rectangle.
+  Point lo = 1;
+
+  // The other corner of the rectangle.
+  Point hi = 2;
+}
+
+// A feature names something at a given point.
+//
+// If a feature could not be named, the name is empty.
+message Feature {
+  // The name of the feature.
+  string name = 1;
+
+  // The point where the feature is detected.
+  Point location = 2;
+}
+
+// Not used in the RPC.  Instead, this is here for the form serialized to disk.
+message FeatureDatabase {
+  repeated Feature feature = 1;
+}
+
+// A RouteNote is a message sent while at a given point.
+message RouteNote {
+  // The location from which the message is sent.
+  Point location = 1;
+
+  // The message to be sent.
+  string message = 2;
+}
+
+// A RouteSummary is received in response to a RecordRoute rpc.
+//
+// It contains the number of individual points received, the number of
+// detected features, and the total distance covered as the cumulative sum of
+// the distance between each point.
+message RouteSummary {
+  // The number of points received.
+  int32 point_count = 1;
+
+  // The number of known features passed while traversing the route.
+  int32 feature_count = 2;
+
+  // The distance covered in metres.
+  int32 distance = 3;
+
+  // The duration of the traversal.
+  google.protobuf.Duration elapsed_time = 4;
+}

--- a/examples/protos/src/main/resources/io/grpc/examples/routeguide/route_guide_db.json
+++ b/examples/protos/src/main/resources/io/grpc/examples/routeguide/route_guide_db.json
@@ -1,0 +1,603 @@
+{
+  "feature": [{
+    "location": {
+      "latitude": 407838351,
+      "longitude": -746143763
+    },
+    "name": "Patriots Path, Mendham, NJ 07945, USA"
+  }, {
+    "location": {
+      "latitude": 408122808,
+      "longitude": -743999179
+    },
+    "name": "101 New Jersey 10, Whippany, NJ 07981, USA"
+  }, {
+    "location": {
+      "latitude": 413628156,
+      "longitude": -749015468
+    },
+    "name": "U.S. 6, Shohola, PA 18458, USA"
+  }, {
+    "location": {
+      "latitude": 419999544,
+      "longitude": -740371136
+    },
+    "name": "5 Conners Road, Kingston, NY 12401, USA"
+  }, {
+    "location": {
+      "latitude": 414008389,
+      "longitude": -743951297
+    },
+    "name": "Mid Hudson Psychiatric Center, New Hampton, NY 10958, USA"
+  }, {
+    "location": {
+      "latitude": 419611318,
+      "longitude": -746524769
+    },
+    "name": "287 Flugertown Road, Livingston Manor, NY 12758, USA"
+  }, {
+    "location": {
+      "latitude": 406109563,
+      "longitude": -742186778
+    },
+    "name": "4001 Tremley Point Road, Linden, NJ 07036, USA"
+  }, {
+    "location": {
+      "latitude": 416802456,
+      "longitude": -742370183
+    },
+    "name": "352 South Mountain Road, Wallkill, NY 12589, USA"
+  }, {
+    "location": {
+      "latitude": 412950425,
+      "longitude": -741077389
+    },
+    "name": "Bailey Turn Road, Harriman, NY 10926, USA"
+  }, {
+    "location": {
+      "latitude": 412144655,
+      "longitude": -743949739
+    },
+    "name": "193-199 Wawayanda Road, Hewitt, NJ 07421, USA"
+  }, {
+    "location": {
+      "latitude": 415736605,
+      "longitude": -742847522
+    },
+    "name": "406-496 Ward Avenue, Pine Bush, NY 12566, USA"
+  }, {
+    "location": {
+      "latitude": 413843930,
+      "longitude": -740501726
+    },
+    "name": "162 Merrill Road, Highland Mills, NY 10930, USA"
+  }, {
+    "location": {
+      "latitude": 410873075,
+      "longitude": -744459023
+    },
+    "name": "Clinton Road, West Milford, NJ 07480, USA"
+  }, {
+    "location": {
+      "latitude": 412346009,
+      "longitude": -744026814
+    },
+    "name": "16 Old Brook Lane, Warwick, NY 10990, USA"
+  }, {
+    "location": {
+      "latitude": 402948455,
+      "longitude": -747903913
+    },
+    "name": "3 Drake Lane, Pennington, NJ 08534, USA"
+  }, {
+    "location": {
+      "latitude": 406337092,
+      "longitude": -740122226
+    },
+    "name": "6324 8th Avenue, Brooklyn, NY 11220, USA"
+  }, {
+    "location": {
+      "latitude": 406421967,
+      "longitude": -747727624
+    },
+    "name": "1 Merck Access Road, Whitehouse Station, NJ 08889, USA"
+  }, {
+    "location": {
+      "latitude": 416318082,
+      "longitude": -749677716
+    },
+    "name": "78-98 Schalck Road, Narrowsburg, NY 12764, USA"
+  }, {
+    "location": {
+      "latitude": 415301720,
+      "longitude": -748416257
+    },
+    "name": "282 Lakeview Drive Road, Highland Lake, NY 12743, USA"
+  }, {
+    "location": {
+      "latitude": 402647019,
+      "longitude": -747071791
+    },
+    "name": "330 Evelyn Avenue, Hamilton Township, NJ 08619, USA"
+  }, {
+    "location": {
+      "latitude": 412567807,
+      "longitude": -741058078
+    },
+    "name": "New York State Reference Route 987E, Southfields, NY 10975, USA"
+  }, {
+    "location": {
+      "latitude": 416855156,
+      "longitude": -744420597
+    },
+    "name": "103-271 Tempaloni Road, Ellenville, NY 12428, USA"
+  }, {
+    "location": {
+      "latitude": 404663628,
+      "longitude": -744820157
+    },
+    "name": "1300 Airport Road, North Brunswick Township, NJ 08902, USA"
+  }, {
+    "location": {
+      "latitude": 407113723,
+      "longitude": -749746483
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 402133926,
+      "longitude": -743613249
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 400273442,
+      "longitude": -741220915
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 411236786,
+      "longitude": -744070769
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 411633782,
+      "longitude": -746784970
+    },
+    "name": "211-225 Plains Road, Augusta, NJ 07822, USA"
+  }, {
+    "location": {
+      "latitude": 415830701,
+      "longitude": -742952812
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 413447164,
+      "longitude": -748712898
+    },
+    "name": "165 Pedersen Ridge Road, Milford, PA 18337, USA"
+  }, {
+    "location": {
+      "latitude": 405047245,
+      "longitude": -749800722
+    },
+    "name": "100-122 Locktown Road, Frenchtown, NJ 08825, USA"
+  }, {
+    "location": {
+      "latitude": 418858923,
+      "longitude": -746156790
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 417951888,
+      "longitude": -748484944
+    },
+    "name": "650-652 Willi Hill Road, Swan Lake, NY 12783, USA"
+  }, {
+    "location": {
+      "latitude": 407033786,
+      "longitude": -743977337
+    },
+    "name": "26 East 3rd Street, New Providence, NJ 07974, USA"
+  }, {
+    "location": {
+      "latitude": 417548014,
+      "longitude": -740075041
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 410395868,
+      "longitude": -744972325
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 404615353,
+      "longitude": -745129803
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 406589790,
+      "longitude": -743560121
+    },
+    "name": "611 Lawrence Avenue, Westfield, NJ 07090, USA"
+  }, {
+    "location": {
+      "latitude": 414653148,
+      "longitude": -740477477
+    },
+    "name": "18 Lannis Avenue, New Windsor, NY 12553, USA"
+  }, {
+    "location": {
+      "latitude": 405957808,
+      "longitude": -743255336
+    },
+    "name": "82-104 Amherst Avenue, Colonia, NJ 07067, USA"
+  }, {
+    "location": {
+      "latitude": 411733589,
+      "longitude": -741648093
+    },
+    "name": "170 Seven Lakes Drive, Sloatsburg, NY 10974, USA"
+  }, {
+    "location": {
+      "latitude": 412676291,
+      "longitude": -742606606
+    },
+    "name": "1270 Lakes Road, Monroe, NY 10950, USA"
+  }, {
+    "location": {
+      "latitude": 409224445,
+      "longitude": -748286738
+    },
+    "name": "509-535 Alphano Road, Great Meadows, NJ 07838, USA"
+  }, {
+    "location": {
+      "latitude": 406523420,
+      "longitude": -742135517
+    },
+    "name": "652 Garden Street, Elizabeth, NJ 07202, USA"
+  }, {
+    "location": {
+      "latitude": 401827388,
+      "longitude": -740294537
+    },
+    "name": "349 Sea Spray Court, Neptune City, NJ 07753, USA"
+  }, {
+    "location": {
+      "latitude": 410564152,
+      "longitude": -743685054
+    },
+    "name": "13-17 Stanley Street, West Milford, NJ 07480, USA"
+  }, {
+    "location": {
+      "latitude": 408472324,
+      "longitude": -740726046
+    },
+    "name": "47 Industrial Avenue, Teterboro, NJ 07608, USA"
+  }, {
+    "location": {
+      "latitude": 412452168,
+      "longitude": -740214052
+    },
+    "name": "5 White Oak Lane, Stony Point, NY 10980, USA"
+  }, {
+    "location": {
+      "latitude": 409146138,
+      "longitude": -746188906
+    },
+    "name": "Berkshire Valley Management Area Trail, Jefferson, NJ, USA"
+  }, {
+    "location": {
+      "latitude": 404701380,
+      "longitude": -744781745
+    },
+    "name": "1007 Jersey Avenue, New Brunswick, NJ 08901, USA"
+  }, {
+    "location": {
+      "latitude": 409642566,
+      "longitude": -746017679
+    },
+    "name": "6 East Emerald Isle Drive, Lake Hopatcong, NJ 07849, USA"
+  }, {
+    "location": {
+      "latitude": 408031728,
+      "longitude": -748645385
+    },
+    "name": "1358-1474 New Jersey 57, Port Murray, NJ 07865, USA"
+  }, {
+    "location": {
+      "latitude": 413700272,
+      "longitude": -742135189
+    },
+    "name": "367 Prospect Road, Chester, NY 10918, USA"
+  }, {
+    "location": {
+      "latitude": 404310607,
+      "longitude": -740282632
+    },
+    "name": "10 Simon Lake Drive, Atlantic Highlands, NJ 07716, USA"
+  }, {
+    "location": {
+      "latitude": 409319800,
+      "longitude": -746201391
+    },
+    "name": "11 Ward Street, Mount Arlington, NJ 07856, USA"
+  }, {
+    "location": {
+      "latitude": 406685311,
+      "longitude": -742108603
+    },
+    "name": "300-398 Jefferson Avenue, Elizabeth, NJ 07201, USA"
+  }, {
+    "location": {
+      "latitude": 419018117,
+      "longitude": -749142781
+    },
+    "name": "43 Dreher Road, Roscoe, NY 12776, USA"
+  }, {
+    "location": {
+      "latitude": 412856162,
+      "longitude": -745148837
+    },
+    "name": "Swan Street, Pine Island, NY 10969, USA"
+  }, {
+    "location": {
+      "latitude": 416560744,
+      "longitude": -746721964
+    },
+    "name": "66 Pleasantview Avenue, Monticello, NY 12701, USA"
+  }, {
+    "location": {
+      "latitude": 405314270,
+      "longitude": -749836354
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 414219548,
+      "longitude": -743327440
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 415534177,
+      "longitude": -742900616
+    },
+    "name": "565 Winding Hills Road, Montgomery, NY 12549, USA"
+  }, {
+    "location": {
+      "latitude": 406898530,
+      "longitude": -749127080
+    },
+    "name": "231 Rocky Run Road, Glen Gardner, NJ 08826, USA"
+  }, {
+    "location": {
+      "latitude": 407586880,
+      "longitude": -741670168
+    },
+    "name": "100 Mount Pleasant Avenue, Newark, NJ 07104, USA"
+  }, {
+    "location": {
+      "latitude": 400106455,
+      "longitude": -742870190
+    },
+    "name": "517-521 Huntington Drive, Manchester Township, NJ 08759, USA"
+  }, {
+    "location": {
+      "latitude": 400066188,
+      "longitude": -746793294
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 418803880,
+      "longitude": -744102673
+    },
+    "name": "40 Mountain Road, Napanoch, NY 12458, USA"
+  }, {
+    "location": {
+      "latitude": 414204288,
+      "longitude": -747895140
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 414777405,
+      "longitude": -740615601
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 415464475,
+      "longitude": -747175374
+    },
+    "name": "48 North Road, Forestburgh, NY 12777, USA"
+  }, {
+    "location": {
+      "latitude": 404062378,
+      "longitude": -746376177
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 405688272,
+      "longitude": -749285130
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 400342070,
+      "longitude": -748788996
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 401809022,
+      "longitude": -744157964
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 404226644,
+      "longitude": -740517141
+    },
+    "name": "9 Thompson Avenue, Leonardo, NJ 07737, USA"
+  }, {
+    "location": {
+      "latitude": 410322033,
+      "longitude": -747871659
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 407100674,
+      "longitude": -747742727
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 418811433,
+      "longitude": -741718005
+    },
+    "name": "213 Bush Road, Stone Ridge, NY 12484, USA"
+  }, {
+    "location": {
+      "latitude": 415034302,
+      "longitude": -743850945
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 411349992,
+      "longitude": -743694161
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 404839914,
+      "longitude": -744759616
+    },
+    "name": "1-17 Bergen Court, New Brunswick, NJ 08901, USA"
+  }, {
+    "location": {
+      "latitude": 414638017,
+      "longitude": -745957854
+    },
+    "name": "35 Oakland Valley Road, Cuddebackville, NY 12729, USA"
+  }, {
+    "location": {
+      "latitude": 412127800,
+      "longitude": -740173578
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 401263460,
+      "longitude": -747964303
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 412843391,
+      "longitude": -749086026
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 418512773,
+      "longitude": -743067823
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 404318328,
+      "longitude": -740835638
+    },
+    "name": "42-102 Main Street, Belford, NJ 07718, USA"
+  }, {
+    "location": {
+      "latitude": 419020746,
+      "longitude": -741172328
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 404080723,
+      "longitude": -746119569
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 401012643,
+      "longitude": -744035134
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 404306372,
+      "longitude": -741079661
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 403966326,
+      "longitude": -748519297
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 405002031,
+      "longitude": -748407866
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 409532885,
+      "longitude": -742200683
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 416851321,
+      "longitude": -742674555
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 406411633,
+      "longitude": -741722051
+    },
+    "name": "3387 Richmond Terrace, Staten Island, NY 10303, USA"
+  }, {
+    "location": {
+      "latitude": 413069058,
+      "longitude": -744597778
+    },
+    "name": "261 Van Sickle Road, Goshen, NY 10924, USA"
+  }, {
+    "location": {
+      "latitude": 418465462,
+      "longitude": -746859398
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 411733222,
+      "longitude": -744228360
+    },
+    "name": ""
+  }, {
+    "location": {
+      "latitude": 410248224,
+      "longitude": -747127767
+    },
+    "name": "3 Hasta Way, Newton, NJ 07860, USA"
+  }]
+}

--- a/extensions/protokt-extensions-api/build.gradle.kts
+++ b/extensions/protokt-extensions-api/build.gradle.kts
@@ -17,5 +17,5 @@ enablePublishing()
 trackKotlinApiCompatibility()
 
 dependencies {
-    compileOnly(libraries.protobuf)
+    compileOnly(libraries.protobufJava)
 }

--- a/protokt-codegen/build.gradle.kts
+++ b/protokt-codegen/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation(libraries.kollection)
     implementation(libraries.kotlinReflect)
     implementation(libraries.kotlinxCoroutinesCore)
-    implementation(libraries.protobuf)
+    implementation(libraries.protobufJava)
     implementation(libraries.stringTemplate)
 
     testImplementation(project(":testing:util"))

--- a/protokt-core/build.gradle.kts
+++ b/protokt-core/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
     api(project(":extensions:protokt-extensions-api"))
     api(project(":protokt-runtime"))
 
-    protobuf(libraries.protobuf)
-    compileOnly(libraries.protobuf)
+    protobuf(libraries.protobufJava)
+    compileOnly(libraries.protobufJava)
 
     implementation(libraries.autoServiceAnnotations)
     implementation(libraries.kotlinReflect)

--- a/protokt-runtime/build.gradle.kts
+++ b/protokt-runtime/build.gradle.kts
@@ -18,5 +18,5 @@ compatibleWithAndroid()
 trackKotlinApiCompatibility()
 
 dependencies {
-    compileOnly(libraries.protobuf)
+    compileOnly(libraries.protobufJava)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,14 @@ include(
     "protokt-gradle-plugin",
     "protokt-util",
 
+    "examples",
+    "examples:grpc-java",
+    "examples:grpc-java-lite",
+    "examples:grpc-kotlin",
+    "examples:grpc-kotlin-lite",
+    "examples:protos",
+    "examples:server-common",
+
     "extensions",
     "extensions:protokt-extensions-api",
     "extensions:protokt-extensions-simple",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,7 +40,6 @@ include(
     "examples:grpc-kotlin",
     "examples:grpc-kotlin-lite",
     "examples:protos",
-    "examples:server-common",
 
     "extensions",
     "extensions:protokt-extensions-api",

--- a/testing/conformance-driver/README.md
+++ b/testing/conformance-driver/README.md
@@ -1,13 +1,13 @@
 Steps taken to build conformance tests (assumed running on a Mac):
 
-```
+```sh
 git clone git@github.com:protocolbuffers/protobuf
 cd protobuf/
 ```
 
 Mac conformance tests:
 
-```
+```sh
 protobuf % ./configure
 protobuf % make clean
 protobuf % make
@@ -19,7 +19,8 @@ protobuf % cp src/.libs/libprotobuf.26.dylib ../protokt/testing/conformance-driv
 ```
 
 Ubuntu conformance tests:
-```
+
+```sh
 protobuf % docker run -v $(pwd):/tmp -t -i ubuntu:16.04 /bin/bash
 root@38f7a53696b9:/# apt-get update && apt-get install build-essential
 root@38f7a53696b9:/# cd tmp/

--- a/testing/conformance-driver/build.gradle.kts
+++ b/testing/conformance-driver/build.gradle.kts
@@ -26,5 +26,5 @@ configure<JavaApplication> {
 dependencies {
     implementation(libraries.arrow)
     implementation(libraries.kotlinxCoroutinesCore)
-    implementation(libraries.protobuf)
+    implementation(libraries.protobufJava)
 }

--- a/testing/conformance-tests/build.gradle.kts
+++ b/testing/conformance-tests/build.gradle.kts
@@ -15,7 +15,7 @@
 
 dependencies {
     testImplementation(project(":testing:util"))
-    testImplementation(libraries.protobuf)
+    testImplementation(libraries.protobufJava)
 }
 
 tasks.named("test") {

--- a/testing/options/build.gradle.kts
+++ b/testing/options/build.gradle.kts
@@ -31,5 +31,5 @@ dependencies {
 
     testImplementation(kotlin("reflect"))
     testImplementation(project(":testing:runtime-tests"))
-    testImplementation(libraries.protobuf)
+    testImplementation(libraries.protobufJava)
 }

--- a/testing/protobuf-java/build.gradle.kts
+++ b/testing/protobuf-java/build.gradle.kts
@@ -21,7 +21,7 @@ apply(plugin = "java")
 apply(plugin = "com.google.protobuf")
 
 dependencies {
-    implementation(libraries.protobuf)
+    implementation(libraries.protobufJava)
 }
 
 sourceSets {

--- a/testing/runtime-tests/build.gradle.kts
+++ b/testing/runtime-tests/build.gradle.kts
@@ -29,5 +29,5 @@ dependencies {
     implementation(libraries.grpcStub)
 
     testImplementation(libraries.jackson)
-    testImplementation(libraries.protobuf)
+    testImplementation(libraries.protobufJava)
 }


### PR DESCRIPTION
Fixes #70.

Leaves kotlin-lite and java-lite TODOs for implementation after #105.