### PR TITLE
Rework descriptors as extension properties

### DIFF
--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -62,6 +62,7 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
 
                 task.plugins {
                     id("protokt") {
+
                         project.afterEvaluate {
                             option("$KOTLIN_EXTRA_CLASSPATH=${extraClasspath(project, task)}")
                             option("$RESPECT_JAVA_PACKAGE=${ext.respectJavaPackage}")

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -63,7 +63,6 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
 
                 task.plugins {
                     id("protokt") {
-
                         project.afterEvaluate {
                             option("$KOTLIN_EXTRA_CLASSPATH=${extraClasspath(project, task)}")
                             option("$RESPECT_JAVA_PACKAGE=${ext.respectJavaPackage}")

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -35,6 +35,7 @@ const val RESPECT_JAVA_PACKAGE = "respect_java_package"
 const val GENERATE_GRPC = "generate_grpc"
 const val ONLY_GENERATE_GRPC = "only_generate_grpc"
 const val LITE = "lite"
+const val ONLY_GENERATE_DESCRIPTORS = "only_generate_descriptors"
 
 internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, binaryPath: String) {
     project.apply(plugin = "com.google.protobuf")
@@ -69,6 +70,7 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
                             option("$GENERATE_GRPC=${ext.generateGrpc}")
                             option("$ONLY_GENERATE_GRPC=${ext.onlyGenerateGrpc}")
                             option("$LITE=${ext.lite}")
+                            option("$ONLY_GENERATE_DESCRIPTORS=${ext.onlyGenerateDescriptors}")
                         }
                     }
                 }

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtoktExtension.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtoktExtension.kt
@@ -36,17 +36,24 @@ open class ProtoktExtension {
     var generateGrpc = false
 
     /**
-     * Whether or not to _only_ generate gRPC-specific code. Useful to generate
+     * Whether to _only_ generate gRPC-specific code. Useful to generate
      * libraries that have already had a version compiled with `generateGrpc`
      * set to `false`.
      */
     var onlyGenerateGrpc = false
 
     /**
-     * Whether or not to generate embedded descriptors for runtime reflective
+     * Whether to generate embedded descriptors for runtime reflective
      * access. Beware: if this option is enabled and any generated file depends
      * on a file generated in a different run of the code generator in which
      * this option was not enabled, the generated code will fail to compile.
      */
     var lite = false
+
+    /**
+     * Whether to _only_ generate descriptor code. Useful to generate
+     * libraries that have already had a version compiled with `lite`
+     * set to `true`.
+     */
+    var onlyGenerateDescriptors = false
 }

--- a/extensions/protokt-extensions-proto-based/build.gradle.kts
+++ b/extensions/protokt-extensions-proto-based/build.gradle.kts
@@ -19,7 +19,7 @@ apply(plugin = "kotlin-kapt")
 
 localProtokt()
 enablePublishing()
-trackKotlinApiCompatibility()
+trackKotlinApiCompatibility(false)
 
 dependencies {
     implementation(project(":extensions:protokt-extensions-api"))

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Accumulator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Accumulator.kt
@@ -31,7 +31,7 @@ internal object Accumulator {
             } ?: imports
 
         val header = StringBuilder()
-        HeaderAccumulator.write(descs, accumulatedImports, header::appendLine)
+        HeaderAccumulator.write(descs, accumulatedImports, header::append)
 
         val body = StringBuilder()
         descs.forEach {
@@ -42,7 +42,7 @@ internal object Accumulator {
             }
         }
 
-        if (body.isNotBlank()) {
+        if (body.isNotBlank() || fileDescriptorInfo != null) {
             acc(header)
             fileDescriptorInfo?.run { body.append(fdp) }
             acc(ImportReplacer.replaceImports(body, accumulatedImports))

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Annotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/Annotator.kt
@@ -71,14 +71,18 @@ object Annotator {
         when (type) {
             is Message ->
                 nonGrpc(ctx) {
-                    annotateMessage(
-                        type,
-                        ctx.copy(enclosing = ctx.enclosing + type)
-                    )
+                    nonDescriptors(ctx) {
+                        annotateMessage(
+                            type,
+                            ctx.copy(enclosing = ctx.enclosing + type)
+                        )
+                    }
                 }
             is Enum ->
                 nonGrpc(ctx) {
-                    annotateEnum(type, ctx)
+                    nonDescriptors(ctx) {
+                        annotateEnum(type, ctx)
+                    }
                 }
             is Service ->
                 annotateService(
@@ -88,6 +92,12 @@ object Annotator {
                         ctx.desc.context.onlyGenerateGrpc
                 )
         }
+
+    private fun nonDescriptors(ctx: Context, gen: () -> String) =
+        nonDescriptors(ctx.desc.context, "", gen)
+
+    fun <T> nonDescriptors(ctx: ProtocolContext, default: T, gen: () -> T) =
+        boolGen(!ctx.onlyGenerateDescriptors, default, gen)
 
     private fun nonGrpc(ctx: Context, gen: () -> String) =
         nonGrpc(ctx.desc.context, "", gen)

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/EnumAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/EnumAnnotator.kt
@@ -58,11 +58,7 @@ private constructor(
         EnumOptions(
             documentation = annotateEnumDocumentation(e, ctx),
             deprecation = enumDeprecation(),
-            suppressDeprecation = (e.hasDeprecation && !enclosingDeprecation(ctx)),
-            parentName = e.parentName,
-            index = e.index,
-            fileDescriptorObjectName = ctx.desc.context.fileDescriptorObjectName,
-            reflect = !ctx.desc.context.lite
+            suppressDeprecation = (e.hasDeprecation && !enclosingDeprecation(ctx))
         )
 
     private fun enumDeprecation() =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/FileDescriptorResolver.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/FileDescriptorResolver.kt
@@ -37,9 +37,7 @@ private constructor(
     private val pkg = kotlinPackage(descs.first())
 
     private fun resolveFileDescriptor(): FileDescriptorInfo? {
-        // If we're only generating services, the file descriptor will
-        // already exist in the non-gRPC file
-        if (ctx.onlyGenerateGrpc || ctx.lite) {
+        if (ctx.lite) {
             return null
         }
 
@@ -130,8 +128,8 @@ private constructor(
                     qualification(containingTypes),
                     ctx.fileDescriptorObjectName,
                     enum.index,
-                    containingTypes.any { it.options.default.deprecated }
-                        || enum.options.default.deprecated
+                    containingTypes.any { it.options.default.deprecated } ||
+                        enum.options.default.deprecated
                 )
             }
 
@@ -159,8 +157,8 @@ private constructor(
                     qualification(containingTypes),
                     ctx.fileDescriptorObjectName,
                     msg.index,
-                    containingTypes.any { it.options.default.deprecated }
-                        || msg.options.default.deprecated
+                    containingTypes.any { it.options.default.deprecated } ||
+                        msg.options.default.deprecated
                 )
             }
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/FileDescriptorResolver.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/FileDescriptorResolver.kt
@@ -16,67 +16,54 @@
 package com.toasttab.protokt.codegen.impl
 
 import com.google.protobuf.DescriptorProtos
-import com.toasttab.protokt.codegen.model.PPackage
-import com.toasttab.protokt.codegen.protoc.ProtocolContext
+import com.toasttab.protokt.codegen.protoc.Enum
+import com.toasttab.protokt.codegen.protoc.Message
+import com.toasttab.protokt.codegen.protoc.TopLevelType
 import com.toasttab.protokt.codegen.protoc.TypeDesc
-import com.toasttab.protokt.codegen.template.Descriptor
+import com.toasttab.protokt.codegen.template.Descriptor.Descriptor
+import com.toasttab.protokt.codegen.template.Descriptor.EnumDescriptorProperty
+import com.toasttab.protokt.codegen.template.Descriptor.MessageDescriptorProperty
 
 class FileDescriptorInfo(
     val fdp: String,
     val imports: Set<String>
 )
 
-object FileDescriptorResolver {
-    fun resolveFileDescriptor(descs: List<TypeDesc>) =
-        descs.firstOrNull()?.let {
-            val aDesc = descs.first()
-            resolveFileDescriptor(aDesc.desc.context, kotlinPackage(aDesc))
-        }
+class FileDescriptorResolver
+private constructor(
+    private val descs: List<TypeDesc>
+) {
+    private val ctx = descs.first().desc.context
+    private val pkg = kotlinPackage(descs.first())
 
-    private fun resolveFileDescriptor(
-        ctx: ProtocolContext,
-        pkg: PPackage
-    ): FileDescriptorInfo? {
+    private fun resolveFileDescriptor(): FileDescriptorInfo? {
         // If we're only generating services, the file descriptor will
         // already exist in the non-gRPC file
         if (ctx.onlyGenerateGrpc || ctx.lite) {
             return null
         }
 
-        val imports = mutableSetOf<String>()
+        val dependenciesAndImports = dependencies()
 
         val template =
-            Descriptor.Descriptor.render(
+            Descriptor.render(
                 ctx.fileDescriptorObjectName,
-                encodeFileDescriptor(
-                    clearJsonInfo(
-                        ctx.fdp.toBuilder()
-                            .clearSourceCodeInfo()
-                            .build()
-                    )
-                ),
-                ctx.fdp.dependencyList
-                    .filter {
-                        // We don't generate anything for files without any of the
-                        // following; e.g., a file containing only extensions.
-                        ctx.allFilesByName.getValue(it).let { fdp ->
-                            fdp.messageTypeCount +
-                                fdp.enumTypeCount +
-                                fdp.serviceCount > 0
-                        }
-                    }.map {
-                        val depPkg = ctx.allPackagesByFileName.getValue(it)
-                        val descriptorObjectName =
-                            ctx.allDescriptorClassNamesByDescriptorName.getValue(it)
-                        if (!depPkg.default && depPkg != pkg) {
-                            imports.add("$depPkg.$descriptorObjectName")
-                        }
-                        descriptorObjectName
-                    },
-                ctx.fdp.dependencyCount > 1
+                fileDescriptorParts(),
+                dependenciesAndImports.dependencies,
+                ctx.fdp.dependencyCount > 1,
+                enumDescriptorExtensionProperties() + messageDescriptorExtensionProperties()
             )
-        return FileDescriptorInfo(template, imports)
+        return FileDescriptorInfo(template, dependenciesAndImports.imports)
     }
+
+    private fun fileDescriptorParts() =
+        encodeFileDescriptor(
+            clearJsonInfo(
+                ctx.fdp.toBuilder()
+                    .clearSourceCodeInfo()
+                    .build()
+            )
+        )
 
     private fun clearJsonInfo(fileDescriptorProto: DescriptorProtos.FileDescriptorProto) =
         fileDescriptorProto.toBuilder()
@@ -102,4 +89,113 @@ object FileDescriptorResolver {
                 )
                 .build()
         }
+
+    private class DependenciesAndImports(
+        val dependencies: List<String>,
+        val imports: Set<String>
+    )
+
+    private fun dependencies(): DependenciesAndImports {
+        val imports = mutableSetOf<String>()
+
+        val dependencies =
+            ctx.fdp.dependencyList
+                .filter {
+                    // We don't generate anything for files without any of the
+                    // following; e.g., a file containing only extensions.
+                    ctx.allFilesByName.getValue(it).let { fdp ->
+                        fdp.messageTypeCount +
+                            fdp.enumTypeCount +
+                            fdp.serviceCount > 0
+                    }
+                }.map {
+                    val depPkg = ctx.allPackagesByFileName.getValue(it)
+                    val descriptorObjectName =
+                        ctx.allDescriptorClassNamesByDescriptorName.getValue(it)
+                    if (!depPkg.default && depPkg != pkg) {
+                        imports.add("$depPkg.$descriptorObjectName")
+                    }
+                    descriptorObjectName
+                }
+
+        return DependenciesAndImports(dependencies, imports)
+    }
+
+    private fun enumDescriptorExtensionProperties() =
+        descs.flatMap { findEnums(emptyList(), it.type.rawType) }
+            .map { (enum, containingTypes) ->
+                EnumDescriptorProperty.render(
+                    containingTypes.isEmpty(),
+                    enum.name,
+                    qualification(containingTypes),
+                    ctx.fileDescriptorObjectName,
+                    enum.index,
+                    containingTypes.any { it.options.default.deprecated }
+                        || enum.options.default.deprecated
+                )
+            }
+
+    private data class EnumInfo(
+        val enum: Enum,
+        val containingTypes: List<Message>
+    )
+
+    private fun findEnums(enclosingMessages: List<Message>, type: TopLevelType): List<EnumInfo> =
+        when (type) {
+            is Enum -> listOf(EnumInfo(type, enclosingMessages))
+            is Message -> findEnums(enclosingMessages + type, type)
+            else -> emptyList()
+        }
+
+    private fun findEnums(enclosingMessages: List<Message>, m: Message) =
+        m.nestedTypes.flatMap { findEnums(enclosingMessages, it) }
+
+    private fun messageDescriptorExtensionProperties() =
+        descs.flatMap { findMessages(emptyList(), it.type.rawType) }
+            .map { (msg, containingTypes) ->
+                MessageDescriptorProperty.render(
+                    containingTypes.isEmpty(),
+                    msg.name,
+                    qualification(containingTypes),
+                    ctx.fileDescriptorObjectName,
+                    msg.index,
+                    containingTypes.any { it.options.default.deprecated }
+                        || msg.options.default.deprecated
+                )
+            }
+
+    private data class MessageInfo(
+        val msg: Message,
+        val containingTypes: List<Message>
+    )
+
+    private fun findMessages(enclosingMessages: List<Message>, type: TopLevelType): List<MessageInfo> =
+        when (type) {
+            is Message ->
+                if (type.mapEntry) {
+                    emptyList()
+                } else {
+                    listOf(MessageInfo(type, enclosingMessages))
+                } + findMessages(enclosingMessages + type, type)
+            else -> emptyList()
+        }
+
+    private fun findMessages(enclosingMessages: List<Message>, m: Message) =
+        m.nestedTypes.flatMap { findMessages(enclosingMessages, it) }
+
+    private fun qualification(enclosingMessages: List<Message>) =
+        if (enclosingMessages.isNotEmpty()) {
+            enclosingMessages.joinToString(".") { it.name } + "."
+        } else {
+            null
+        }
+
+    companion object {
+        fun resolveFileDescriptor(descs: List<TypeDesc>) =
+            if (descs.isNotEmpty()) {
+                FileDescriptorResolver(descs).resolveFileDescriptor()
+            } else {
+                null
+            }
+    }
 }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/HeaderAccumulator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/HeaderAccumulator.kt
@@ -27,13 +27,13 @@ object HeaderAccumulator {
         imports: Set<Import>,
         acc: (String) -> Unit
     ) {
-        descs.firstOrNone().map {
+        descs.firstOrNone().map { desc ->
             acc(
                 Header.render(
-                    `package` = `package`(it),
-                    imports = imports.map(Import::qualifiedName).sorted(),
-                    version = it.desc.context.version,
-                    fileName = it.desc.name
+                    `package` = `package`(desc),
+                    imports = imports.map(Import::qualifiedName).sorted().takeIf { it.isNotEmpty() },
+                    version = desc.desc.context.version,
+                    fileName = desc.desc.name
                 )
             )
         }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/ImportResolver.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/ImportResolver.kt
@@ -20,6 +20,7 @@ import com.github.andrewoma.dexx.kollection.ImmutableSet
 import com.github.andrewoma.dexx.kollection.immutableSetOf
 import com.github.andrewoma.dexx.kollection.toImmutableSet
 import com.toasttab.protokt.codegen.impl.Annotator.grpc
+import com.toasttab.protokt.codegen.impl.Annotator.nonDescriptors
 import com.toasttab.protokt.codegen.impl.Annotator.nonGrpc
 import com.toasttab.protokt.codegen.impl.ClassLookup.getClassOrNone
 import com.toasttab.protokt.codegen.model.Import
@@ -77,11 +78,17 @@ class ImportResolver(
 
     private fun imports(t: TopLevelType): ImmutableSet<Import> =
         when (t) {
-            is Message -> nonGrpc(ctx, immutableSetOf()) { imports(t) }
-            is Enum -> nonGrpc(ctx, immutableSetOf()) { enumImports }
+            is Message ->
+                nonGrpc(ctx, immutableSetOf()) {
+                    nonDescriptors(ctx, immutableSetOf()) { imports(t) }
+                }
+            is Enum ->
+                nonGrpc(ctx, immutableSetOf()) {
+                    nonDescriptors(ctx, immutableSetOf(), ::enumImports)
+                }
             is Service -> grpc(ctx, immutableSetOf()) { serviceImports(t) }
         } +
-            if (!ctx.lite) {
+            if (!ctx.lite || ctx.onlyGenerateDescriptors) {
                 descriptorImports
             } else {
                 emptySet()

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/MessageAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/MessageAnnotator.kt
@@ -67,7 +67,8 @@ private constructor(
             implements = msg.implements,
             documentation = annotateMessageDocumentation(ctx),
             deprecation = deprecation(),
-            suppressDeprecation = suppressDeprecation()
+            suppressDeprecation = suppressDeprecation(),
+            fullTypeName = msg.fullProtobufTypeName
         )
 
     private fun deprecation() =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/MessageAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/MessageAnnotator.kt
@@ -34,7 +34,6 @@ import com.toasttab.protokt.codegen.model.PPackage
 import com.toasttab.protokt.codegen.protoc.Message
 import com.toasttab.protokt.codegen.template.Message.Message.MessageInfo
 import com.toasttab.protokt.codegen.template.Message.Message.Options
-import com.toasttab.protokt.codegen.template.Message.Message.ReflectInfo
 import com.toasttab.protokt.codegen.template.Message.Message as MessageTemplate
 
 class MessageAnnotator
@@ -54,7 +53,6 @@ private constructor(
                 serialize = annotateSerializer(msg, ctx),
                 deserialize = annotateDeserializer(msg, ctx),
                 nested = nestedTypes(),
-                reflect = reflectInfo(),
                 options = options()
             )
         }
@@ -100,17 +98,6 @@ private constructor(
             longDeserializer = lengthAsOneLine > IDEAL_MAX_WIDTH
         )
     }
-
-    private fun reflectInfo() =
-        if (ctx.desc.context.lite) {
-            null
-        } else {
-            ReflectInfo(
-                fileDescriptorObjectName = ctx.desc.context.fileDescriptorObjectName,
-                index = msg.index,
-                parentName = msg.parentName
-            )
-        }
 
     companion object {
         const val IDEAL_MAX_WIDTH = 100

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Protocol.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Protocol.kt
@@ -179,7 +179,8 @@ private fun toMessage(
             desc.options,
             desc.options.getExtension(Protokt.class_)
         ),
-        index = idx
+        index = idx,
+        fullProtobufTypeName = "${ctx.fdp.`package`}.${desc.name}"
     )
 }
 

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/ProtocolContext.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/ProtocolContext.kt
@@ -21,6 +21,7 @@ import com.toasttab.protokt.codegen.impl.resolvePackage
 import com.toasttab.protokt.gradle.GENERATE_GRPC
 import com.toasttab.protokt.gradle.KOTLIN_EXTRA_CLASSPATH
 import com.toasttab.protokt.gradle.LITE
+import com.toasttab.protokt.gradle.ONLY_GENERATE_DESCRIPTORS
 import com.toasttab.protokt.gradle.ONLY_GENERATE_GRPC
 import com.toasttab.protokt.gradle.RESPECT_JAVA_PACKAGE
 import com.toasttab.protokt.util.getProtoktVersion
@@ -29,7 +30,7 @@ import java.net.URLDecoder
 class ProtocolContext(
     val fdp: FileDescriptorProto,
     params: Map<String, String>,
-    val filesToGenerate: Set<String>,
+    private val filesToGenerate: Set<String>,
     allFiles: List<FileDescriptorProto>
 ) {
     val classpath =
@@ -41,6 +42,7 @@ class ProtocolContext(
     val generateGrpc = params.getValue(GENERATE_GRPC).toBoolean()
     val onlyGenerateGrpc = params.getValue(ONLY_GENERATE_GRPC).toBoolean()
     val lite = params.getValue(LITE).toBoolean()
+    val onlyGenerateDescriptors = params.getValue(ONLY_GENERATE_DESCRIPTORS).toBoolean()
 
     val fileName = fdp.name
     val version = getProtoktVersion(ProtocolContext::class)

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Types.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Types.kt
@@ -33,8 +33,7 @@ class Message(
     val nestedTypes: List<TopLevelType>,
     val mapEntry: Boolean,
     val options: MessageOptions,
-    val index: Int,
-    val parentName: String?
+    val index: Int
 ) : TopLevelType()
 
 data class MessageOptions(
@@ -46,7 +45,6 @@ class Enum(
     override val name: String,
     val options: EnumOptions,
     val values: List<Value>,
-    val parentName: String?,
     val index: Int
 ) : TopLevelType() {
     class Value(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Types.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/protoc/Types.kt
@@ -33,7 +33,8 @@ class Message(
     val nestedTypes: List<TopLevelType>,
     val mapEntry: Boolean,
     val options: MessageOptions,
-    val index: Int
+    val index: Int,
+    val fullProtobufTypeName: String
 ) : TopLevelType()
 
 data class MessageOptions(

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Descriptor.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Descriptor.kt
@@ -21,13 +21,53 @@ object Descriptor {
             fileDescriptorObjectName: String,
             parts: List<List<String>>,
             dependencies: List<String>,
-            longDependencies: Boolean
+            longDependencies: Boolean,
+            descriptorExtensionProperties: List<String>
         ) =
             renderArgs(
                 fileDescriptorObjectName,
                 parts,
                 dependencies,
-                longDependencies
+                longDependencies,
+                descriptorExtensionProperties
+            )
+    }
+
+    object MessageDescriptorProperty : StTemplate(StGroup.Descriptor) {
+        fun render(
+            topLevel: Boolean,
+            typeName: String,
+            qualification: String?,
+            fileDescriptorObjectName: String,
+            index: Int,
+            suppressDeprecation: Boolean
+        ) =
+            renderArgs(
+                topLevel,
+                typeName,
+                qualification,
+                fileDescriptorObjectName,
+                index,
+                suppressDeprecation
+            )
+    }
+
+    object EnumDescriptorProperty : StTemplate(StGroup.Descriptor) {
+        fun render(
+            topLevel: Boolean,
+            typeName: String,
+            qualification: String?,
+            fileDescriptorObjectName: String,
+            index: Int,
+            suppressDeprecation: Boolean
+        ) =
+            renderArgs(
+                topLevel,
+                typeName,
+                qualification,
+                fileDescriptorObjectName,
+                index,
+                suppressDeprecation
             )
     }
 }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Enum.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Enum.kt
@@ -35,11 +35,7 @@ object Enum {
         class EnumOptions(
             val documentation: List<String>,
             val deprecation: Deprecation.RenderOptions?,
-            val suppressDeprecation: Boolean,
-            val index: Int,
-            val parentName: String?,
-            val fileDescriptorObjectName: String,
-            val reflect: Boolean
+            val suppressDeprecation: Boolean
         )
     }
 }

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Header.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Header.kt
@@ -21,7 +21,7 @@ object Header {
     object Header : StTemplate(StGroup.Header) {
         fun render(
             `package`: PPackage?,
-            imports: List<String>,
+            imports: List<String>?,
             version: String,
             fileName: String
         ) =

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Message.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Message.kt
@@ -46,7 +46,8 @@ object Message {
             val implements: String,
             val documentation: List<String>,
             val deprecation: Deprecation.RenderOptions?,
-            val suppressDeprecation: Boolean
+            val suppressDeprecation: Boolean,
+            val fullTypeName: String
         )
 
         interface FieldInfo {

--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Message.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/template/Message.kt
@@ -27,7 +27,6 @@ object Message {
             properties: List<PropertyInfo>,
             oneofs: List<String>,
             nested: List<String>,
-            reflect: ReflectInfo?,
             options: Options
         ) =
             renderArgs(
@@ -38,7 +37,6 @@ object Message {
                 properties,
                 oneofs,
                 nested,
-                reflect,
                 options
             )
 
@@ -112,12 +110,6 @@ object Message {
             override val name
                 get() = assignment.fieldName
         }
-
-        data class ReflectInfo(
-            val fileDescriptorObjectName: String,
-            val index: Int,
-            val parentName: String?
-        )
 
         class Options(
             val wellKnownType: Boolean,

--- a/protokt-codegen/src/main/resources/descriptor.stg
+++ b/protokt-codegen/src/main/resources/descriptor.stg
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-descriptor(fileDescriptorObjectName, parts, dependencies, longDependencies) ::= <<
+import "options.stg"
+
+descriptor(fileDescriptorObjectName, parts, dependencies, longDependencies, descriptorExtensionProperties) ::= <<
 object <fileDescriptorObjectName> {
     val descriptor by lazy {
         val descriptorData = arrayOf(
@@ -33,4 +35,27 @@ object <fileDescriptorObjectName> {
     }
 }
 
+<descriptorExtensionProperties: {p | <p>}; separator="\n">
+>>
+
+messageDescriptorProperty(topLevel, typeName, qualification, fileDescriptorObjectName, index, suppressDeprecation) ::= <<
+<suppressDeprecation(suppressDeprecation)><\\>
+val <qualification><typeName>.Deserializer.descriptor
+    get() = <\\>
+        <if (topLevel)><\\>
+        <fileDescriptorObjectName>.descriptor.messageTypes[<index>]
+        <else><\\>
+        <qualification>descriptor.nestedTypes[<index>]
+        <endif>
+>>
+
+enumDescriptorProperty(topLevel, typeName, qualification, fileDescriptorObjectName, index, suppressDeprecation) ::= <<
+<suppressDeprecation(suppressDeprecation)><\\>
+val <qualification><typeName>.Deserializer.descriptor
+    get() = <\\>
+        <if (topLevel)><\\>
+        <fileDescriptorObjectName>.descriptor.enumTypes[<index>]
+        <else><\\>
+        <qualification>descriptor.enumTypes[<index>]
+        <endif>
 >>

--- a/protokt-codegen/src/main/resources/deserializer.stg
+++ b/protokt-codegen/src/main/resources/deserializer.stg
@@ -45,15 +45,5 @@ companion object Deserializer : KtDeserializer\<<message.name>\>, (<message.name
     }
 
     <dslInvoke()>
-    <if (reflect)>
-
-    val descriptor by lazy {
-        <if (reflect.parentName)>
-        <reflect.parentName>.descriptor.nestedTypes[<reflect.index>]
-        <else>
-        <reflect.fileDescriptorObjectName>.descriptor.messageTypes[<reflect.index>]
-        <endif>
-    }
-    <endif>
 }
 >>

--- a/protokt-codegen/src/main/resources/enum.stg
+++ b/protokt-codegen/src/main/resources/enum.stg
@@ -18,7 +18,7 @@ import "renderers.stg"
 
 enum(name, map, options) ::= <<
 <blockComment(options.documentation)><\\>
-<suppressDeprecation(options)><\\>
+<suppressDeprecation(options.suppressDeprecation)><\\>
 <deprecated(options)><\\>
 sealed class <name>(
     override val value: Int,
@@ -38,16 +38,6 @@ sealed class <name>(
                 <map.keys:{k | <k> -> <map.(k).valueName>}; separator="\n">
                 else -> UNRECOGNIZED(value)
             }
-        <if (options.reflect)>
-
-        val descriptor by lazy {
-            <if (options.parentName)>
-            <options.parentName>.descriptor.enumTypes[<options.index>]
-            <else>
-            <options.fileDescriptorObjectName>.descriptor.enumTypes[<options.index>]
-            <endif>
-        }
-        <endif>
     }
 }
 

--- a/protokt-codegen/src/main/resources/header.stg
+++ b/protokt-codegen/src/main/resources/header.stg
@@ -20,6 +20,5 @@ header(package, imports, version, fileName) ::= <<
  */
 
 <if (package)>package <package><\n><\n><endif><\\>
-<imports : { it | import <it>}; separator="\n">
-
+<if (imports)><imports : { it | import <it>}; separator="\n"><\n><\n><endif><\\>
 >>

--- a/protokt-codegen/src/main/resources/message.stg
+++ b/protokt-codegen/src/main/resources/message.stg
@@ -22,7 +22,7 @@ message(message, serialize, deserialize, sizeof, nested, properties, oneofs, opt
 <blockComment(message.documentation)><\\>
 <suppressDeprecation(message.suppressDeprecation)><\\>
 <deprecated(message)><\\>
-@KtGeneratedMessage
+@KtGeneratedMessage("<message.fullTypeName>")
 class <message.name>
 private constructor(
     <properties:{p |<\\>

--- a/protokt-codegen/src/main/resources/message.stg
+++ b/protokt-codegen/src/main/resources/message.stg
@@ -18,9 +18,9 @@ import "dsl.stg"
 import "options.stg"
 import "renderers.stg"
 
-message(message, serialize, deserialize, sizeof, nested, properties, oneofs, reflect, options) ::= <<
+message(message, serialize, deserialize, sizeof, nested, properties, oneofs, options) ::= <<
 <blockComment(message.documentation)><\\>
-<suppressDeprecation(message)><\\>
+<suppressDeprecation(message.suppressDeprecation)><\\>
 <deprecated(message)><\\>
 @KtGeneratedMessage
 class <message.name>
@@ -128,14 +128,5 @@ private constructor(
     <nested:{n | <n>}; separator="\n"><\\>
     <endif><\\>
 }
-<if (reflect)>
 
-val <message.name>.Deserializer.descriptor
-    get() = <\\>
-        <if (reflect.parentName)><\\>
-        <reflect.parentName>.descriptor.nestedTypes[<reflect.index>]
-        <else><\\>
-        <reflect.fileDescriptorObjectName>.descriptor.messageTypes[<reflect.index>]
-        <endif><\\>
-<endif>
 >>

--- a/protokt-codegen/src/main/resources/message.stg
+++ b/protokt-codegen/src/main/resources/message.stg
@@ -128,5 +128,14 @@ private constructor(
     <nested:{n | <n>}; separator="\n"><\\>
     <endif><\\>
 }
+<if (reflect)>
 
+val <message.name>.Deserializer.descriptor
+    get() = <\\>
+        <if (reflect.parentName)><\\>
+        <reflect.parentName>.descriptor.nestedTypes[<reflect.index>]
+        <else><\\>
+        <reflect.fileDescriptorObjectName>.descriptor.messageTypes[<reflect.index>]
+        <endif><\\>
+<endif>
 >>

--- a/protokt-codegen/src/main/resources/options.stg
+++ b/protokt-codegen/src/main/resources/options.stg
@@ -73,8 +73,8 @@ deprecated(any) ::= <%
     <endif>
 %>
 
-suppressDeprecation(any) ::= <%
-    <if (any.suppressDeprecation)>
+suppressDeprecation(suppress) ::= <%
+    <if (suppress)>
         @Suppress("DEPRECATION")<\n>
     <endif>
 %>

--- a/protokt-core/build.gradle.kts
+++ b/protokt-core/build.gradle.kts
@@ -15,6 +15,7 @@
 
 import com.google.protobuf.gradle.proto
 import com.google.protobuf.gradle.protobuf
+import com.toasttab.protokt.gradle.protokt
 
 plugins {
     kotlin("kapt")
@@ -24,11 +25,15 @@ localProtokt()
 pureKotlin()
 enablePublishing()
 compatibleWithAndroid()
-trackKotlinApiCompatibility()
+trackKotlinApiCompatibility(false)
+
+protokt {
+    onlyGenerateDescriptors = true
+}
 
 dependencies {
     api(project(":extensions:protokt-extensions-api"))
-    api(project(":protokt-runtime"))
+    api(project(":protokt-core-lite"))
 
     protobuf(libraries.protobufJava)
     compileOnly(libraries.protobufJava)
@@ -43,9 +48,6 @@ sourceSets {
     main {
         proto {
             srcDir("../protokt-runtime/src/main/resources")
-        }
-        java {
-            srcDir("../protokt-core-lite/src/main/kotlin")
         }
     }
 }

--- a/protokt-core/src/main/kotlin/com/toasttab/protokt/Descriptors.kt
+++ b/protokt-core/src/main/kotlin/com/toasttab/protokt/Descriptors.kt
@@ -17,10 +17,6 @@ package com.toasttab.protokt
 
 import com.toasttab.protokt.rt.finishList
 
-fun foo() {
-    DescriptorProto.ExtensionRange.descriptor
-}
-
 class FileDescriptor(
     val proto: FileDescriptorProto,
     val dependencies: List<FileDescriptor>

--- a/protokt-core/src/main/kotlin/com/toasttab/protokt/Descriptors.kt
+++ b/protokt-core/src/main/kotlin/com/toasttab/protokt/Descriptors.kt
@@ -17,6 +17,10 @@ package com.toasttab.protokt
 
 import com.toasttab.protokt.rt.finishList
 
+fun foo() {
+    DescriptorProto.ExtensionRange.descriptor
+}
+
 class FileDescriptor(
     val proto: FileDescriptorProto,
     val dependencies: List<FileDescriptor>

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedMessage.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedMessage.kt
@@ -20,6 +20,5 @@ annotation class KtGeneratedMessage(
     /**
      * The full protocol buffer type name of this message used for packing into an Any.
      */
-    @Deprecated("Use the generated descriptor")
-    val fullTypeName: String = ""
+    val fullTypeName: String
 )

--- a/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/FileDescriptorEncodingTest.kt
+++ b/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/FileDescriptorEncodingTest.kt
@@ -26,27 +26,26 @@ import com.toasttab.protokt.FileDescriptor
 import com.toasttab.protokt.FileDescriptorProto
 import com.toasttab.protokt.Type
 import com.toasttab.protokt.descriptor
-import com.toasttab.protokt.rt.KtDeserializer
 import com.toasttab.protokt.testing.rt.other.DeeplyNested
 import com.toasttab.protokt.testing.rt.other.HasAService
 import org.junit.jupiter.api.Test
 import toasttab.protokt.testing.rt.DeeplyNested1.DeeplyNested2.DeeplyNested3.DeeplyNested4
 import toasttab.protokt.testing.rt.FooService
+import toasttab.protokt.testing.rt.descriptor
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty1
 
 // Assert against a sampling of generated descriptors.
 class FileDescriptorEncodingTest {
     @Test
     fun `encoding of file descriptors is equal`() {
-        assertFileDescriptorsAreEqual(com.toasttab.protokt.Any, com.google.protobuf.Any::class)
-        assertFileDescriptorsAreEqual(Api, com.google.protobuf.Api::class)
-        assertFileDescriptorsAreEqual(FileDescriptorProto, DescriptorProtos.FileDescriptorProto::class)
-        assertFileDescriptorsAreEqual(Type, com.google.protobuf.Type::class)
+        assertFileDescriptorsAreEqual(com.toasttab.protokt.Any.descriptor, com.google.protobuf.Any::class)
+        assertFileDescriptorsAreEqual(Api.descriptor, com.google.protobuf.Api::class)
+        assertFileDescriptorsAreEqual(FileDescriptorProto.descriptor, DescriptorProtos.FileDescriptorProto::class)
+        assertFileDescriptorsAreEqual(Type.descriptor, com.google.protobuf.Type::class)
 
         // nested types
-        assertFileDescriptorsAreEqual(DescriptorProto.ExtensionRange, DescriptorProtos.DescriptorProto.ExtensionRange::class)
-        assertFileDescriptorsAreEqual(DeeplyNested4, DeeplyNested.DeeplyNested1.DeeplyNested2.DeeplyNested3.DeeplyNested4::class)
+        assertFileDescriptorsAreEqual(DescriptorProto.ExtensionRange.descriptor, DescriptorProtos.DescriptorProto.ExtensionRange::class)
+        assertFileDescriptorsAreEqual(DeeplyNested4.descriptor, DeeplyNested.DeeplyNested1.DeeplyNested2.DeeplyNested3.DeeplyNested4::class)
 
         // todo: get a really big type descriptor that doesn't fit in one string
 
@@ -64,39 +63,39 @@ class FileDescriptorEncodingTest {
     }
 
     private fun assertFileDescriptorsAreEqual(
-        protokt: KtDeserializer<*>,
+        protoktDescriptor: Descriptor,
         google: KClass<out GeneratedMessageV3>
     ) {
         assertThat(
-            protokt.descriptor().proto
+            protoktDescriptor.file.proto
         ).isEqualTo(
             FileDescriptorProto.deserialize(google.descriptor().toProto().toByteArray())
         )
 
         assertThat(
             DescriptorProtos.FileDescriptorProto.parseFrom(
-                protokt.descriptor().proto.serialize()
+                protoktDescriptor.file.proto.serialize()
             )
         ).isEqualTo(google.descriptor().toProto())
     }
 
     @Test
     fun `check re-encoding to protobuf-java FDP`() {
-        assertEqualComponents(com.toasttab.protokt.Any, com.google.protobuf.Any::class)
-        assertEqualComponents(Api, com.google.protobuf.Api::class)
-        assertEqualComponents(FileDescriptorProto, DescriptorProtos.FileDescriptorProto::class)
-        assertEqualComponents(Type, com.google.protobuf.Type::class)
+        assertEqualComponents(com.toasttab.protokt.Any.descriptor, com.google.protobuf.Any::class)
+        assertEqualComponents(Api.descriptor, com.google.protobuf.Api::class)
+        assertEqualComponents(FileDescriptorProto.descriptor, DescriptorProtos.FileDescriptorProto::class)
+        assertEqualComponents(Type.descriptor, com.google.protobuf.Type::class)
 
         // nested types
-        assertEqualComponents(DescriptorProto.ExtensionRange, DescriptorProtos.DescriptorProto.ExtensionRange::class)
-        assertEqualComponents(DeeplyNested4, DeeplyNested.DeeplyNested1.DeeplyNested2.DeeplyNested3.DeeplyNested4::class)
+        assertEqualComponents(DescriptorProto.ExtensionRange.descriptor, DescriptorProtos.DescriptorProto.ExtensionRange::class)
+        assertEqualComponents(DeeplyNested4.descriptor, DeeplyNested.DeeplyNested1.DeeplyNested2.DeeplyNested3.DeeplyNested4::class)
     }
 
     fun assertEqualComponents(
-        protokt: KtDeserializer<*>,
+        protokt: Descriptor,
         google: KClass<out GeneratedMessageV3>
     ) {
-        val asProtoDesc = protokt.descriptor().toProtobufJavaDescriptor()
+        val asProtoDesc = protokt.file.toProtobufJavaDescriptor()
 
         assertThat(asProtoDesc.toProto())
             .isEqualTo(google.descriptor().toProto())
@@ -126,16 +125,6 @@ class FileDescriptorEncodingTest {
             dependencies.map { it.toProtobufJavaDescriptor() }.toTypedArray(),
             true
         )
-
-    fun KtDeserializer<*>.descriptor() =
-        this::class
-            .propertyNamed("descriptor")
-            .let {
-                @Suppress("UNCHECKED_CAST")
-                it as KProperty1<Any, Descriptor>
-            }
-            .get(this)
-            .file
 
     fun KClass<out GeneratedMessageV3>.descriptor() =
         java.getMethod("getDescriptor")

--- a/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/FileDescriptorEncodingTest.kt
+++ b/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/FileDescriptorEncodingTest.kt
@@ -25,6 +25,7 @@ import com.toasttab.protokt.DescriptorProto
 import com.toasttab.protokt.FileDescriptor
 import com.toasttab.protokt.FileDescriptorProto
 import com.toasttab.protokt.Type
+import com.toasttab.protokt.descriptor
 import com.toasttab.protokt.rt.KtDeserializer
 import com.toasttab.protokt.testing.rt.other.DeeplyNested
 import com.toasttab.protokt.testing.rt.other.HasAService

--- a/third-party/proto-google-common-protos/build.gradle.kts
+++ b/third-party/proto-google-common-protos/build.gradle.kts
@@ -14,13 +14,20 @@
  */
 
 import com.google.protobuf.gradle.protobuf
+import com.toasttab.protokt.gradle.protokt
 
 localProtokt()
 pureKotlin()
 enablePublishing()
 
+protokt {
+    onlyGenerateDescriptors = true
+}
+
 dependencies {
     protobuf(libraries.protoGoogleCommonProtos) {
         exclude(group = "com.google.protobuf", module = "protobuf-java")
     }
+
+    api(project(":third-party:proto-google-common-protos-lite"))
 }


### PR DESCRIPTION
Pros:
- Generating descriptors is add-only, which means generated code composes well
- Therefore `protokt-core` and `protokt-core-lite` do not conflict - `core` depends on `lite` now

Cons:
- Access to descriptors cannot be done reflectively without bytecode access (https://stackoverflow.com/questions/57421010/enumerate-the-extension-properties-defined-in-a-package)
- Therefore Any packing has to be done via the annotation again short of some clever way to access the descriptor not involving reflection

Sample generated code:
```kotlin
/*
 * Generated by protokt version 0.6.6-SNAPSHOT. Do not modify.
 * Source: google/protobuf/struct.proto
 */

package com.toasttab.protokt

object StructProto {
    val descriptor by lazy {
        val descriptorData = arrayOf(
            "\ngoogle/protobuf/struct.protogoogle.p" +
            "rotobuf\"ﾄ\nStruct3\nfields (2#.goo" +
            "gle.protobuf.Struct.FieldsEntryE\nField" +
            "sEntry\nkey (\t%\nvalue (2.goo" +
            "gle.protobuf.Value:8\"￪\nValue0\n\nnull" +
            "_value (2.google.protobuf.NullValue" +
            "H�\nnumber_value (H�\nstring_val" +
            "ue (\tH�\n\nbool_value (\bH�/\nstru" +
            "ct_value (2.google.protobuf.StructH" +
            "�0\n\nlist_value (2.google.protobuf." +
            "ListValueH�B\nkind\"3\n\tListValue&\nvalu" +
            "es (2.google.protobuf.Value*\n\tNull" +
            "Value\n\nNULL_VALUE�B\ncom.google.prot" +
            "obufBStructProtoPZ/google.golang.org/p" +
            "rotobuf/types/known/structpb￸ﾢGPBﾪ" +
            "Google.Protobuf.WellKnownTypesbproto3"
        )

        FileDescriptor.buildFrom(
            descriptorData,
            listOf()
        )
    }
}

val NullValue.Deserializer.descriptor
    get() = StructProto.descriptor.enumTypes[0]

val Struct.Deserializer.descriptor
    get() = StructProto.descriptor.messageTypes[0]

val Value.Deserializer.descriptor
    get() = StructProto.descriptor.messageTypes[1]

val ListValue.Deserializer.descriptor
    get() = StructProto.descriptor.messageTypes[2]

```