### PR TITLE
Clean up standard field message size

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/KotlinPoetUtil.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/KotlinPoetUtil.kt
@@ -55,9 +55,6 @@ fun buildFunSpec(name: String, funSpecBuilder: FunSpec.Builder.() -> Unit): FunS
     return FunSpec.builder(name).apply(funSpecBuilder).build()
 }
 
-fun TypeName.toParamName() =
-    toString().replace(".", "_")
-
 fun namedCodeBlock(format: String, arguments: Map<String, *>) =
     CodeBlock.builder().addNamed(format, arguments).build()
 


### PR DESCRIPTION
Cleans up method construction for message size computation - functions and types were being fully qualified. There's still more cleanup to do, but this is a nice self-contained change.

We now get this:
```kotlin
private fun messageSize(): Int {
    var result = 0
    if (major != null) {
        result += sizeof(Tag(1)) + sizeof(Int32(major)) 
    }
    if (minor != null) {
        result += sizeof(Tag(2)) + sizeof(Int32(minor)) 
    }
    if (patch != null) {
        result += sizeof(Tag(3)) + sizeof(Int32(patch)) 
    }
    if (suffix != null) {
        result += sizeof(Tag(4)) + sizeof(suffix) 
    }
    result += unknownFields.size()
    return result
}
```

instead of:
```kotlin
private fun messageSize(): Int {
    var result = 0
    if (major != null) {
        result += com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Tag(1)) + com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Int32(major))
    }
    if (minor != null) {
        result += com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Tag(2)) + com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Int32(minor))
    }
    if (patch != null) {
        result += com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Tag(3)) + com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Int32(patch))
    }
    if (suffix != null) {
        result += com.toasttab.protokt.rt.sizeof(com.toasttab.protokt.rt.Tag(4)) + com.toasttab.protokt.rt.sizeof(suffix)
    }
    result += unknownFields.size()
    return result
}
```