### PR TITLE
Add annotations for generated services, enums, and file descriptors

### DIFF
--- a/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/EnumBuilder.kt
+++ b/protokt-codegen/src/main/kotlin/com/toasttab/protokt/codegen/impl/EnumBuilder.kt
@@ -17,6 +17,7 @@ package com.toasttab.protokt.codegen.impl
 
 import com.google.protobuf.DescriptorProtos.DescriptorProto.ENUM_TYPE_FIELD_NUMBER
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto.VALUE_FIELD_NUMBER
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -32,6 +33,7 @@ import com.toasttab.protokt.codegen.impl.Deprecation.hasDeprecation
 import com.toasttab.protokt.codegen.protoc.Enum
 import com.toasttab.protokt.rt.KtEnum
 import com.toasttab.protokt.rt.KtEnumDeserializer
+import com.toasttab.protokt.rt.KtGeneratedEnum
 
 class EnumBuilder(
     val e: Enum,
@@ -44,12 +46,21 @@ class EnumBuilder(
             addModifiers(KModifier.SEALED)
             superclass(KtEnum::class)
             addKDoc()
+            addAnnotation()
             handleDeprecation(e.options.default.deprecated, e.options.protokt.deprecationMessage)
             handleDeprecationSuppression(e.hasDeprecation, ctx)
             addConstructor()
             addEnumValues()
             addDeserializer()
         }.build()
+
+    private fun TypeSpec.Builder.addAnnotation() {
+        addAnnotation(
+            AnnotationSpec.builder(KtGeneratedEnum::class)
+                .addMember("fullTypeName = %S", "${ctx.desc.protoPackage}.${e.name}")
+                .build()
+        )
+    }
 
     private fun TypeSpec.Builder.addKDoc() {
         val documentation = baseLocation(ctx, enumPath).cleanDocumentation()

--- a/protokt-core/api/protokt-core.api
+++ b/protokt-core/api/protokt-core.api
@@ -97,6 +97,7 @@ public final class com/toasttab/protokt/EmptyProto {
 public final class com/toasttab/protokt/EnumDescriptor {
 	public fun <init> (Lcom/toasttab/protokt/EnumDescriptorProto;Lcom/toasttab/protokt/FileDescriptor;I)V
 	public final fun getFile ()Lcom/toasttab/protokt/FileDescriptor;
+	public final fun getFullName ()Ljava/lang/String;
 	public final fun getIndex ()I
 	public final fun getProto ()Lcom/toasttab/protokt/EnumDescriptorProto;
 }

--- a/protokt-core/src/main/kotlin/com/toasttab/protokt/Descriptors.kt
+++ b/protokt-core/src/main/kotlin/com/toasttab/protokt/Descriptors.kt
@@ -91,7 +91,9 @@ class EnumDescriptor(
     val proto: EnumDescriptorProto,
     val file: FileDescriptor,
     val index: Int
-)
+) {
+    val fullName = computeFullName(file, null, proto.name.orEmpty())
+}
 
 class ServiceDescriptor(
     val proto: ServiceDescriptorProto,

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedEnum.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedEnum.kt
@@ -1,0 +1,5 @@
+package com.toasttab.protokt.rt
+
+annotation class KtGeneratedEnum(
+    val fullTypeName: String
+)

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedFileDescriptor.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedFileDescriptor.kt
@@ -1,0 +1,7 @@
+package com.toasttab.protokt.rt
+
+annotation class KtGeneratedFileDescriptor(
+    val containedMessages: Array<String>,
+    val containedEnums: Array<String>,
+    val containedServices: Array<String>
+)

--- a/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedService.kt
+++ b/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtGeneratedService.kt
@@ -1,0 +1,5 @@
+package com.toasttab.protokt.rt
+
+annotation class KtGeneratedService(
+    val fullTypeName: String
+)


### PR DESCRIPTION
This should preserve compatibility between lite/non-lite versions and still gives us the info we need