### PR TITLE
Upgrade protobuf-gradle-plugin

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,7 +24,7 @@ object versions {
     const val kotlinxCollections = "0.3.5"
     const val kotlinxCoroutines = "1.6.4"
     const val protobuf = DEFAULT_PROTOBUF_VERSION
-    const val protobufPlugin = "0.9.1"
+    const val protobufPlugin = "0.9.4"
 
     // Test
     const val jackson = "2.13.0"

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -31,8 +31,6 @@ internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, bi
     project.apply(plugin = "com.google.protobuf")
 
     project.configure<ProtobufExtension> {
-        generatedFilesBaseDir = "${project.buildDir}/generated-sources"
-
         configureSources(project, generatedFilesBaseDir)
 
         protoc {


### PR DESCRIPTION
Google no longer wants us setting a custom generated sources folder.