### PR TITLE
protokt-extensions-simple should depend on protokt-core-lite

### DIFF
--- a/extensions/protokt-extensions-simple/build.gradle.kts
+++ b/extensions/protokt-extensions-simple/build.gradle.kts
@@ -21,7 +21,7 @@ enablePublishing()
 trackKotlinApiCompatibility()
 
 dependencies {
-    implementation(project(":protokt-core"))
+    implementation(project(":protokt-core-lite"))
     implementation(libraries.autoServiceAnnotations)
 
     kapt(libraries.autoService)


### PR DESCRIPTION
Right now it depends on protokt-core which means that protokt-extensions-lite has a transient dependency on protokt-core.