### PR TITLE
Bump animal-sniffer

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.8.17")
     implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0")
     implementation("com.google.guava:guava:30.1.1-jre")
-    implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.0")
+    implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.4")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.7.0")
     implementation(kotlin("gradle-plugin-api"))
 }

--- a/buildSrc/src/main/kotlin/AndroidCompatibility.kt
+++ b/buildSrc/src/main/kotlin/AndroidCompatibility.kt
@@ -15,13 +15,19 @@
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferPlugin
 
 fun Project.compatibleWithAndroid(api: Int = 19) {
     apply<AnimalSnifferPlugin>()
 
+    configure<AnimalSnifferExtension> {
+        toolVersion = "1.21"
+    }
+
     dependencies {
-        add("signature", "com.toasttab.android:gummy-bears-api-$api:0.1.0@signature")
+        add("signature", "com.toasttab.android:gummy-bears-api-$api:0.4.0@signature")
     }
 }


### PR DESCRIPTION
Addresses incorrect handling of covariant return types (i.e. the infamous ByteBuffer API issue) when validating android compatibility (see https://github.com/mojohaus/animal-sniffer/pull/83).