### PR TITLE
Add integration test for wrapper types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,9 @@ workflows:
             parameters:
               jdk: ["8", "11", "17"]
               kotlin: ["1.5.32", "1.6.21", "1.7.20", "1.8.0"]
+            exclude:
+              - jdk: "17"
+                kotlin: "1.5.32"
       - release:
           context: OSS
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,10 +122,7 @@ workflows:
           matrix:
             parameters:
               jdk: ["8", "11", "17"]
-              kotlin: ["1.5.32", "1.6.21", "1.7.20", "1.8.0"]
-            exclude:
-              - jdk: "17"
-                kotlin: "1.5.32"
+              kotlin: ["1.6.21", "1.7.21", "1.8.22"]
       - release:
           context: OSS
           filters:

--- a/buildSrc/src/main/kotlin/Lint.kt
+++ b/buildSrc/src/main/kotlin/Lint.kt
@@ -31,6 +31,7 @@ fun Project.lint() {
             ktlint()
             target("**/*.kt")
             targetExclude("**/generated-sources/**")
+            targetExclude("**/generated/source/**")
         }
 
         kotlinGradle {

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -79,9 +79,11 @@ private fun extraClasspath(project: Project, task: GenerateProtoTask): String {
     // won't pick them up as dependencies unless we do this. There may be a better way to do this but for now just
     // manually do what protobuf-gradle-plugin used to do.
     // https://github.com/google/protobuf-gradle-plugin/commit/0521fe707ccedee7a0b4ce0fb88409eefb04e59d
-    project.tasks.withType<ProtobufExtract>()
-        .filter { it.name.startsWith("extractInclude") }
-        .forEach { it.inputFiles.from(extensions) }
+    project.tasks.withType<ProtobufExtract> {
+        if (name.startsWith("extractInclude")) {
+            inputFiles.from(extensions)
+        }
+    }
 
     return extensions.joinToString(";") { URLEncoder.encode(it.path, "UTF-8") }
 }

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -80,7 +80,7 @@ private fun extraClasspath(project: Project, task: GenerateProtoTask): String {
     // manually do what protobuf-gradle-plugin used to do.
     // https://github.com/google/protobuf-gradle-plugin/commit/0521fe707ccedee7a0b4ce0fb88409eefb04e59d
     project.tasks.withType<ProtobufExtract>().filter { it.name.startsWith("extractInclude") }.forEach {
-        // it.inputFiles.from(extensions)
+        it.inputFiles.from(extensions)
     }
 
     return extensions.joinToString(";") { URLEncoder.encode(it.path, "UTF-8") }

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -17,6 +17,7 @@ package com.toasttab.protokt.gradle
 
 import com.google.protobuf.gradle.GenerateProtoTask
 import com.google.protobuf.gradle.ProtobufExtension
+import com.google.protobuf.gradle.ProtobufExtract
 import com.google.protobuf.gradle.id
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
@@ -25,6 +26,7 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
 import java.net.URLEncoder
 
 internal fun configureProtobufPlugin(project: Project, ext: ProtoktExtension, binaryPath: String) {
@@ -71,6 +73,14 @@ private fun extraClasspath(project: Project, task: GenerateProtoTask): String {
 
     if (task.isTest) {
         extensions += project.configurations.getByName(TEST_EXTENSIONS)
+    }
+
+    // Must explicitly register input files here; if any extensions dependencies are project dependencies then Gradle
+    // won't pick them up as dependencies unless we do this. There may be a better way to do this but for now just
+    // manually do what protobuf-gradle-plugin used to do.
+    // https://github.com/google/protobuf-gradle-plugin/commit/0521fe707ccedee7a0b4ce0fb88409eefb04e59d
+    project.tasks.withType<ProtobufExtract>().filter { it.name.startsWith("extractInclude") }.forEach {
+        // it.inputFiles.from(extensions)
     }
 
     return extensions.joinToString(";") { URLEncoder.encode(it.path, "UTF-8") }

--- a/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
+++ b/buildSrc/src/main/kotlin/com/toasttab/protokt/gradle/ProtobufBuild.kt
@@ -79,9 +79,9 @@ private fun extraClasspath(project: Project, task: GenerateProtoTask): String {
     // won't pick them up as dependencies unless we do this. There may be a better way to do this but for now just
     // manually do what protobuf-gradle-plugin used to do.
     // https://github.com/google/protobuf-gradle-plugin/commit/0521fe707ccedee7a0b4ce0fb88409eefb04e59d
-    project.tasks.withType<ProtobufExtract>().filter { it.name.startsWith("extractInclude") }.forEach {
-        it.inputFiles.from(extensions)
-    }
+    project.tasks.withType<ProtobufExtract>()
+        .filter { it.name.startsWith("extractInclude") }
+        .forEach { it.inputFiles.from(extensions) }
 
     return extensions.joinToString(";") { URLEncoder.encode(it.path, "UTF-8") }
 }

--- a/gradle-plugin-integration-test/build.gradle.kts
+++ b/gradle-plugin-integration-test/build.gradle.kts
@@ -30,7 +30,7 @@ buildscript {
 
     dependencies {
         classpath("com.toasttab.protokt:protokt-gradle-plugin:$version")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${System.getProperty("kotlin.version", "1.4.32")}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${System.getProperty("kotlin.version", "1.5.32")}")
         classpath("com.diffplug.spotless:spotless-plugin-gradle:5.15.0")
     }
 }
@@ -63,7 +63,7 @@ subprojects {
                 apiVersion =
                     System.getProperty("kotlin.version")
                         ?.substringBeforeLast(".")
-                        ?: "1.4"
+                        ?: "1.5"
 
                 languageVersion = apiVersion
             }

--- a/gradle-plugin-integration-test/build.gradle.kts
+++ b/gradle-plugin-integration-test/build.gradle.kts
@@ -30,7 +30,7 @@ buildscript {
 
     dependencies {
         classpath("com.toasttab.protokt:protokt-gradle-plugin:$version")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${System.getProperty("kotlin.version", "1.5.32")}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${System.getProperty("kotlin.version", "1.6.32")}")
         classpath("com.diffplug.spotless:spotless-plugin-gradle:5.15.0")
     }
 }
@@ -63,7 +63,7 @@ subprojects {
                 apiVersion =
                     System.getProperty("kotlin.version")
                         ?.substringBeforeLast(".")
-                        ?: "1.5"
+                        ?: "1.6"
 
                 languageVersion = apiVersion
             }

--- a/gradle-plugin-integration-test/jvm-lite/build.gradle.kts
+++ b/gradle-plugin-integration-test/jvm-lite/build.gradle.kts
@@ -30,6 +30,7 @@ tasks {
 
 dependencies {
     protoktExtensions("com.toasttab.protokt:protokt-extensions-lite:$version")
+    protoktExtensions(project(":wrapper-types"))
 
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.2")

--- a/gradle-plugin-integration-test/jvm-lite/src/main/proto/toasttab/protokt/testing/wrapper_test.proto
+++ b/gradle-plugin-integration-test/jvm-lite/src/main/proto/toasttab/protokt/testing/wrapper_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast Inc.
+ * Copyright (c) 2023 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,14 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
-    }
+syntax = "proto3";
+
+package toasttab.protokt.testing;
+
+option java_package = "com.toasttab.protokt.testing";
+
+import "protokt/protokt.proto";
+
+message WrapperTest {
+  bytes foo = 1 [(.protokt.property).wrap = "Id"];
 }
-
-apply(plugin = "net.vivin.gradle-semantic-build-versioning")
-
-rootProject.name = "gradle-plugin-integration-test"
-
-listOf(
-    "jvm-regular",
-    "jvm-lite",
-    "wrapper-types"
-).forEach { include(it) }

--- a/gradle-plugin-integration-test/wrapper-types/build.gradle.kts
+++ b/gradle-plugin-integration-test/wrapper-types/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast Inc.
+ * Copyright (c) 2023 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,19 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
-    }
+plugins {
+    kotlin("jvm")
+    kotlin("kapt")
 }
 
-apply(plugin = "net.vivin.gradle-semantic-build-versioning")
+dependencies {
+    implementation("com.toasttab.protokt:protokt-core:$version")
+    implementation("com.google.auto.service:auto-service-annotations:1.0.1")
 
-rootProject.name = "gradle-plugin-integration-test"
+    kapt("com.google.auto.service:auto-service:1.0.1")
+}
 
-listOf(
-    "jvm-regular",
-    "jvm-lite",
-    "wrapper-types"
-).forEach { include(it) }
+configure<JavaPluginExtension> {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/gradle-plugin-integration-test/wrapper-types/src/main/kotlin/com/toasttab/protokt/testing/Id.kt
+++ b/gradle-plugin-integration-test/wrapper-types/src/main/kotlin/com/toasttab/protokt/testing/Id.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast Inc.
+ * Copyright (c) 2023 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,22 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
-    }
+package com.toasttab.protokt.testing
+
+import com.google.auto.service.AutoService
+import com.toasttab.protokt.ext.Converter
+
+data class Id(val value: String)
+
+@AutoService(Converter::class)
+object IdConverter : Converter<Id, ByteArray> {
+    override val wrapper = Id::class
+
+    override val wrapped = ByteArray::class
+
+    override fun wrap(unwrapped: ByteArray) =
+        Id(String(unwrapped))
+
+    override fun unwrap(wrapped: Id) =
+        wrapped.value.toByteArray()
 }
-
-apply(plugin = "net.vivin.gradle-semantic-build-versioning")
-
-rootProject.name = "gradle-plugin-integration-test"
-
-listOf(
-    "jvm-regular",
-    "jvm-lite",
-    "wrapper-types"
-).forEach { include(it) }

--- a/protokt-gradle-plugin/build.gradle.kts
+++ b/protokt-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 gradlePlugin {
-    isAutomatedPublishing = true
+    isAutomatedPublishing = false
 
     plugins {
         create("protokt") {

--- a/protokt-gradle-plugin/build.gradle.kts
+++ b/protokt-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 gradlePlugin {
-    isAutomatedPublishing = false
+    isAutomatedPublishing = true
 
     plugins {
         create("protokt") {


### PR DESCRIPTION
Fixes problem where `protoktExtensions` dependencies no longer create a task dependency within a project to create a JAR needed by subsequent protobuf generation.