### PR TITLE
Omit empty unknown fields from message toString

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/annotators/MessageAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/annotators/MessageAnnotator.kt
@@ -206,21 +206,24 @@ private constructor(
                 .addModifiers(KModifier.OVERRIDE)
                 .addCode(
                     if (properties.isEmpty()) {
-                        "return \"${msg.name}(unknownFields=\$unknownFields)\""
+                        "return \"${msg.name}(${unknownFieldsToString(prefix = "")})\""
                     } else {
                         """
                             |return "${msg.name}(" +
                             |${toStringLines(properties)}
-                            |    "unknownFields=${"$"}unknownFields)"
+                            |    "${unknownFieldsToString(prefix = ", ")})"
                         """.bindMargin()
                     }
                 )
                 .build()
         )
 
+    private fun unknownFieldsToString(prefix: String) =
+        "\${if (unknownFields.isEmpty()) \"\" else \"${prefix}unknownFields=\$unknownFields\"}"
+
     private fun toStringLines(properties: List<PropertyInfo>) =
-        properties.joinToString("\n") {
-            "    \"${it.name}=\$${it.name}, \" +"
+        properties.joinToString(separator = ", \" +\n", postfix = "\" +") {
+            "    \"${it.name}=\$${it.name}"
         }.bindSpaces()
 
     private fun suppressDeprecation() =

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/UnknownFieldSet.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/UnknownFieldSet.kt
@@ -22,6 +22,9 @@ private constructor(
     fun size() =
         unknownFields.entries.sumOf { (k, v) -> v.size(k) }
 
+    fun isEmpty() =
+        unknownFields.isEmpty()
+
     override fun equals(other: Any?) =
         other is UnknownFieldSet &&
             other.unknownFields == unknownFields

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/UnknownFieldSet.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/UnknownFieldSet.kt
@@ -48,9 +48,10 @@ private constructor(
     class Builder {
         private val map = mutableMapOf<Int, Field.Builder>()
 
-        fun add(unknown: UnknownField) {
+        fun add(unknown: UnknownField): Builder {
             map.getOrPut(unknown.fieldNumber) { Field.Builder() }
                 .add(unknown.value)
+            return this
         }
 
         fun build() =

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/UnknownFieldSet.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/UnknownFieldSet.kt
@@ -48,10 +48,9 @@ private constructor(
     class Builder {
         private val map = mutableMapOf<Int, Field.Builder>()
 
-        fun add(unknown: UnknownField): Builder {
+        fun add(unknown: UnknownField) {
             map.getOrPut(unknown.fieldNumber) { Field.Builder() }
                 .add(unknown.value)
-            return this
         }
 
         fun build() =

--- a/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/ToStringTest.kt
+++ b/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/ToStringTest.kt
@@ -36,7 +36,9 @@ class ToStringTest {
     fun `toString prints the correct format for empty message with unknown fields`() {
         assertThat(
             Empty {
-                unknownFields = UnknownFieldSet.Builder().add(UnknownField.fixed32(5, 10)).build()
+                unknownFields = UnknownFieldSet.Builder().apply {
+                    add(UnknownField.fixed32(5, 10))
+                }.build()
             }.toString()
         ).isEqualTo(
             "Empty(unknownFields=UnknownFieldSet(unknownFields={5=Field(varint=[], fixed32=[Fixed32Val(value=Fixed32(value=10))], fixed64=[], lengthDelimited=[])}))"
@@ -57,7 +59,9 @@ class ToStringTest {
         assertThat(
             Test2 {
                 extra = "foo"
-                unknownFields = UnknownFieldSet.Builder().add(UnknownField.fixed32(5, 10)).build()
+                unknownFields = UnknownFieldSet.Builder().apply {
+                    add(UnknownField.fixed32(5, 10))
+                }.build()
             }.toString()
         ).isEqualTo(
             "Test2(`val`=[], extra=foo, unknownFields=UnknownFieldSet(unknownFields={5=Field(varint=[], fixed32=[Fixed32Val(value=Fixed32(value=10))], fixed64=[], lengthDelimited=[])}))"

--- a/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/ToStringTest.kt
+++ b/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/ToStringTest.kt
@@ -19,6 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.toasttab.protokt.rt.UnknownField
 import com.toasttab.protokt.rt.UnknownFieldSet
 import org.junit.jupiter.api.Test
+import toasttab.protokt.testing.rt.Empty
 import toasttab.protokt.testing.rt.Test2
 
 class ToStringTest {

--- a/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/ToStringTest.kt
+++ b/testing/runtime-tests/src/test/kotlin/com/toasttab/protokt/testing/rt/ToStringTest.kt
@@ -16,16 +16,50 @@
 package com.toasttab.protokt.testing.rt
 
 import com.google.common.truth.Truth.assertThat
+import com.toasttab.protokt.rt.UnknownField
+import com.toasttab.protokt.rt.UnknownFieldSet
 import org.junit.jupiter.api.Test
 import toasttab.protokt.testing.rt.Test2
 
 class ToStringTest {
     @Test
-    fun `toString prints the correct format`() {
+    fun `toString prints the correct format for empty message`() {
+        assertThat(
+            Empty { }.toString()
+        ).isEqualTo(
+            "Empty()"
+        )
+    }
+
+    @Test
+    fun `toString prints the correct format for empty message with unknown fields`() {
+        assertThat(
+            Empty {
+                unknownFields = UnknownFieldSet.Builder().add(UnknownField.fixed32(5, 10)).build()
+            }.toString()
+        ).isEqualTo(
+            "Empty(unknownFields=UnknownFieldSet(unknownFields={5=Field(varint=[], fixed32=[Fixed32Val(value=Fixed32(value=10))], fixed64=[], lengthDelimited=[])}))"
+        )
+    }
+
+    @Test
+    fun `toString omits unknown fields when empty`() {
         assertThat(
             Test2 { extra = "foo" }.toString()
         ).isEqualTo(
-            "Test2(`val`=[], extra=foo, unknownFields=UnknownFieldSet(unknownFields={}))"
+            "Test2(`val`=[], extra=foo)"
+        )
+    }
+
+    @Test
+    fun `toString prints the correct format with non-empty unknown fields`() {
+        assertThat(
+            Test2 {
+                extra = "foo"
+                unknownFields = UnknownFieldSet.Builder().add(UnknownField.fixed32(5, 10)).build()
+            }.toString()
+        ).isEqualTo(
+            "Test2(`val`=[], extra=foo, unknownFields=UnknownFieldSet(unknownFields={5=Field(varint=[], fixed32=[Fixed32Val(value=Fixed32(value=10))], fixed64=[], lengthDelimited=[])}))"
         )
     }
 }


### PR DESCRIPTION
The current implementation of `toString` logs the unknown fields map as `{}` when empty, which causes problems for logging because the empty map is interpreted as an argument placeholder. This results in the incorrect nesting of log arguments.

With this change, we omit unknown fields from the `toString` representation if it is empty. This is consistent with protobuf-java, which does not print empty unknown fields. 

Example generated `toString`:
```
    override fun toString(): String = "Any(" +
        "typeUrl=$typeUrl, " +
        "value=$value" +
        "${if (unknownFields.isEmpty()) "" else ", unknownFields=$unknownFields"})"

```