### PR TITLE
Check in Kotlin API signatures

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinApiCompatibility.kt
+++ b/buildSrc/src/main/kotlin/KotlinApiCompatibility.kt
@@ -13,76 +13,15 @@
  * limitations under the License.
  */
 
-import kotlinx.validation.ApiCompareCompareTask
+import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.Copy
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.register
 
 fun Project.trackKotlinApiCompatibility(validate: Boolean = true) {
     apply(plugin = "binary-compatibility-validator")
 
-    if (validate) {
-        val apiDir = buildDir.resolve("reference-api")
-
-        tasks.named<ApiCompareCompareTask>("apiCheck") {
-            projectApiDir = apiDir
-            dependsOn("downloadPreviousApiSignatures")
-        }
-
-        tasks.register<Copy>("downloadPreviousApiSignatures") {
-            selfDependencyHack { group ->
-                val ktapiScope = project.configurations.create("ktapi")
-                dependencies.add("ktapi", "$group:${project.name}:latest.release:ktapi@api")
-
-                from(ktapiScope.files)
-            }
-
-            rename {
-                "${project.name}.api"
-            }
-
-            into(apiDir)
-        }
-    } else {
-        tasks.named<ApiCompareCompareTask>("apiCheck") {
-            enabled = false
-        }
-    }
-
-    configure<PublishingExtension> {
-        publications {
-            create<MavenPublication>("api") {
-                artifact("$buildDir/api/${project.name}.api") {
-                    extension = "api"
-                    classifier = "ktapi"
-                    builtBy(tasks.named("apiDump"))
-                }
-
-                artifactId = project.name
-                version = "${project.version}"
-                groupId = "$group"
-            }
-        }
-    }
-}
-
-/**
- * Works around the Gradle bug https://github.com/gradle/gradle/issues/7706
- * to declare a dependency on a published artifact from a prior version.
- */
-private fun Project.selfDependencyHack(action: Project.(String) -> Unit) {
-    val originalGroup = group
-
-    try {
-        group = "_hack_gradle_issues_7706_"
-        action.invoke(this, "$originalGroup")
-    } finally {
-        group = originalGroup
+    configure<ApiValidationExtension> {
+        validationDisabled = !validate
     }
 }

--- a/extensions/protokt-extensions-api/api/protokt-extensions-api.api
+++ b/extensions/protokt-extensions-api/api/protokt-extensions-api.api
@@ -1,0 +1,11 @@
+public abstract interface class com/toasttab/protokt/ext/Converter {
+	public abstract fun getWrapped ()Lkotlin/reflect/KClass;
+	public abstract fun getWrapper ()Lkotlin/reflect/KClass;
+	public abstract fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/toasttab/protokt/ext/OptimizedSizeofConverter : com/toasttab/protokt/ext/Converter {
+	public abstract fun sizeof (Ljava/lang/Object;)I
+}
+

--- a/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
+++ b/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
@@ -1,0 +1,409 @@
+public final class com/toasttab/protokt/ext/InetSocketAddress : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/InetSocketAddress$Deserializer;
+	public synthetic fun <init> (Ljava/net/InetAddress;ILcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Ljava/net/InetAddress;
+	public fun getMessageSize ()I
+	public final fun getPort ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/InetSocketAddress$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+}
+
+public final class com/toasttab/protokt/ext/InetSocketAddress$InetSocketAddressDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public final fun getAddress ()Ljava/net/InetAddress;
+	public final fun getPort ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setAddress (Ljava/net/InetAddress;)V
+	public final fun setPort (I)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/InetSocketAddressConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/InetSocketAddressConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/net/InetSocketAddress;)Lcom/toasttab/protokt/ext/InetSocketAddress;
+	public fun wrap (Lcom/toasttab/protokt/ext/InetSocketAddress;)Ljava/net/InetSocketAddress;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktEnumOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktEnumOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktEnumOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktEnumOptions$ProtoktEnumOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktEnumOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktEnumValueOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktEnumValueOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktEnumValueOptions$ProtoktEnumValueOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktFieldOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktFieldOptions$Deserializer;
+	public synthetic fun <init> (ZLjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytesSlice ()Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getKeyWrap ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValueWrap ()Ljava/lang/String;
+	public final fun getWrap ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktFieldOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktFieldOptions$ProtoktFieldOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktFieldOptions;
+	public final fun getBytesSlice ()Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getKeyWrap ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValueWrap ()Ljava/lang/String;
+	public final fun getWrap ()Ljava/lang/String;
+	public final fun setBytesSlice (Z)V
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setKeyWrap (Ljava/lang/String;)V
+	public final fun setNonNull (Z)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValueWrap (Ljava/lang/String;)V
+	public final fun setWrap (Ljava/lang/String;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktFileOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktFileOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public final fun getKotlinPackage ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktFileOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktFileOptions$ProtoktFileOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktFileOptions;
+	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public final fun getKotlinPackage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setFileDescriptorObjectName (Ljava/lang/String;)V
+	public final fun setKotlinPackage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktMessageOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktMessageOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktMessageOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktMessageOptions$ProtoktMessageOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktMessageOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setImplements (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktMethodOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktMethodOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getRequestMarshaller ()Ljava/lang/String;
+	public final fun getResponseMarshaller ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktMethodOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktMethodOptions$ProtoktMethodOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktMethodOptions;
+	public final fun getRequestMarshaller ()Ljava/lang/String;
+	public final fun getResponseMarshaller ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setRequestMarshaller (Ljava/lang/String;)V
+	public final fun setResponseMarshaller (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktOneofOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktOneofOptions$Deserializer;
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktOneofOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktOneofOptions$ProtoktOneofOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktOneofOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setImplements (Ljava/lang/String;)V
+	public final fun setNonNull (Z)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktServiceOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ext/ProtoktServiceOptions$Deserializer;
+	public synthetic fun <init> (Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktServiceOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktServiceOptions$ProtoktServiceOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ext/ProtoktServiceOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+

--- a/extensions/protokt-extensions-simple/api/protokt-extensions-simple.api
+++ b/extensions/protokt-extensions-simple/api/protokt-extensions-simple.api
@@ -1,0 +1,84 @@
+public final class com/toasttab/protokt/ext/DurationConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/DurationConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/time/Duration;)Lcom/toasttab/protokt/Duration;
+	public fun wrap (Lcom/toasttab/protokt/Duration;)Ljava/time/Duration;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ext/InetAddressBytesValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/InetAddressBytesValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/net/InetAddress;)Lcom/toasttab/protokt/BytesValue;
+	public fun wrap (Lcom/toasttab/protokt/BytesValue;)Ljava/net/InetAddress;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ext/InetAddressConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/InetAddressConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/net/InetAddress;)[B
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap ([B)Ljava/net/InetAddress;
+}
+
+public final class com/toasttab/protokt/ext/InstantConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/InstantConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/time/Instant;)Lcom/toasttab/protokt/Timestamp;
+	public fun wrap (Lcom/toasttab/protokt/Timestamp;)Ljava/time/Instant;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ext/LocalDateConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/LocalDateConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/time/LocalDate;)Ljava/lang/String;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Ljava/lang/String;)Ljava/time/LocalDate;
+}
+
+public final class com/toasttab/protokt/ext/LocalDateStringValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/LocalDateStringValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/time/LocalDate;)Lcom/toasttab/protokt/StringValue;
+	public fun wrap (Lcom/toasttab/protokt/StringValue;)Ljava/time/LocalDate;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ext/UuidBytesValueConverter : com/toasttab/protokt/ext/OptimizedSizeofConverter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/UuidBytesValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun sizeof (Ljava/lang/Object;)I
+	public fun sizeof (Ljava/util/UUID;)I
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/util/UUID;)Lcom/toasttab/protokt/BytesValue;
+	public fun wrap (Lcom/toasttab/protokt/BytesValue;)Ljava/util/UUID;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ext/UuidConverter : com/toasttab/protokt/ext/OptimizedSizeofConverter {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/UuidConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun sizeof (Ljava/lang/Object;)I
+	public fun sizeof (Ljava/util/UUID;)I
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/util/UUID;)[B
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap ([B)Ljava/util/UUID;
+}
+

--- a/extensions/protokt-extensions/api/protokt-extensions.api
+++ b/extensions/protokt-extensions/api/protokt-extensions.api
@@ -1,0 +1,25 @@
+public final class com/toasttab/protokt/ext/InetSocketAddress_ {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/InetSocketAddress_;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/ext/Inet_socket_addressKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/InetSocketAddress$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/ext/Protokt {
+	public static final field INSTANCE Lcom/toasttab/protokt/ext/Protokt;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktEnumOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktEnumValueOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktFieldOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktFileOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktMessageOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktMethodOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktOneofOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ext/ProtoktServiceOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+

--- a/protokt-core-lite/api/protokt-core-lite.api
+++ b/protokt-core-lite/api/protokt-core-lite.api
@@ -1,0 +1,3351 @@
+public final class com/toasttab/protokt/Any : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Any$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/rt/Bytes;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Any;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getTypeUrl ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Any$AnyDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Any;
+	public final fun getTypeUrl ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public final fun setTypeUrl (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (Lcom/toasttab/protokt/rt/Bytes;)V
+}
+
+public final class com/toasttab/protokt/Any$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Any;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Any;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Any;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Any;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Any;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Any;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Any;
+}
+
+public final class com/toasttab/protokt/Api : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Api$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/toasttab/protokt/SourceContext;Ljava/util/List;Lcom/toasttab/protokt/Syntax;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Api;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getMethods ()Ljava/util/List;
+	public final fun getMixins ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getSourceContext ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Api$ApiDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Api;
+	public final fun getMethods ()Ljava/util/List;
+	public final fun getMixins ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getSourceContext ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getVersion ()Ljava/lang/String;
+	public final fun setMethods (Ljava/util/List;)V
+	public final fun setMixins (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Ljava/util/List;)V
+	public final fun setSourceContext (Lcom/toasttab/protokt/SourceContext;)V
+	public final fun setSyntax (Lcom/toasttab/protokt/Syntax;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setVersion (Ljava/lang/String;)V
+}
+
+public final class com/toasttab/protokt/Api$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Api;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Api;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Api;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Api;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Api;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Api;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Api;
+}
+
+public final class com/toasttab/protokt/BoolValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/BoolValue$Deserializer;
+	public synthetic fun <init> (ZLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/BoolValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/BoolValue$BoolValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/BoolValue;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Z
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (Z)V
+}
+
+public final class com/toasttab/protokt/BoolValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/BoolValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/BoolValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/BoolValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/BoolValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/BoolValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/BoolValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/BoolValue;
+}
+
+public final class com/toasttab/protokt/BoolValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/BoolValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Z)Lcom/toasttab/protokt/BoolValue;
+	public fun wrap (Lcom/toasttab/protokt/BoolValue;)Ljava/lang/Boolean;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/BytesValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/BytesValue$Deserializer;
+	public synthetic fun <init> (Lcom/toasttab/protokt/rt/Bytes;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/BytesValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/BytesValue$BytesValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/BytesValue;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (Lcom/toasttab/protokt/rt/Bytes;)V
+}
+
+public final class com/toasttab/protokt/BytesValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/BytesValue;
+}
+
+public final class com/toasttab/protokt/BytesValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/BytesValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/BytesValue;)Lcom/toasttab/protokt/rt/Bytes;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/DescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/DescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/toasttab/protokt/MessageOptions;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnumType ()Ljava/util/List;
+	public final fun getExtension ()Ljava/util/List;
+	public final fun getExtensionRange ()Ljava/util/List;
+	public final fun getField ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNestedType ()Ljava/util/List;
+	public final fun getOneofDecl ()Ljava/util/List;
+	public final fun getOptions ()Lcom/toasttab/protokt/MessageOptions;
+	public final fun getReservedName ()Ljava/util/List;
+	public final fun getReservedRange ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/DescriptorProto$DescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/DescriptorProto;
+	public final fun getEnumType ()Ljava/util/List;
+	public final fun getExtension ()Ljava/util/List;
+	public final fun getExtensionRange ()Ljava/util/List;
+	public final fun getField ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNestedType ()Ljava/util/List;
+	public final fun getOneofDecl ()Ljava/util/List;
+	public final fun getOptions ()Lcom/toasttab/protokt/MessageOptions;
+	public final fun getReservedName ()Ljava/util/List;
+	public final fun getReservedRange ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setEnumType (Ljava/util/List;)V
+	public final fun setExtension (Ljava/util/List;)V
+	public final fun setExtensionRange (Ljava/util/List;)V
+	public final fun setField (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setNestedType (Ljava/util/List;)V
+	public final fun setOneofDecl (Ljava/util/List;)V
+	public final fun setOptions (Lcom/toasttab/protokt/MessageOptions;)V
+	public final fun setReservedName (Ljava/util/List;)V
+	public final fun setReservedRange (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/DescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/DescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/DescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/DescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/DescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/DescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/DescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DescriptorProto;
+}
+
+public final class com/toasttab/protokt/DescriptorProto$ExtensionRange : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/DescriptorProto$ExtensionRange$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/toasttab/protokt/ExtensionRangeOptions;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnd ()Ljava/lang/Integer;
+	public fun getMessageSize ()I
+	public final fun getOptions ()Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/DescriptorProto$ExtensionRange$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+}
+
+public final class com/toasttab/protokt/DescriptorProto$ExtensionRange$ExtensionRangeDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/DescriptorProto$ExtensionRange;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getOptions ()Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setEnd (Ljava/lang/Integer;)V
+	public final fun setOptions (Lcom/toasttab/protokt/ExtensionRangeOptions;)V
+	public final fun setStart (Ljava/lang/Integer;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/DescriptorProto$ReservedRange : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/DescriptorProto$ReservedRange$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnd ()Ljava/lang/Integer;
+	public fun getMessageSize ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/DescriptorProto$ReservedRange$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+}
+
+public final class com/toasttab/protokt/DescriptorProto$ReservedRange$ReservedRangeDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/DescriptorProto$ReservedRange;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setEnd (Ljava/lang/Integer;)V
+	public final fun setStart (Ljava/lang/Integer;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/DoubleValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/DoubleValue$Deserializer;
+	public synthetic fun <init> (DLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DoubleValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/DoubleValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/DoubleValue;
+}
+
+public final class com/toasttab/protokt/DoubleValue$DoubleValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/DoubleValue;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()D
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (D)V
+}
+
+public final class com/toasttab/protokt/DoubleValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/DoubleValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (D)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/DoubleValue;)Ljava/lang/Double;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/Duration : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Duration$Deserializer;
+	public synthetic fun <init> (JILcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Duration;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getNanos ()I
+	public final fun getSeconds ()J
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Duration$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Duration;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Duration;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Duration;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Duration;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Duration;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Duration;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Duration;
+}
+
+public final class com/toasttab/protokt/Duration$DurationDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Duration;
+	public final fun getNanos ()I
+	public final fun getSeconds ()J
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setNanos (I)V
+	public final fun setSeconds (J)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Empty : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Empty$Deserializer;
+	public synthetic fun <init> (Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Empty;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Empty$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Empty;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Empty;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Empty;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Empty;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Empty;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Empty;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Empty;
+}
+
+public final class com/toasttab/protokt/Empty$EmptyDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Empty;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/EnumDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/EnumDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/toasttab/protokt/EnumOptions;Ljava/util/List;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/EnumOptions;
+	public final fun getReservedName ()Ljava/util/List;
+	public final fun getReservedRange ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/EnumDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/EnumDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumDescriptorProto;
+}
+
+public final class com/toasttab/protokt/EnumDescriptorProto$EnumDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/EnumDescriptorProto;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/EnumOptions;
+	public final fun getReservedName ()Ljava/util/List;
+	public final fun getReservedRange ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Ljava/util/List;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Lcom/toasttab/protokt/EnumOptions;)V
+	public final fun setReservedName (Ljava/util/List;)V
+	public final fun setReservedRange (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (Ljava/util/List;)V
+}
+
+public final class com/toasttab/protokt/EnumDescriptorProto$EnumReservedRange : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnd ()Ljava/lang/Integer;
+	public fun getMessageSize ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/EnumDescriptorProto$EnumReservedRange$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+}
+
+public final class com/toasttab/protokt/EnumDescriptorProto$EnumReservedRange$EnumReservedRangeDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setEnd (Ljava/lang/Integer;)V
+	public final fun setStart (Ljava/lang/Integer;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/EnumOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/EnumOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAlias ()Ljava/lang/Boolean;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getMessageSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/EnumOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/EnumOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/EnumOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/EnumOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/EnumOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/EnumOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/EnumOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumOptions;
+}
+
+public final class com/toasttab/protokt/EnumOptions$EnumOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/EnumOptions;
+	public final fun getAllowAlias ()Ljava/lang/Boolean;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setAllowAlias (Ljava/lang/Boolean;)V
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/EnumValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/EnumValue$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;ILjava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()I
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/EnumValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/EnumValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/EnumValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/EnumValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/EnumValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/EnumValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/EnumValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumValue;
+}
+
+public final class com/toasttab/protokt/EnumValue$EnumValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/EnumValue;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()I
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setNumber (I)V
+	public final fun setOptions (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/EnumValueDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/EnumValueDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lcom/toasttab/protokt/EnumValueOptions;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOptions ()Lcom/toasttab/protokt/EnumValueOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/EnumValueDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumValueDescriptorProto;
+}
+
+public final class com/toasttab/protokt/EnumValueDescriptorProto$EnumValueDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/EnumValueDescriptorProto;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOptions ()Lcom/toasttab/protokt/EnumValueOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setNumber (Ljava/lang/Integer;)V
+	public final fun setOptions (Lcom/toasttab/protokt/EnumValueOptions;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/EnumValueOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/EnumValueOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumValueOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getMessageSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/EnumValueOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/EnumValueOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/EnumValueOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/EnumValueOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/EnumValueOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/EnumValueOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/EnumValueOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/EnumValueOptions;
+}
+
+public final class com/toasttab/protokt/EnumValueOptions$EnumValueOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/EnumValueOptions;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Enum_ : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Enum_$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/toasttab/protokt/SourceContext;Lcom/toasttab/protokt/Syntax;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Enum_;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnumvalue ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getSourceContext ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Enum_$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Enum_;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Enum_;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Enum_;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Enum_;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Enum_;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Enum_;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Enum_;
+}
+
+public final class com/toasttab/protokt/Enum_$Enum_Dsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Enum_;
+	public final fun getEnumvalue ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getSourceContext ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setEnumvalue (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Ljava/util/List;)V
+	public final fun setSourceContext (Lcom/toasttab/protokt/SourceContext;)V
+	public final fun setSyntax (Lcom/toasttab/protokt/Syntax;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ExtensionRangeOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ExtensionRangeOptions$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ExtensionRangeOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ExtensionRangeOptions;
+}
+
+public final class com/toasttab/protokt/ExtensionRangeOptions$ExtensionRangeOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ExtensionRangeOptions;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Field : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Field$Deserializer;
+	public synthetic fun <init> (Lcom/toasttab/protokt/Field$Kind;Lcom/toasttab/protokt/Field$Cardinality;ILjava/lang/String;Ljava/lang/String;IZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Field;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCardinality ()Lcom/toasttab/protokt/Field$Cardinality;
+	public final fun getDefaultValue ()Ljava/lang/String;
+	public final fun getJsonName ()Ljava/lang/String;
+	public final fun getKind ()Lcom/toasttab/protokt/Field$Kind;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()I
+	public final fun getOneofIndex ()I
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getPacked ()Z
+	public final fun getTypeUrl ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/toasttab/protokt/Field$Cardinality : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/Field$Cardinality$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/Field$Cardinality$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/Field$Cardinality;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/Field$Cardinality$OPTIONAL : com/toasttab/protokt/Field$Cardinality {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Cardinality$OPTIONAL;
+}
+
+public final class com/toasttab/protokt/Field$Cardinality$REPEATED : com/toasttab/protokt/Field$Cardinality {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Cardinality$REPEATED;
+}
+
+public final class com/toasttab/protokt/Field$Cardinality$REQUIRED : com/toasttab/protokt/Field$Cardinality {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Cardinality$REQUIRED;
+}
+
+public final class com/toasttab/protokt/Field$Cardinality$UNKNOWN : com/toasttab/protokt/Field$Cardinality {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Cardinality$UNKNOWN;
+}
+
+public final class com/toasttab/protokt/Field$Cardinality$UNRECOGNIZED : com/toasttab/protokt/Field$Cardinality {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/Field$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Field;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Field;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Field;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Field;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Field;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Field;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Field;
+}
+
+public final class com/toasttab/protokt/Field$FieldDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Field;
+	public final fun getCardinality ()Lcom/toasttab/protokt/Field$Cardinality;
+	public final fun getDefaultValue ()Ljava/lang/String;
+	public final fun getJsonName ()Ljava/lang/String;
+	public final fun getKind ()Lcom/toasttab/protokt/Field$Kind;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()I
+	public final fun getOneofIndex ()I
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getPacked ()Z
+	public final fun getTypeUrl ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setCardinality (Lcom/toasttab/protokt/Field$Cardinality;)V
+	public final fun setDefaultValue (Ljava/lang/String;)V
+	public final fun setJsonName (Ljava/lang/String;)V
+	public final fun setKind (Lcom/toasttab/protokt/Field$Kind;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setNumber (I)V
+	public final fun setOneofIndex (I)V
+	public final fun setOptions (Ljava/util/List;)V
+	public final fun setPacked (Z)V
+	public final fun setTypeUrl (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public abstract class com/toasttab/protokt/Field$Kind : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/Field$Kind$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/Field$Kind$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/Field$Kind;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_BOOL : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_BOOL;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_BYTES : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_BYTES;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_DOUBLE : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_DOUBLE;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_ENUM : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_ENUM;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_FIXED32 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_FIXED32;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_FIXED64 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_FIXED64;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_FLOAT : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_FLOAT;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_GROUP : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_GROUP;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_INT32 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_INT32;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_INT64 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_INT64;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_MESSAGE : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_MESSAGE;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_SFIXED32 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_SFIXED32;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_SFIXED64 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_SFIXED64;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_SINT32 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_SINT32;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_SINT64 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_SINT64;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_STRING : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_STRING;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_UINT32 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_UINT32;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_UINT64 : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_UINT64;
+}
+
+public final class com/toasttab/protokt/Field$Kind$TYPE_UNKNOWN : com/toasttab/protokt/Field$Kind {
+	public static final field INSTANCE Lcom/toasttab/protokt/Field$Kind$TYPE_UNKNOWN;
+}
+
+public final class com/toasttab/protokt/Field$Kind$UNRECOGNIZED : com/toasttab/protokt/Field$Kind {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/toasttab/protokt/FieldDescriptorProto$Label;Lcom/toasttab/protokt/FieldDescriptorProto$Type;Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/FieldOptions;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Ljava/lang/String;
+	public final fun getExtendee ()Ljava/lang/String;
+	public final fun getJsonName ()Ljava/lang/String;
+	public final fun getLabel ()Lcom/toasttab/protokt/FieldDescriptorProto$Label;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOneofIndex ()Ljava/lang/Integer;
+	public final fun getOptions ()Lcom/toasttab/protokt/FieldOptions;
+	public final fun getProto3Optional ()Ljava/lang/Boolean;
+	public final fun getType ()Lcom/toasttab/protokt/FieldDescriptorProto$Type;
+	public final fun getTypeName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FieldDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FieldDescriptorProto;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$FieldDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FieldDescriptorProto;
+	public final fun getDefaultValue ()Ljava/lang/String;
+	public final fun getExtendee ()Ljava/lang/String;
+	public final fun getJsonName ()Ljava/lang/String;
+	public final fun getLabel ()Lcom/toasttab/protokt/FieldDescriptorProto$Label;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOneofIndex ()Ljava/lang/Integer;
+	public final fun getOptions ()Lcom/toasttab/protokt/FieldOptions;
+	public final fun getProto3Optional ()Ljava/lang/Boolean;
+	public final fun getType ()Lcom/toasttab/protokt/FieldDescriptorProto$Type;
+	public final fun getTypeName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDefaultValue (Ljava/lang/String;)V
+	public final fun setExtendee (Ljava/lang/String;)V
+	public final fun setJsonName (Ljava/lang/String;)V
+	public final fun setLabel (Lcom/toasttab/protokt/FieldDescriptorProto$Label;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setNumber (Ljava/lang/Integer;)V
+	public final fun setOneofIndex (Ljava/lang/Integer;)V
+	public final fun setOptions (Lcom/toasttab/protokt/FieldOptions;)V
+	public final fun setProto3Optional (Ljava/lang/Boolean;)V
+	public final fun setType (Lcom/toasttab/protokt/FieldDescriptorProto$Type;)V
+	public final fun setTypeName (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public abstract class com/toasttab/protokt/FieldDescriptorProto$Label : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldDescriptorProto$Label$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Label$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/FieldDescriptorProto$Label;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Label$OPTIONAL : com/toasttab/protokt/FieldDescriptorProto$Label {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Label$OPTIONAL;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Label$REPEATED : com/toasttab/protokt/FieldDescriptorProto$Label {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Label$REPEATED;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Label$REQUIRED : com/toasttab/protokt/FieldDescriptorProto$Label {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Label$REQUIRED;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Label$UNRECOGNIZED : com/toasttab/protokt/FieldDescriptorProto$Label {
+	public fun <init> (I)V
+}
+
+public abstract class com/toasttab/protokt/FieldDescriptorProto$Type : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldDescriptorProto$Type$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$BOOL : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$BOOL;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$BYTES : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$BYTES;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$DOUBLE : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$DOUBLE;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/FieldDescriptorProto$Type;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$ENUM : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$ENUM;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$FIXED32 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$FIXED32;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$FIXED64 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$FIXED64;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$FLOAT : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$FLOAT;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$GROUP : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$GROUP;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$INT32 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$INT32;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$INT64 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$INT64;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$MESSAGE : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$MESSAGE;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$SFIXED32 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$SFIXED32;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$SFIXED64 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$SFIXED64;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$SINT32 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$SINT32;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$SINT64 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$SINT64;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$STRING : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$STRING;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$UINT32 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$UINT32;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$UINT64 : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldDescriptorProto$Type$UINT64;
+}
+
+public final class com/toasttab/protokt/FieldDescriptorProto$Type$UNRECOGNIZED : com/toasttab/protokt/FieldDescriptorProto$Type {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/FieldMask : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldMask$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FieldMask;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getPaths ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/FieldMask$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FieldMask;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FieldMask;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FieldMask;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FieldMask;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FieldMask;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FieldMask;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FieldMask;
+}
+
+public final class com/toasttab/protokt/FieldMask$FieldMaskDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FieldMask;
+	public final fun getPaths ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setPaths (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/FieldOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldOptions$Deserializer;
+	public synthetic fun <init> (Lcom/toasttab/protokt/FieldOptions$CType;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/toasttab/protokt/FieldOptions$JSType;Ljava/lang/Boolean;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FieldOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCtype ()Lcom/toasttab/protokt/FieldOptions$CType;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getJstype ()Lcom/toasttab/protokt/FieldOptions$JSType;
+	public final fun getLazy ()Ljava/lang/Boolean;
+	public fun getMessageSize ()I
+	public final fun getPacked ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getWeak ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/toasttab/protokt/FieldOptions$CType : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldOptions$CType$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/FieldOptions$CType$CORD : com/toasttab/protokt/FieldOptions$CType {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldOptions$CType$CORD;
+}
+
+public final class com/toasttab/protokt/FieldOptions$CType$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/FieldOptions$CType;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/FieldOptions$CType$STRING : com/toasttab/protokt/FieldOptions$CType {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldOptions$CType$STRING;
+}
+
+public final class com/toasttab/protokt/FieldOptions$CType$STRING_PIECE : com/toasttab/protokt/FieldOptions$CType {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldOptions$CType$STRING_PIECE;
+}
+
+public final class com/toasttab/protokt/FieldOptions$CType$UNRECOGNIZED : com/toasttab/protokt/FieldOptions$CType {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/FieldOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FieldOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FieldOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FieldOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FieldOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FieldOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FieldOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FieldOptions;
+}
+
+public final class com/toasttab/protokt/FieldOptions$FieldOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FieldOptions;
+	public final fun getCtype ()Lcom/toasttab/protokt/FieldOptions$CType;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getJstype ()Lcom/toasttab/protokt/FieldOptions$JSType;
+	public final fun getLazy ()Ljava/lang/Boolean;
+	public final fun getPacked ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getWeak ()Ljava/lang/Boolean;
+	public final fun setCtype (Lcom/toasttab/protokt/FieldOptions$CType;)V
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setJstype (Lcom/toasttab/protokt/FieldOptions$JSType;)V
+	public final fun setLazy (Ljava/lang/Boolean;)V
+	public final fun setPacked (Ljava/lang/Boolean;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setWeak (Ljava/lang/Boolean;)V
+}
+
+public abstract class com/toasttab/protokt/FieldOptions$JSType : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/FieldOptions$JSType$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/FieldOptions$JSType$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/FieldOptions$JSType;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/FieldOptions$JSType$JS_NORMAL : com/toasttab/protokt/FieldOptions$JSType {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldOptions$JSType$JS_NORMAL;
+}
+
+public final class com/toasttab/protokt/FieldOptions$JSType$JS_NUMBER : com/toasttab/protokt/FieldOptions$JSType {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldOptions$JSType$JS_NUMBER;
+}
+
+public final class com/toasttab/protokt/FieldOptions$JSType$JS_STRING : com/toasttab/protokt/FieldOptions$JSType {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldOptions$JSType$JS_STRING;
+}
+
+public final class com/toasttab/protokt/FieldOptions$JSType$UNRECOGNIZED : com/toasttab/protokt/FieldOptions$JSType {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/FileDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FileDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/toasttab/protokt/FileOptions;Lcom/toasttab/protokt/SourceCodeInfo;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FileDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDependency ()Ljava/util/List;
+	public final fun getEnumType ()Ljava/util/List;
+	public final fun getExtension ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getMessageType ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/FileOptions;
+	public final fun getPackage ()Ljava/lang/String;
+	public final fun getPublicDependency ()Ljava/util/List;
+	public final fun getService ()Ljava/util/List;
+	public final fun getSourceCodeInfo ()Lcom/toasttab/protokt/SourceCodeInfo;
+	public final fun getSyntax ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getWeakDependency ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/FileDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FileDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FileDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FileDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FileDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FileDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FileDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FileDescriptorProto;
+}
+
+public final class com/toasttab/protokt/FileDescriptorProto$FileDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FileDescriptorProto;
+	public final fun getDependency ()Ljava/util/List;
+	public final fun getEnumType ()Ljava/util/List;
+	public final fun getExtension ()Ljava/util/List;
+	public final fun getMessageType ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/FileOptions;
+	public final fun getPackage ()Ljava/lang/String;
+	public final fun getPublicDependency ()Ljava/util/List;
+	public final fun getService ()Ljava/util/List;
+	public final fun getSourceCodeInfo ()Lcom/toasttab/protokt/SourceCodeInfo;
+	public final fun getSyntax ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getWeakDependency ()Ljava/util/List;
+	public final fun setDependency (Ljava/util/List;)V
+	public final fun setEnumType (Ljava/util/List;)V
+	public final fun setExtension (Ljava/util/List;)V
+	public final fun setMessageType (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Lcom/toasttab/protokt/FileOptions;)V
+	public final fun setPackage (Ljava/lang/String;)V
+	public final fun setPublicDependency (Ljava/util/List;)V
+	public final fun setService (Ljava/util/List;)V
+	public final fun setSourceCodeInfo (Lcom/toasttab/protokt/SourceCodeInfo;)V
+	public final fun setSyntax (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setWeakDependency (Ljava/util/List;)V
+}
+
+public final class com/toasttab/protokt/FileDescriptorSet : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FileDescriptorSet$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FileDescriptorSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/FileDescriptorSet$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FileDescriptorSet;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FileDescriptorSet;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FileDescriptorSet;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FileDescriptorSet;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FileDescriptorSet;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FileDescriptorSet;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FileDescriptorSet;
+}
+
+public final class com/toasttab/protokt/FileDescriptorSet$FileDescriptorSetDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FileDescriptorSet;
+	public final fun getFile ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setFile (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/FileOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FileOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/FileOptions$OptimizeMode;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FileOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCcEnableArenas ()Ljava/lang/Boolean;
+	public final fun getCcGenericServices ()Ljava/lang/Boolean;
+	public final fun getCsharpNamespace ()Ljava/lang/String;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getGoPackage ()Ljava/lang/String;
+	public final fun getJavaGenerateEqualsAndHash ()Ljava/lang/Boolean;
+	public final fun getJavaGenericServices ()Ljava/lang/Boolean;
+	public final fun getJavaMultipleFiles ()Ljava/lang/Boolean;
+	public final fun getJavaOuterClassname ()Ljava/lang/String;
+	public final fun getJavaPackage ()Ljava/lang/String;
+	public final fun getJavaStringCheckUtf8 ()Ljava/lang/Boolean;
+	public fun getMessageSize ()I
+	public final fun getObjcClassPrefix ()Ljava/lang/String;
+	public final fun getOptimizeFor ()Lcom/toasttab/protokt/FileOptions$OptimizeMode;
+	public final fun getPhpClassPrefix ()Ljava/lang/String;
+	public final fun getPhpGenericServices ()Ljava/lang/Boolean;
+	public final fun getPhpMetadataNamespace ()Ljava/lang/String;
+	public final fun getPhpNamespace ()Ljava/lang/String;
+	public final fun getPyGenericServices ()Ljava/lang/Boolean;
+	public final fun getRubyPackage ()Ljava/lang/String;
+	public final fun getSwiftPrefix ()Ljava/lang/String;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/FileOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FileOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FileOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FileOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FileOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FileOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FileOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FileOptions;
+}
+
+public final class com/toasttab/protokt/FileOptions$FileOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FileOptions;
+	public final fun getCcEnableArenas ()Ljava/lang/Boolean;
+	public final fun getCcGenericServices ()Ljava/lang/Boolean;
+	public final fun getCsharpNamespace ()Ljava/lang/String;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getGoPackage ()Ljava/lang/String;
+	public final fun getJavaGenerateEqualsAndHash ()Ljava/lang/Boolean;
+	public final fun getJavaGenericServices ()Ljava/lang/Boolean;
+	public final fun getJavaMultipleFiles ()Ljava/lang/Boolean;
+	public final fun getJavaOuterClassname ()Ljava/lang/String;
+	public final fun getJavaPackage ()Ljava/lang/String;
+	public final fun getJavaStringCheckUtf8 ()Ljava/lang/Boolean;
+	public final fun getObjcClassPrefix ()Ljava/lang/String;
+	public final fun getOptimizeFor ()Lcom/toasttab/protokt/FileOptions$OptimizeMode;
+	public final fun getPhpClassPrefix ()Ljava/lang/String;
+	public final fun getPhpGenericServices ()Ljava/lang/Boolean;
+	public final fun getPhpMetadataNamespace ()Ljava/lang/String;
+	public final fun getPhpNamespace ()Ljava/lang/String;
+	public final fun getPyGenericServices ()Ljava/lang/Boolean;
+	public final fun getRubyPackage ()Ljava/lang/String;
+	public final fun getSwiftPrefix ()Ljava/lang/String;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setCcEnableArenas (Ljava/lang/Boolean;)V
+	public final fun setCcGenericServices (Ljava/lang/Boolean;)V
+	public final fun setCsharpNamespace (Ljava/lang/String;)V
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setGoPackage (Ljava/lang/String;)V
+	public final fun setJavaGenerateEqualsAndHash (Ljava/lang/Boolean;)V
+	public final fun setJavaGenericServices (Ljava/lang/Boolean;)V
+	public final fun setJavaMultipleFiles (Ljava/lang/Boolean;)V
+	public final fun setJavaOuterClassname (Ljava/lang/String;)V
+	public final fun setJavaPackage (Ljava/lang/String;)V
+	public final fun setJavaStringCheckUtf8 (Ljava/lang/Boolean;)V
+	public final fun setObjcClassPrefix (Ljava/lang/String;)V
+	public final fun setOptimizeFor (Lcom/toasttab/protokt/FileOptions$OptimizeMode;)V
+	public final fun setPhpClassPrefix (Ljava/lang/String;)V
+	public final fun setPhpGenericServices (Ljava/lang/Boolean;)V
+	public final fun setPhpMetadataNamespace (Ljava/lang/String;)V
+	public final fun setPhpNamespace (Ljava/lang/String;)V
+	public final fun setPyGenericServices (Ljava/lang/Boolean;)V
+	public final fun setRubyPackage (Ljava/lang/String;)V
+	public final fun setSwiftPrefix (Ljava/lang/String;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public abstract class com/toasttab/protokt/FileOptions$OptimizeMode : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/FileOptions$OptimizeMode$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/FileOptions$OptimizeMode$CODE_SIZE : com/toasttab/protokt/FileOptions$OptimizeMode {
+	public static final field INSTANCE Lcom/toasttab/protokt/FileOptions$OptimizeMode$CODE_SIZE;
+}
+
+public final class com/toasttab/protokt/FileOptions$OptimizeMode$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/FileOptions$OptimizeMode;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/FileOptions$OptimizeMode$LITE_RUNTIME : com/toasttab/protokt/FileOptions$OptimizeMode {
+	public static final field INSTANCE Lcom/toasttab/protokt/FileOptions$OptimizeMode$LITE_RUNTIME;
+}
+
+public final class com/toasttab/protokt/FileOptions$OptimizeMode$SPEED : com/toasttab/protokt/FileOptions$OptimizeMode {
+	public static final field INSTANCE Lcom/toasttab/protokt/FileOptions$OptimizeMode$SPEED;
+}
+
+public final class com/toasttab/protokt/FileOptions$OptimizeMode$UNRECOGNIZED : com/toasttab/protokt/FileOptions$OptimizeMode {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/FloatValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/FloatValue$Deserializer;
+	public synthetic fun <init> (FLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FloatValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/FloatValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/FloatValue;
+}
+
+public final class com/toasttab/protokt/FloatValue$FloatValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/FloatValue;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()F
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (F)V
+}
+
+public final class com/toasttab/protokt/FloatValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/FloatValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (F)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/FloatValue;)Ljava/lang/Float;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/GeneratedCodeInfo : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/GeneratedCodeInfo$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotation ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/GeneratedCodeInfo$Annotation : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBegin ()Ljava/lang/Integer;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public fun getMessageSize ()I
+	public final fun getPath ()Ljava/util/List;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/GeneratedCodeInfo$Annotation$AnnotationDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public final fun getBegin ()Ljava/lang/Integer;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/util/List;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setBegin (Ljava/lang/Integer;)V
+	public final fun setEnd (Ljava/lang/Integer;)V
+	public final fun setPath (Ljava/util/List;)V
+	public final fun setSourceFile (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/GeneratedCodeInfo$Annotation$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation;
+}
+
+public final class com/toasttab/protokt/GeneratedCodeInfo$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/GeneratedCodeInfo;
+}
+
+public final class com/toasttab/protokt/GeneratedCodeInfo$GeneratedCodeInfoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public final fun getAnnotation ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setAnnotation (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Int32Value : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Int32Value$Deserializer;
+	public synthetic fun <init> (ILcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Int32Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Int32Value$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Int32Value;
+}
+
+public final class com/toasttab/protokt/Int32Value$Int32ValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Int32Value;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()I
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (I)V
+}
+
+public final class com/toasttab/protokt/Int32ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/Int32ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (I)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/Int32Value;)Ljava/lang/Integer;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/Int64Value : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Int64Value$Deserializer;
+	public synthetic fun <init> (JLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Int64Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Int64Value$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Int64Value;
+}
+
+public final class com/toasttab/protokt/Int64Value$Int64ValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Int64Value;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()J
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (J)V
+}
+
+public final class com/toasttab/protokt/Int64ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/Int64ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (J)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/Int64Value;)Ljava/lang/Long;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/ListValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ListValue$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ListValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ListValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ListValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ListValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ListValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ListValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ListValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ListValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ListValue;
+}
+
+public final class com/toasttab/protokt/ListValue$ListValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ListValue;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValues ()Ljava/util/List;
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValues (Ljava/util/List;)V
+}
+
+public final class com/toasttab/protokt/MessageOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/MessageOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/MessageOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getMapEntry ()Ljava/lang/Boolean;
+	public final fun getMessageSetWireFormat ()Ljava/lang/Boolean;
+	public fun getMessageSize ()I
+	public final fun getNoStandardDescriptorAccessor ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/MessageOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/MessageOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/MessageOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/MessageOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/MessageOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/MessageOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/MessageOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/MessageOptions;
+}
+
+public final class com/toasttab/protokt/MessageOptions$MessageOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/MessageOptions;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getMapEntry ()Ljava/lang/Boolean;
+	public final fun getMessageSetWireFormat ()Ljava/lang/Boolean;
+	public final fun getNoStandardDescriptorAccessor ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setMapEntry (Ljava/lang/Boolean;)V
+	public final fun setMessageSetWireFormat (Ljava/lang/Boolean;)V
+	public final fun setNoStandardDescriptorAccessor (Ljava/lang/Boolean;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Method : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Method$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lcom/toasttab/protokt/Syntax;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Method;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getRequestStreaming ()Z
+	public final fun getRequestTypeUrl ()Ljava/lang/String;
+	public final fun getResponseStreaming ()Z
+	public final fun getResponseTypeUrl ()Ljava/lang/String;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Method$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Method;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Method;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Method;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Method;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Method;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Method;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Method;
+}
+
+public final class com/toasttab/protokt/Method$MethodDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Method;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getRequestStreaming ()Z
+	public final fun getRequestTypeUrl ()Ljava/lang/String;
+	public final fun getResponseStreaming ()Z
+	public final fun getResponseTypeUrl ()Ljava/lang/String;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Ljava/util/List;)V
+	public final fun setRequestStreaming (Z)V
+	public final fun setRequestTypeUrl (Ljava/lang/String;)V
+	public final fun setResponseStreaming (Z)V
+	public final fun setResponseTypeUrl (Ljava/lang/String;)V
+	public final fun setSyntax (Lcom/toasttab/protokt/Syntax;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/MethodDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/MethodDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/MethodOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientStreaming ()Ljava/lang/Boolean;
+	public final fun getInputType ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/MethodOptions;
+	public final fun getOutputType ()Ljava/lang/String;
+	public final fun getServerStreaming ()Ljava/lang/Boolean;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/MethodDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/MethodDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/MethodDescriptorProto;
+}
+
+public final class com/toasttab/protokt/MethodDescriptorProto$MethodDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/MethodDescriptorProto;
+	public final fun getClientStreaming ()Ljava/lang/Boolean;
+	public final fun getInputType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/MethodOptions;
+	public final fun getOutputType ()Ljava/lang/String;
+	public final fun getServerStreaming ()Ljava/lang/Boolean;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setClientStreaming (Ljava/lang/Boolean;)V
+	public final fun setInputType (Ljava/lang/String;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Lcom/toasttab/protokt/MethodOptions;)V
+	public final fun setOutputType (Ljava/lang/String;)V
+	public final fun setServerStreaming (Ljava/lang/Boolean;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/MethodOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/MethodOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Boolean;Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/MethodOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getIdempotencyLevel ()Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel;
+	public fun getMessageSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/MethodOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/MethodOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/MethodOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/MethodOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/MethodOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/MethodOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/MethodOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/MethodOptions;
+}
+
+public abstract class com/toasttab/protokt/MethodOptions$IdempotencyLevel : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/MethodOptions$IdempotencyLevel$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/MethodOptions$IdempotencyLevel$IDEMPOTENCY_UNKNOWN : com/toasttab/protokt/MethodOptions$IdempotencyLevel {
+	public static final field INSTANCE Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel$IDEMPOTENCY_UNKNOWN;
+}
+
+public final class com/toasttab/protokt/MethodOptions$IdempotencyLevel$IDEMPOTENT : com/toasttab/protokt/MethodOptions$IdempotencyLevel {
+	public static final field INSTANCE Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel$IDEMPOTENT;
+}
+
+public final class com/toasttab/protokt/MethodOptions$IdempotencyLevel$NO_SIDE_EFFECTS : com/toasttab/protokt/MethodOptions$IdempotencyLevel {
+	public static final field INSTANCE Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel$NO_SIDE_EFFECTS;
+}
+
+public final class com/toasttab/protokt/MethodOptions$IdempotencyLevel$UNRECOGNIZED : com/toasttab/protokt/MethodOptions$IdempotencyLevel {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/MethodOptions$MethodOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/MethodOptions;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getIdempotencyLevel ()Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setIdempotencyLevel (Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Mixin : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Mixin$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Mixin;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRoot ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Mixin$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Mixin;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Mixin;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Mixin;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Mixin;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Mixin;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Mixin;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Mixin;
+}
+
+public final class com/toasttab/protokt/Mixin$MixinDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Mixin;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRoot ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setRoot (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public abstract class com/toasttab/protokt/NullValue : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/NullValue$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/NullValue$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/NullValue;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/NullValue$NULL_VALUE : com/toasttab/protokt/NullValue {
+	public static final field INSTANCE Lcom/toasttab/protokt/NullValue$NULL_VALUE;
+}
+
+public final class com/toasttab/protokt/NullValue$UNRECOGNIZED : com/toasttab/protokt/NullValue {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/OneofDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/OneofDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/OneofOptions;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/OneofOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/OneofDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/OneofDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/OneofDescriptorProto;
+}
+
+public final class com/toasttab/protokt/OneofDescriptorProto$OneofDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/OneofDescriptorProto;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/OneofOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Lcom/toasttab/protokt/OneofOptions;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/OneofOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/OneofOptions$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/OneofOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/OneofOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/OneofOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/OneofOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/OneofOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/OneofOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/OneofOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/OneofOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/OneofOptions;
+}
+
+public final class com/toasttab/protokt/OneofOptions$OneofOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/OneofOptions;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Option : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Option$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/Any;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Option;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Lcom/toasttab/protokt/Any;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Option$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Option;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Option;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Option;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Option;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Option;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Option;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Option;
+}
+
+public final class com/toasttab/protokt/Option$OptionDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Option;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Lcom/toasttab/protokt/Any;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (Lcom/toasttab/protokt/Any;)V
+}
+
+public final class com/toasttab/protokt/ServiceDescriptorProto : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ServiceDescriptorProto$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/toasttab/protokt/ServiceOptions;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getMethod ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/ServiceOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ServiceDescriptorProto$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ServiceDescriptorProto;
+}
+
+public final class com/toasttab/protokt/ServiceDescriptorProto$ServiceDescriptorProtoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ServiceDescriptorProto;
+	public final fun getMethod ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/toasttab/protokt/ServiceOptions;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setMethod (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOptions (Lcom/toasttab/protokt/ServiceOptions;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/ServiceOptions : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/ServiceOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ServiceOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getMessageSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/ServiceOptions$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/ServiceOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/ServiceOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/ServiceOptions;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/ServiceOptions;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ServiceOptions;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/ServiceOptions;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/ServiceOptions;
+}
+
+public final class com/toasttab/protokt/ServiceOptions$ServiceOptionsDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/ServiceOptions;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setDeprecated (Ljava/lang/Boolean;)V
+	public final fun setUninterpretedOption (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/SourceCodeInfo : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/SourceCodeInfo$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/SourceCodeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocation ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/SourceCodeInfo$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/SourceCodeInfo;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/SourceCodeInfo;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/SourceCodeInfo;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/SourceCodeInfo;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/SourceCodeInfo;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/SourceCodeInfo;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/SourceCodeInfo;
+}
+
+public final class com/toasttab/protokt/SourceCodeInfo$Location : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/SourceCodeInfo$Location$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLeadingComments ()Ljava/lang/String;
+	public final fun getLeadingDetachedComments ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getPath ()Ljava/util/List;
+	public final fun getSpan ()Ljava/util/List;
+	public final fun getTrailingComments ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/SourceCodeInfo$Location$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/SourceCodeInfo$Location;
+}
+
+public final class com/toasttab/protokt/SourceCodeInfo$Location$LocationDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/SourceCodeInfo$Location;
+	public final fun getLeadingComments ()Ljava/lang/String;
+	public final fun getLeadingDetachedComments ()Ljava/util/List;
+	public final fun getPath ()Ljava/util/List;
+	public final fun getSpan ()Ljava/util/List;
+	public final fun getTrailingComments ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setLeadingComments (Ljava/lang/String;)V
+	public final fun setLeadingDetachedComments (Ljava/util/List;)V
+	public final fun setPath (Ljava/util/List;)V
+	public final fun setSpan (Ljava/util/List;)V
+	public final fun setTrailingComments (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/SourceCodeInfo$SourceCodeInfoDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/SourceCodeInfo;
+	public final fun getLocation ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setLocation (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/SourceContext : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/SourceContext$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/SourceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileName ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/SourceContext$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/SourceContext;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/SourceContext;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/SourceContext;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/SourceContext;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/SourceContext;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/SourceContext;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/SourceContext;
+}
+
+public final class com/toasttab/protokt/SourceContext$SourceContextDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getFileName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setFileName (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/StringValue : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/StringValue$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/StringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/StringValue$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/StringValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/StringValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/StringValue;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/StringValue;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/StringValue;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/StringValue;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/StringValue;
+}
+
+public final class com/toasttab/protokt/StringValue$StringValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/StringValue;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()Ljava/lang/String;
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (Ljava/lang/String;)V
+}
+
+public final class com/toasttab/protokt/StringValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/StringValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/lang/String;)Lcom/toasttab/protokt/StringValue;
+	public fun wrap (Lcom/toasttab/protokt/StringValue;)Ljava/lang/String;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/Struct : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Struct$Deserializer;
+	public synthetic fun <init> (Ljava/util/Map;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Struct;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFields ()Ljava/util/Map;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Struct$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Struct;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Struct;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Struct;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Struct;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Struct;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Struct;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Struct;
+}
+
+public final class com/toasttab/protokt/Struct$StructDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Struct;
+	public final fun getFields ()Ljava/util/Map;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setFields (Ljava/util/Map;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public abstract class com/toasttab/protokt/Syntax : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/Syntax$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/Syntax$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/Syntax;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/Syntax$PROTO2 : com/toasttab/protokt/Syntax {
+	public static final field INSTANCE Lcom/toasttab/protokt/Syntax$PROTO2;
+}
+
+public final class com/toasttab/protokt/Syntax$PROTO3 : com/toasttab/protokt/Syntax {
+	public static final field INSTANCE Lcom/toasttab/protokt/Syntax$PROTO3;
+}
+
+public final class com/toasttab/protokt/Syntax$UNRECOGNIZED : com/toasttab/protokt/Syntax {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/Timestamp : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Timestamp$Deserializer;
+	public synthetic fun <init> (JILcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Timestamp;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getNanos ()I
+	public final fun getSeconds ()J
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Timestamp$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Timestamp;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Timestamp;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Timestamp;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Timestamp;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Timestamp;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Timestamp;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Timestamp;
+}
+
+public final class com/toasttab/protokt/Timestamp$TimestampDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Timestamp;
+	public final fun getNanos ()I
+	public final fun getSeconds ()J
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setNanos (I)V
+	public final fun setSeconds (J)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Type : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Type$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/toasttab/protokt/SourceContext;Lcom/toasttab/protokt/Syntax;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Type;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFields ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOneofs ()Ljava/util/List;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getSourceContext ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Type$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Type;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Type;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Type;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Type;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Type;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Type;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Type;
+}
+
+public final class com/toasttab/protokt/Type$TypeDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Type;
+	public final fun getFields ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOneofs ()Ljava/util/List;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getSourceContext ()Lcom/toasttab/protokt/SourceContext;
+	public final fun getSyntax ()Lcom/toasttab/protokt/Syntax;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setFields (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setOneofs (Ljava/util/List;)V
+	public final fun setOptions (Ljava/util/List;)V
+	public final fun setSourceContext (Lcom/toasttab/protokt/SourceContext;)V
+	public final fun setSyntax (Lcom/toasttab/protokt/Syntax;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/UInt32Value : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/UInt32Value$Deserializer;
+	public synthetic fun <init> (ILcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UInt32Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/UInt32Value$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UInt32Value;
+}
+
+public final class com/toasttab/protokt/UInt32Value$UInt32ValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/UInt32Value;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()I
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (I)V
+}
+
+public final class com/toasttab/protokt/UInt32ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/UInt32ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (I)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/UInt32Value;)Ljava/lang/Integer;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/UInt64Value : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/UInt64Value$Deserializer;
+	public synthetic fun <init> (JLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UInt64Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/UInt64Value$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UInt64Value;
+}
+
+public final class com/toasttab/protokt/UInt64Value$UInt64ValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/UInt64Value;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun getValue ()J
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+	public final fun setValue (J)V
+}
+
+public final class com/toasttab/protokt/UInt64ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/UInt64ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (J)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/UInt64Value;)Ljava/lang/Long;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/toasttab/protokt/UninterpretedOption : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/UninterpretedOption$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Lcom/toasttab/protokt/rt/Bytes;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UninterpretedOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAggregateValue ()Ljava/lang/String;
+	public final fun getDoubleValue ()Ljava/lang/Double;
+	public final fun getIdentifierValue ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/util/List;
+	public final fun getNegativeIntValue ()Ljava/lang/Long;
+	public final fun getPositiveIntValue ()Ljava/lang/Long;
+	public final fun getStringValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/UninterpretedOption$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/UninterpretedOption;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/UninterpretedOption;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/UninterpretedOption;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/UninterpretedOption;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/UninterpretedOption;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/UninterpretedOption;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UninterpretedOption;
+}
+
+public final class com/toasttab/protokt/UninterpretedOption$NamePart : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/UninterpretedOption$NamePart$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;ZLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageSize ()I
+	public final fun getNamePart ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public final fun isExtension ()Z
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/UninterpretedOption$NamePart$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+}
+
+public final class com/toasttab/protokt/UninterpretedOption$NamePart$NamePartDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/UninterpretedOption$NamePart;
+	public final fun getNamePart ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun isExtension ()Z
+	public final fun setExtension (Z)V
+	public final fun setNamePart (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/UninterpretedOption$UninterpretedOptionDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/UninterpretedOption;
+	public final fun getAggregateValue ()Ljava/lang/String;
+	public final fun getDoubleValue ()Ljava/lang/Double;
+	public final fun getIdentifierValue ()Ljava/lang/String;
+	public final fun getName ()Ljava/util/List;
+	public final fun getNegativeIntValue ()Ljava/lang/Long;
+	public final fun getPositiveIntValue ()Ljava/lang/Long;
+	public final fun getStringValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setAggregateValue (Ljava/lang/String;)V
+	public final fun setDoubleValue (Ljava/lang/Double;)V
+	public final fun setIdentifierValue (Ljava/lang/String;)V
+	public final fun setName (Ljava/util/List;)V
+	public final fun setNegativeIntValue (Ljava/lang/Long;)V
+	public final fun setPositiveIntValue (Ljava/lang/Long;)V
+	public final fun setStringValue (Lcom/toasttab/protokt/rt/Bytes;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/Value : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/Value$Deserializer;
+	public synthetic fun <init> (Lcom/toasttab/protokt/Value$Kind;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Lcom/toasttab/protokt/Value$Kind;
+	public fun getMessageSize ()I
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/Value;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/Value;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/Value;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/Value;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/Value;
+}
+
+public abstract class com/toasttab/protokt/Value$Kind {
+}
+
+public final class com/toasttab/protokt/Value$Kind$BoolValue : com/toasttab/protokt/Value$Kind {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/toasttab/protokt/Value$Kind$BoolValue;
+	public static synthetic fun copy$default (Lcom/toasttab/protokt/Value$Kind$BoolValue;ZILjava/lang/Object;)Lcom/toasttab/protokt/Value$Kind$BoolValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoolValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$Kind$ListValue : com/toasttab/protokt/Value$Kind {
+	public fun <init> (Lcom/toasttab/protokt/ListValue;)V
+	public final fun component1 ()Lcom/toasttab/protokt/ListValue;
+	public final fun copy (Lcom/toasttab/protokt/ListValue;)Lcom/toasttab/protokt/Value$Kind$ListValue;
+	public static synthetic fun copy$default (Lcom/toasttab/protokt/Value$Kind$ListValue;Lcom/toasttab/protokt/ListValue;ILjava/lang/Object;)Lcom/toasttab/protokt/Value$Kind$ListValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getListValue ()Lcom/toasttab/protokt/ListValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$Kind$NullValue : com/toasttab/protokt/Value$Kind {
+	public fun <init> (Lcom/toasttab/protokt/NullValue;)V
+	public final fun component1 ()Lcom/toasttab/protokt/NullValue;
+	public final fun copy (Lcom/toasttab/protokt/NullValue;)Lcom/toasttab/protokt/Value$Kind$NullValue;
+	public static synthetic fun copy$default (Lcom/toasttab/protokt/Value$Kind$NullValue;Lcom/toasttab/protokt/NullValue;ILjava/lang/Object;)Lcom/toasttab/protokt/Value$Kind$NullValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNullValue ()Lcom/toasttab/protokt/NullValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$Kind$NumberValue : com/toasttab/protokt/Value$Kind {
+	public fun <init> (D)V
+	public final fun component1 ()D
+	public final fun copy (D)Lcom/toasttab/protokt/Value$Kind$NumberValue;
+	public static synthetic fun copy$default (Lcom/toasttab/protokt/Value$Kind$NumberValue;DILjava/lang/Object;)Lcom/toasttab/protokt/Value$Kind$NumberValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNumberValue ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$Kind$StringValue : com/toasttab/protokt/Value$Kind {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/toasttab/protokt/Value$Kind$StringValue;
+	public static synthetic fun copy$default (Lcom/toasttab/protokt/Value$Kind$StringValue;Ljava/lang/String;ILjava/lang/Object;)Lcom/toasttab/protokt/Value$Kind$StringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStringValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$Kind$StructValue : com/toasttab/protokt/Value$Kind {
+	public fun <init> (Lcom/toasttab/protokt/Struct;)V
+	public final fun component1 ()Lcom/toasttab/protokt/Struct;
+	public final fun copy (Lcom/toasttab/protokt/Struct;)Lcom/toasttab/protokt/Value$Kind$StructValue;
+	public static synthetic fun copy$default (Lcom/toasttab/protokt/Value$Kind$StructValue;Lcom/toasttab/protokt/Struct;ILjava/lang/Object;)Lcom/toasttab/protokt/Value$Kind$StructValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStructValue ()Lcom/toasttab/protokt/Struct;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/Value$ValueDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/Value;
+	public final fun getKind ()Lcom/toasttab/protokt/Value$Kind;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setKind (Lcom/toasttab/protokt/Value$Kind;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorRequest : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/compiler/CodeGeneratorRequest$Deserializer;
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lcom/toasttab/protokt/compiler/Version;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompilerVersion ()Lcom/toasttab/protokt/compiler/Version;
+	public final fun getFileToGenerate ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getParameter ()Ljava/lang/String;
+	public final fun getProtoFile ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorRequest$CodeGeneratorRequestDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public final fun getCompilerVersion ()Lcom/toasttab/protokt/compiler/Version;
+	public final fun getFileToGenerate ()Ljava/util/List;
+	public final fun getParameter ()Ljava/lang/String;
+	public final fun getProtoFile ()Ljava/util/List;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setCompilerVersion (Lcom/toasttab/protokt/compiler/Version;)V
+	public final fun setFileToGenerate (Ljava/util/List;)V
+	public final fun setParameter (Ljava/lang/String;)V
+	public final fun setProtoFile (Ljava/util/List;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorRequest$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/CodeGeneratorRequest;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/String;
+	public final fun getFile ()Ljava/util/List;
+	public fun getMessageSize ()I
+	public final fun getSupportedFeatures ()Ljava/lang/Long;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$CodeGeneratorResponseDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public final fun getError ()Ljava/lang/String;
+	public final fun getFile ()Ljava/util/List;
+	public final fun getSupportedFeatures ()Ljava/lang/Long;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setError (Ljava/lang/String;)V
+	public final fun setFile (Ljava/util/List;)V
+	public final fun setSupportedFeatures (Ljava/lang/Long;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse;
+}
+
+public abstract class com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature : com/toasttab/protokt/rt/KtEnum {
+	public static final field Deserializer Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$Deserializer;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$Deserializer : com/toasttab/protokt/rt/KtEnumDeserializer {
+	public fun from (I)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Feature;
+	public synthetic fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$NONE : com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature {
+	public static final field INSTANCE Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$NONE;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$PROTO3_OPTIONAL : com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature {
+	public static final field INSTANCE Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$PROTO3_OPTIONAL;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$UNRECOGNIZED : com/toasttab/protokt/compiler/CodeGeneratorResponse$Feature {
+	public fun <init> (I)V
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$File : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/toasttab/protokt/GeneratedCodeInfo;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getGeneratedCodeInfo ()Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public final fun getInsertionPoint ()Ljava/lang/String;
+	public fun getMessageSize ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$File$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+}
+
+public final class com/toasttab/protokt/compiler/CodeGeneratorResponse$File$FileDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File;
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getGeneratedCodeInfo ()Lcom/toasttab/protokt/GeneratedCodeInfo;
+	public final fun getInsertionPoint ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setContent (Ljava/lang/String;)V
+	public final fun setGeneratedCodeInfo (Lcom/toasttab/protokt/GeneratedCodeInfo;)V
+	public final fun setInsertionPoint (Ljava/lang/String;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/compiler/Version : com/toasttab/protokt/rt/KtMessage {
+	public static final field Deserializer Lcom/toasttab/protokt/compiler/Version$Deserializer;
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/Version;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMajor ()Ljava/lang/Integer;
+	public fun getMessageSize ()I
+	public final fun getMinor ()Ljava/lang/Integer;
+	public final fun getPatch ()Ljava/lang/Integer;
+	public final fun getSuffix ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public fun serialize (Ljava/io/OutputStream;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/compiler/Version$Deserializer : com/toasttab/protokt/rt/KtDeserializer, kotlin/jvm/functions/Function1 {
+	public fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/compiler/Version;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/compiler/Version;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/compiler/Version;
+	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/compiler/Version;
+	public synthetic fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/compiler/Version;
+	public synthetic fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public fun deserialize ([B)Lcom/toasttab/protokt/compiler/Version;
+	public synthetic fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/compiler/Version;
+}
+
+public final class com/toasttab/protokt/compiler/Version$VersionDsl {
+	public fun <init> ()V
+	public final fun build ()Lcom/toasttab/protokt/compiler/Version;
+	public final fun getMajor ()Ljava/lang/Integer;
+	public final fun getMinor ()Ljava/lang/Integer;
+	public final fun getPatch ()Ljava/lang/Integer;
+	public final fun getSuffix ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun setMajor (Ljava/lang/Integer;)V
+	public final fun setMinor (Ljava/lang/Integer;)V
+	public final fun setPatch (Ljava/lang/Integer;)V
+	public final fun setSuffix (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+

--- a/protokt-core/api/protokt-core.api
+++ b/protokt-core/api/protokt-core.api
@@ -1,0 +1,210 @@
+public final class com/toasttab/protokt/AnyExtKt {
+	public static final fun pack (Lcom/toasttab/protokt/Any$Deserializer;Lcom/toasttab/protokt/rt/KtMessage;Ljava/lang/String;)Lcom/toasttab/protokt/Any;
+	public static synthetic fun pack$default (Lcom/toasttab/protokt/Any$Deserializer;Lcom/toasttab/protokt/rt/KtMessage;Ljava/lang/String;ILjava/lang/Object;)Lcom/toasttab/protokt/Any;
+}
+
+public final class com/toasttab/protokt/AnyKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Any$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/AnyProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/AnyProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/ApiKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Api$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Method$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Mixin$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/ApiProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/ApiProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/Descriptor {
+	public fun <init> (Lcom/toasttab/protokt/DescriptorProto;Lcom/toasttab/protokt/FileDescriptor;ILcom/toasttab/protokt/Descriptor;)V
+	public synthetic fun <init> (Lcom/toasttab/protokt/DescriptorProto;Lcom/toasttab/protokt/FileDescriptor;ILcom/toasttab/protokt/Descriptor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/toasttab/protokt/DescriptorProto;Lcom/toasttab/protokt/FileDescriptor;ILjava/lang/String;)V
+	public final fun getEnumTypes ()Ljava/util/List;
+	public final fun getFile ()Lcom/toasttab/protokt/FileDescriptor;
+	public final fun getFullName ()Ljava/lang/String;
+	public final fun getIndex ()I
+	public final fun getNestedTypes ()Ljava/util/List;
+	public final fun getProto ()Lcom/toasttab/protokt/DescriptorProto;
+}
+
+public final class com/toasttab/protokt/DescriptorKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/DescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/DescriptorProto$ExtensionRange$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/DescriptorProto$ReservedRange$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/EnumDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/EnumDescriptorProto$EnumReservedRange$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/EnumOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/EnumValueDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/EnumValueOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ExtensionRangeOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldDescriptorProto$Label$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldDescriptorProto$Type$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldOptions$CType$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldOptions$JSType$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FileDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FileDescriptorSet$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FileOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FileOptions$OptimizeMode$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/GeneratedCodeInfo$Annotation$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/GeneratedCodeInfo$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/MessageOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/MethodDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/MethodOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/MethodOptions$IdempotencyLevel$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/OneofDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/OneofOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ServiceDescriptorProto$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ServiceOptions$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/SourceCodeInfo$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/SourceCodeInfo$Location$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/UninterpretedOption$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/UninterpretedOption$NamePart$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/DescriptorProtos {
+	public static final field INSTANCE Lcom/toasttab/protokt/DescriptorProtos;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/DurationKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Duration$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/DurationProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/DurationProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/EmptyKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Empty$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/EmptyProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/EmptyProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/EnumDescriptor {
+	public fun <init> (Lcom/toasttab/protokt/EnumDescriptorProto;Lcom/toasttab/protokt/FileDescriptor;I)V
+	public final fun getFile ()Lcom/toasttab/protokt/FileDescriptor;
+	public final fun getIndex ()I
+	public final fun getProto ()Lcom/toasttab/protokt/EnumDescriptorProto;
+}
+
+public final class com/toasttab/protokt/FieldMaskProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/FieldMaskProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/Field_maskKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FieldMask$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/FileDescriptor {
+	public static final field Companion Lcom/toasttab/protokt/FileDescriptor$Companion;
+	public fun <init> (Lcom/toasttab/protokt/FileDescriptorProto;Ljava/util/List;)V
+	public final fun getDependencies ()Ljava/util/List;
+	public final fun getEnumTypes ()Ljava/util/List;
+	public final fun getMessageTypes ()Ljava/util/List;
+	public final fun getProto ()Lcom/toasttab/protokt/FileDescriptorProto;
+	public final fun getServices ()Ljava/util/List;
+}
+
+public final class com/toasttab/protokt/FileDescriptor$Companion {
+	public final fun buildFrom ([Ljava/lang/String;Ljava/util/List;)Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/ServiceDescriptor {
+	public fun <init> (Lcom/toasttab/protokt/ServiceDescriptorProto;Lcom/toasttab/protokt/FileDescriptor;I)V
+	public final fun getFile ()Lcom/toasttab/protokt/FileDescriptor;
+	public final fun getFullName ()Ljava/lang/String;
+	public final fun getIndex ()I
+	public final fun getProto ()Lcom/toasttab/protokt/ServiceDescriptorProto;
+}
+
+public final class com/toasttab/protokt/SourceContextProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/SourceContextProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/Source_contextKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/SourceContext$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/StructKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/ListValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/NullValue$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Struct$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Value$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/StructProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/StructProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/TimestampKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Timestamp$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/TimestampProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/TimestampProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/TypeKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/EnumValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Enum_$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Field$Cardinality$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Field$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Field$Kind$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Option$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Syntax$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Type$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/TypeProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/TypeProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/WrappersKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/BoolValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/BytesValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/DoubleValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/FloatValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Int32Value$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/Int64Value$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/StringValue$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/UInt32Value$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/UInt64Value$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/WrappersProto {
+	public static final field INSTANCE Lcom/toasttab/protokt/WrappersProto;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+
+public final class com/toasttab/protokt/compiler/PluginKt {
+	public static final fun getDescriptor (Lcom/toasttab/protokt/compiler/CodeGeneratorRequest$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$Feature$Deserializer;)Lcom/toasttab/protokt/EnumDescriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/compiler/CodeGeneratorResponse$File$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+	public static final fun getDescriptor (Lcom/toasttab/protokt/compiler/Version$Deserializer;)Lcom/toasttab/protokt/Descriptor;
+}
+
+public final class com/toasttab/protokt/compiler/PluginProtos {
+	public static final field INSTANCE Lcom/toasttab/protokt/compiler/PluginProtos;
+	public final fun getDescriptor ()Lcom/toasttab/protokt/FileDescriptor;
+}
+

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -1,0 +1,454 @@
+public final class com/toasttab/protokt/rt/Bytes {
+	public static final field Companion Lcom/toasttab/protokt/rt/Bytes$Companion;
+	public fun <init> ([B)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public final fun isNotEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/rt/Bytes$Companion {
+	public final fun empty ()Lcom/toasttab/protokt/rt/Bytes;
+}
+
+public final class com/toasttab/protokt/rt/BytesKt {
+	public static final fun toBytesSlice (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/BytesSlice;
+}
+
+public final class com/toasttab/protokt/rt/BytesSlice {
+	public static final field Companion Lcom/toasttab/protokt/rt/BytesSlice$Companion;
+	public fun <init> ([B)V
+	public fun <init> ([BII)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLength ()I
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public final fun isNotEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/rt/BytesSlice$Companion {
+	public final fun empty ()Lcom/toasttab/protokt/rt/BytesSlice;
+}
+
+public final class com/toasttab/protokt/rt/BytesSliceKt {
+	public static final fun toBytes (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/Bytes;
+}
+
+public final class com/toasttab/protokt/rt/Fixed32 {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/Fixed32;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/Fixed32Val : com/toasttab/protokt/rt/UnknownValue {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/Fixed32Val;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue-9VXsanU ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun size ()I
+	public static fun size-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/Fixed64 {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/Fixed64;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/toasttab/protokt/rt/Fixed64Val : com/toasttab/protokt/rt/UnknownValue {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/Fixed64Val;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue-EgeNUQI ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun size ()I
+	public static fun size-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/toasttab/protokt/rt/Int32 {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/Int32;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/Int64 {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/Int64;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public abstract interface class com/toasttab/protokt/rt/KtDeserializer {
+	public abstract fun deserialize (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public abstract fun deserialize (Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public abstract fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public abstract fun deserialize (Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public abstract fun deserialize (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public abstract fun deserialize ([B)Lcom/toasttab/protokt/rt/KtMessage;
+}
+
+public final class com/toasttab/protokt/rt/KtDeserializer$DefaultImpls {
+	public static fun deserialize (Lcom/toasttab/protokt/rt/KtDeserializer;Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessage;
+	public static fun deserialize (Lcom/toasttab/protokt/rt/KtDeserializer;Lcom/toasttab/protokt/rt/BytesSlice;)Lcom/toasttab/protokt/rt/KtMessage;
+	public static fun deserialize (Lcom/toasttab/protokt/rt/KtDeserializer;Ljava/io/InputStream;)Lcom/toasttab/protokt/rt/KtMessage;
+	public static fun deserialize (Lcom/toasttab/protokt/rt/KtDeserializer;Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public static fun deserialize (Lcom/toasttab/protokt/rt/KtDeserializer;[B)Lcom/toasttab/protokt/rt/KtMessage;
+}
+
+public abstract class com/toasttab/protokt/rt/KtEnum {
+	public fun <init> ()V
+	public final fun equals (Ljava/lang/Object;)Z
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getValue ()I
+	public final fun hashCode ()I
+	public final fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/toasttab/protokt/rt/KtEnumDeserializer {
+	public abstract fun from (I)Lcom/toasttab/protokt/rt/KtEnum;
+}
+
+public abstract interface annotation class com/toasttab/protokt/rt/KtGeneratedMessage : java/lang/annotation/Annotation {
+	public abstract fun fullTypeName ()Ljava/lang/String;
+}
+
+public abstract interface class com/toasttab/protokt/rt/KtMessage {
+	public abstract fun getMessageSize ()I
+	public abstract fun serialize ()[B
+	public abstract fun serialize (Lcom/toasttab/protokt/rt/KtMessageSerializer;)V
+	public abstract fun serialize (Ljava/io/OutputStream;)V
+}
+
+public final class com/toasttab/protokt/rt/KtMessage$DefaultImpls {
+	public static fun serialize (Lcom/toasttab/protokt/rt/KtMessage;)[B
+	public static fun serialize (Lcom/toasttab/protokt/rt/KtMessage;Ljava/io/OutputStream;)V
+}
+
+public abstract interface class com/toasttab/protokt/rt/KtMessageDeserializer {
+	public abstract fun readBool ()Z
+	public abstract fun readBytes ()Lcom/toasttab/protokt/rt/Bytes;
+	public abstract fun readBytesSlice ()Lcom/toasttab/protokt/rt/BytesSlice;
+	public abstract fun readDouble ()D
+	public abstract fun readEnum (Lcom/toasttab/protokt/rt/KtEnumDeserializer;)Lcom/toasttab/protokt/rt/KtEnum;
+	public abstract fun readFixed32 ()I
+	public abstract fun readFixed64 ()J
+	public abstract fun readFloat ()F
+	public abstract fun readInt32 ()I
+	public abstract fun readInt64 ()J
+	public abstract fun readMessage (Lcom/toasttab/protokt/rt/KtDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
+	public abstract fun readRepeated (ZLkotlin/jvm/functions/Function1;)V
+	public abstract fun readSFixed32 ()I
+	public abstract fun readSFixed64 ()J
+	public abstract fun readSInt32 ()I
+	public abstract fun readSInt64 ()J
+	public abstract fun readString ()Ljava/lang/String;
+	public abstract fun readTag ()I
+	public abstract fun readUInt32 ()I
+	public abstract fun readUInt64 ()J
+	public abstract fun readUnknown ()Lcom/toasttab/protokt/rt/UnknownField;
+}
+
+public final class com/toasttab/protokt/rt/KtMessageDeserializerKt {
+	public static final fun deserializer (Lcom/google/protobuf/CodedInputStream;[B)Lcom/toasttab/protokt/rt/KtMessageDeserializer;
+	public static final fun deserializer (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/KtMessageDeserializer;
+	public static final fun deserializer ([B)Lcom/toasttab/protokt/rt/KtMessageDeserializer;
+	public static synthetic fun deserializer$default (Lcom/google/protobuf/CodedInputStream;[BILjava/lang/Object;)Lcom/toasttab/protokt/rt/KtMessageDeserializer;
+}
+
+public abstract interface class com/toasttab/protokt/rt/KtMessageSerializer {
+	public abstract fun write (D)V
+	public abstract fun write (F)V
+	public abstract fun write (Lcom/toasttab/protokt/rt/Bytes;)V
+	public abstract fun write (Lcom/toasttab/protokt/rt/BytesSlice;)V
+	public abstract fun write (Lcom/toasttab/protokt/rt/KtEnum;)V
+	public abstract fun write (Lcom/toasttab/protokt/rt/KtMessage;)V
+	public abstract fun write (Ljava/lang/String;)V
+	public abstract fun write (Z)V
+	public abstract fun write ([B)V
+	public abstract fun write-0uKwbYc (I)V
+	public abstract fun write-5ypQ2uo (I)V
+	public abstract fun write-7pWS-KA (I)V
+	public abstract fun write-F7A3Lgg (J)V
+	public abstract fun write-Kmvk60k (J)V
+	public abstract fun write-PbWFcY0 (I)V
+	public abstract fun write-Q1qAQ9Y (I)V
+	public abstract fun write-eCTEKGc (I)Lcom/toasttab/protokt/rt/KtMessageSerializer;
+	public abstract fun write-mT82CqI (J)V
+	public abstract fun write-p0b2sSQ (J)V
+	public abstract fun write-vBJ1sQw (J)V
+	public abstract fun writeUnknown (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
+}
+
+public final class com/toasttab/protokt/rt/KtMessageSerializer$DefaultImpls {
+	public static fun write (Lcom/toasttab/protokt/rt/KtMessageSerializer;Lcom/toasttab/protokt/rt/Bytes;)V
+}
+
+public final class com/toasttab/protokt/rt/KtMessageSerializerKt {
+	public static final fun serializer (Lcom/google/protobuf/CodedOutputStream;)Lcom/toasttab/protokt/rt/KtMessageSerializer;
+}
+
+public final class com/toasttab/protokt/rt/LengthDelimitedVal : com/toasttab/protokt/rt/UnknownValue {
+	public static final synthetic fun box-impl (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/LengthDelimitedVal;
+	public static fun constructor-impl (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/rt/Bytes;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lcom/toasttab/protokt/rt/Bytes;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lcom/toasttab/protokt/rt/Bytes;Lcom/toasttab/protokt/rt/Bytes;)Z
+	public final fun getValue ()Lcom/toasttab/protokt/rt/Bytes;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lcom/toasttab/protokt/rt/Bytes;)I
+	public fun size ()I
+	public static fun size-impl (Lcom/toasttab/protokt/rt/Bytes;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lcom/toasttab/protokt/rt/Bytes;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lcom/toasttab/protokt/rt/Bytes;
+}
+
+public final class com/toasttab/protokt/rt/RuntimeUtilsKt {
+	public static final fun copyList (Ljava/util/List;)Ljava/util/List;
+	public static final fun copyMap (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun finishList (Ljava/util/List;)Ljava/util/List;
+	public static final fun finishMap (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public final class com/toasttab/protokt/rt/SFixed32 {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/SFixed32;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/SFixed64 {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/SFixed64;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/toasttab/protokt/rt/SInt32 {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/SInt32;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/SInt64 {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/SInt64;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/toasttab/protokt/rt/SizeCodecsKt {
+	public static final fun sizeof (D)I
+	public static final fun sizeof (F)I
+	public static final fun sizeof (Lcom/toasttab/protokt/rt/Bytes;)I
+	public static final fun sizeof (Lcom/toasttab/protokt/rt/BytesSlice;)I
+	public static final fun sizeof (Lcom/toasttab/protokt/rt/KtEnum;)I
+	public static final fun sizeof (Lcom/toasttab/protokt/rt/KtMessage;)I
+	public static final fun sizeof (Ljava/lang/String;)I
+	public static final fun sizeof (Z)I
+	public static final fun sizeof ([B)I
+	public static final fun sizeof-0uKwbYc (I)I
+	public static final fun sizeof-5ypQ2uo (I)I
+	public static final fun sizeof-7pWS-KA (I)I
+	public static final fun sizeof-F7A3Lgg (J)I
+	public static final fun sizeof-Kmvk60k (J)I
+	public static final fun sizeof-PbWFcY0 (I)I
+	public static final fun sizeof-Q1qAQ9Y (I)I
+	public static final fun sizeof-eCTEKGc (I)I
+	public static final fun sizeof-mT82CqI (J)I
+	public static final fun sizeof-p0b2sSQ (J)I
+	public static final fun sizeof-vBJ1sQw (J)I
+	public static final fun sizeofMap-o-SdxxE (Ljava/util/Map;ILkotlin/jvm/functions/Function2;)I
+}
+
+public final class com/toasttab/protokt/rt/Tag {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/Tag;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/UInt32 {
+	public static final synthetic fun box-impl (I)Lcom/toasttab/protokt/rt/UInt32;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/toasttab/protokt/rt/UInt64 {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/UInt64;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/toasttab/protokt/rt/UnknownField {
+	public static final field Companion Lcom/toasttab/protokt/rt/UnknownField$Companion;
+	public synthetic fun <init> (ILcom/toasttab/protokt/rt/UnknownValue;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFieldNumber ()I
+	public final fun getValue ()Lcom/toasttab/protokt/rt/UnknownValue;
+}
+
+public final class com/toasttab/protokt/rt/UnknownField$Companion {
+	public final fun fixed32 (II)Lcom/toasttab/protokt/rt/UnknownField;
+	public final fun fixed64 (IJ)Lcom/toasttab/protokt/rt/UnknownField;
+	public final fun lengthDelimited (I[B)Lcom/toasttab/protokt/rt/UnknownField;
+	public final fun varint (IJ)Lcom/toasttab/protokt/rt/UnknownField;
+}
+
+public final class com/toasttab/protokt/rt/UnknownFieldSet {
+	public static final field Companion Lcom/toasttab/protokt/rt/UnknownFieldSet$Companion;
+	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun size ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/toasttab/protokt/rt/UnknownFieldSet$Builder {
+	public fun <init> ()V
+	public final fun add (Lcom/toasttab/protokt/rt/UnknownField;)V
+	public final fun build ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+}
+
+public final class com/toasttab/protokt/rt/UnknownFieldSet$Companion {
+	public final fun empty ()Lcom/toasttab/protokt/rt/UnknownFieldSet;
+	public final fun from (Lcom/toasttab/protokt/rt/UnknownFieldSet$Builder;)Lcom/toasttab/protokt/rt/UnknownFieldSet;
+}
+
+public final class com/toasttab/protokt/rt/UnknownFieldSet$Field {
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFixed32 ()Ljava/util/List;
+	public final fun getFixed64 ()Ljava/util/List;
+	public final fun getLengthDelimited ()Ljava/util/List;
+	public final fun getVarint ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun size (I)I
+	public fun toString ()Ljava/lang/String;
+	public final fun write (ILcom/toasttab/protokt/rt/KtMessageSerializer;)V
+}
+
+public final class com/toasttab/protokt/rt/UnknownFieldSet$Field$Builder {
+	public final fun add (Lcom/toasttab/protokt/rt/UnknownValue;)V
+	public final fun build ()Lcom/toasttab/protokt/rt/UnknownFieldSet$Field;
+}
+
+public abstract interface class com/toasttab/protokt/rt/UnknownValue {
+	public abstract fun size ()I
+}
+
+public final class com/toasttab/protokt/rt/VarintVal : com/toasttab/protokt/rt/UnknownValue {
+	public static final synthetic fun box-impl (J)Lcom/toasttab/protokt/rt/VarintVal;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue-q-79Ojo ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun size ()I
+	public static fun size-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+


### PR DESCRIPTION
This changes our custom kotlin-binary-compatibility-validator setup to the [recommended workflow](https://github.com/Kotlin/binary-compatibility-validator#workflow) where the API signature files are updated and checked in 
 whenever the API changes; kotlin-binary-compatibility-validator [cannot infer](https://github.com/Kotlin/binary-compatibility-validator/issues/70) whether API changes are backwards-compatible, so comparing API against previous release version is not very valuable.