### PR TITLE
fix tags in codegen for large field numbers

### DIFF
--- a/buildSrc/src/main/kotlin/protokt.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/protokt.spotless-conventions.gradle.kts
@@ -78,7 +78,10 @@ allprojects {
                     "examples/protos/src/main/proto/io/grpc/examples/route_guide.proto",
                     "testing/conformance/driver/src/main/proto/conformance/conformance.proto",
                     "testing/conformance/driver/src/main/proto/proto3/test_messages_proto3.proto",
-                    "testing/interop/src/main/proto/tutorial/addressbook.proto"
+                    "testing/interop/src/main/proto/tutorial/addressbook.proto",
+                    "testing/interop/src/main/proto/google/protobuf/unittest_import.proto",
+                    "testing/interop/src/main/proto/google/protobuf/unittest_import_public.proto",
+                    "testing/interop/src/main/proto/google/protobuf/unittest_proto3.proto",
                 ).map(rootProject::file) +
                     "node_modules/**" +
                     "**/build/extracted-include-protos/**" +

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/CodeGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/CodeGenerator.kt
@@ -35,11 +35,7 @@ object CodeGenerator {
 
     fun generate(contents: ProtoFileContents) =
         contents.types.flatMap {
-            generate(
-                it,
-                Context(emptyList(), contents.info)
-            )
-                .map { type -> GeneratedType(it, type) }
+            generate(it, Context(emptyList(), contents.info)).map(::GeneratedType)
         }
 
     fun generate(type: TopLevelType, ctx: Context): Iterable<TypeSpec> =

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/DeserializerGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/DeserializerGenerator.kt
@@ -83,7 +83,7 @@ private class DeserializerGenerator(
                     beginControlFlow("when (deserializer.readTag())")
                     val constructor =
                         buildCodeBlock {
-                            add("0·->·return·%T(\n", msg.className)
+                            add("0u·->·return·%T(\n", msg.className)
                             withIndent {
                                 constructorLines(properties).forEach(::add)
                             }
@@ -92,7 +92,7 @@ private class DeserializerGenerator(
                     addStatement("%L", constructor)
                     deserializerInfo.forEach {
                         addStatement(
-                            "%L -> %N = %L",
+                            "%Lu -> %N = %L",
                             it.tag,
                             it.fieldName,
                             it.value
@@ -156,7 +156,7 @@ private class DeserializerGenerator(
             CodeBlock.of("%T.from(unknownFields)", UnknownFieldSet::class)
 
     private class DeserializerInfo(
-        val tag: Int,
+        val tag: UInt,
         val fieldName: String,
         val value: CodeBlock
     )

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MapEntryGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MapEntryGenerator.kt
@@ -135,11 +135,11 @@ private class MapEntryGenerator(
                         beginControlFlow("when (deserializer.readTag())")
                         addStatement("%L", constructOnZero(value))
                         addStatement(
-                            "${key.tag.value} -> key = %L",
+                            "${key.tag.value}u -> key = %L",
                             deserialize(key, ctx)
                         )
                         addStatement(
-                            "${value.tag.value} -> value = %L",
+                            "${value.tag.value}u -> value = %L",
                             deserialize(value, ctx)
                         )
                         endControlFlow()
@@ -170,7 +170,7 @@ private class MapEntryGenerator(
 
     private fun constructOnZero(f: StandardField) =
         buildCodeBlock {
-            add("0 -> return %T(key, value", msg.className)
+            add("0u -> return %T(key, value", msg.className)
             if (f.type == FieldType.Message) {
                 add(" ?: %T{}", value.className)
             }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/Types.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/Types.kt
@@ -166,11 +166,10 @@ class ProtoFileContents(
 )
 
 class GeneratedType(
-    val rawType: TopLevelType,
     val typeSpec: TypeSpec
 )
 
-sealed class Tag(val value: Int) : Comparable<Tag> {
+sealed class Tag(val value: UInt) : Comparable<Tag> {
     class Packed(
         number: Int
     ) : Tag(computeTag(number, 2))
@@ -188,4 +187,4 @@ sealed class Tag(val value: Int) : Comparable<Tag> {
 }
 
 private fun computeTag(fieldNumber: Int, wireType: Int) =
-    (fieldNumber shl 3) or wireType
+    (fieldNumber shl 3).toUInt() or wireType.toUInt()

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -595,7 +595,7 @@ public abstract interface class protokt/v1/KtMessageDeserializer {
 	public abstract fun readSInt32 ()I
 	public abstract fun readSInt64 ()J
 	public abstract fun readString ()Ljava/lang/String;
-	public abstract fun readTag ()I
+	public abstract fun readTag-pVg5ArA ()I
 	public fun readUInt32-pVg5ArA ()I
 	public abstract fun readUInt64-s-VKNKU ()J
 	public abstract fun readUnknown ()Lprotokt/v1/UnknownField;

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/KtMessageDeserializer.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/KtMessageDeserializer.kt
@@ -29,7 +29,7 @@ interface KtMessageDeserializer {
     fun readSInt64(): Long
     fun readString(): String
     fun readUInt64(): ULong
-    fun readTag(): Int
+    fun readTag(): UInt
     fun readUnknown(): UnknownField
     fun readRepeated(packed: Boolean, acc: KtMessageDeserializer.() -> Unit)
     fun <T : KtMessage> readMessage(m: KtDeserializer<T>): T

--- a/protokt-runtime/src/jsMain/kotlin/protokt/v1/JsKtMessageDeserializer.kt
+++ b/protokt-runtime/src/jsMain/kotlin/protokt/v1/JsKtMessageDeserializer.kt
@@ -17,7 +17,7 @@ package protokt.v1
 
 internal fun deserializer(reader: Reader): KtMessageDeserializer {
     return object : KtMessageDeserializer {
-        var lastTag = 0
+        var lastTag = 0u
         var endPosition = reader.len
 
         override fun readDouble() =
@@ -53,14 +53,14 @@ internal fun deserializer(reader: Reader): KtMessageDeserializer {
         override fun readUInt64() =
             Long.fromProtobufJsLong(reader.uint64()).toULong()
 
-        override fun readTag(): Int {
+        override fun readTag(): UInt {
             lastTag =
                 if (reader.pos == endPosition) {
-                    0
+                    0u
                 } else {
                     val tag = readInt32()
                     check(tag ushr 3 != 0) { "Invalid tag" }
-                    tag
+                    tag.toUInt()
                 }
             return lastTag
         }
@@ -73,7 +73,7 @@ internal fun deserializer(reader: Reader): KtMessageDeserializer {
             readBytes().toBytesSlice()
 
         override fun readUnknown(): UnknownField {
-            val fieldNumber = (lastTag ushr 3).toUInt()
+            val fieldNumber = (lastTag.toInt() ushr 3).toUInt()
 
             return when (tagWireType(lastTag)) {
                 0 -> UnknownField.varint(fieldNumber, readInt64())
@@ -115,5 +115,5 @@ internal fun deserializer(reader: Reader): KtMessageDeserializer {
     }
 }
 
-private fun tagWireType(tag: Int) =
-    tag and ((1 shl 3) - 1)
+private fun tagWireType(tag: UInt) =
+    tag.toInt() and ((1 shl 3) - 1)

--- a/protokt-runtime/src/jvmMain/kotlin/com/toasttab/protokt/rt/KtGeneratedMessage.kt
+++ b/protokt-runtime/src/jvmMain/kotlin/com/toasttab/protokt/rt/KtGeneratedMessage.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt.rt
 
+@Deprecated("use v1")
 @Target(AnnotationTarget.CLASS)
 annotation class KtGeneratedMessage(
     /**

--- a/protokt-runtime/src/jvmMain/kotlin/protokt/v1/JvmKtMessageDeserializer.kt
+++ b/protokt-runtime/src/jvmMain/kotlin/protokt/v1/JvmKtMessageDeserializer.kt
@@ -58,7 +58,7 @@ internal fun deserializer(
             stream.readUInt64().toULong()
 
         override fun readTag() =
-            stream.readTag()
+            stream.readTag().toUInt()
 
         override fun readBytes() =
             Bytes(stream.readByteArray())

--- a/testing/interop/src/main/proto/google/protobuf/unittest_import.proto
+++ b/testing/interop/src/main/proto/google/protobuf/unittest_import.proto
@@ -1,0 +1,49 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which is imported by unittest.proto to test importing.
+
+syntax = "proto2";
+
+// We don't put this in a package within proto2 because we need to make sure
+// that the generated code doesn't depend on being in the proto2 namespace.
+// In test_util.h we do
+// "using namespace unittest_import = protobuf_unittest_import".
+package protobuf_unittest_import;
+
+option optimize_for = SPEED;
+option cc_enable_arenas = true;
+
+// Exercise the java_package option.
+option java_package = "com.google.protobuf.test";
+
+// Do not set a java_outer_classname here to verify that Proto2 works without
+// one.
+
+// Test public import
+import public "google/protobuf/unittest_import_public.proto";
+
+message ImportMessage {
+  optional int32 d = 1;
+}
+
+enum ImportEnum {
+  IMPORT_FOO = 7;
+  IMPORT_BAR = 8;
+  IMPORT_BAZ = 9;
+}
+
+// To use an enum in a map, it must has the first value as 0.
+enum ImportEnumForMap {
+  UNKNOWN = 0;
+  FOO = 1;
+  BAR = 2;
+}

--- a/testing/interop/src/main/proto/google/protobuf/unittest_import_public.proto
+++ b/testing/interop/src/main/proto/google/protobuf/unittest_import_public.proto
@@ -1,0 +1,18 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// Author: liujisi@google.com (Pherl Liu)
+
+syntax = "proto2";
+
+package protobuf_unittest_import;
+
+option java_package = "com.google.protobuf.test";
+
+message PublicImportMessage {
+  optional int32 e = 1;
+}

--- a/testing/interop/src/main/proto/google/protobuf/unittest_proto3.proto
+++ b/testing/interop/src/main/proto/google/protobuf/unittest_proto3.proto
@@ -1,0 +1,206 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+syntax = "proto3";
+
+package proto3_unittest;
+
+import "google/protobuf/unittest_import.proto";
+
+option optimize_for = SPEED;
+
+// This proto includes every type of field in both singular and repeated
+// forms.
+message TestAllTypes {
+  message NestedMessage {
+    // The field name "b" fails to compile in proto1 because it conflicts with
+    // a local variable named "b" in one of the generated methods.  Doh.
+    // This file needs to compile in proto1 to test backwards-compatibility.
+    int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    ZERO = 0;
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+    NEG = -1;  // Intentionally negative.
+  }
+
+  // Singular
+  int32 optional_int32 = 1;
+  int64 optional_int64 = 2;
+  uint32 optional_uint32 = 3;
+  uint64 optional_uint64 = 4;
+  sint32 optional_sint32 = 5;
+  sint64 optional_sint64 = 6;
+  fixed32 optional_fixed32 = 7;
+  fixed64 optional_fixed64 = 8;
+  sfixed32 optional_sfixed32 = 9;
+  sfixed64 optional_sfixed64 = 10;
+  float optional_float = 11;
+  double optional_double = 12;
+  bool optional_bool = 13;
+  string optional_string = 14;
+  bytes optional_bytes = 15;
+
+  // Groups are not allowed in proto3.
+  // optional group OptionalGroup = 16 {
+  //   optional int32 a = 17;
+  // }
+
+  optional NestedMessage optional_nested_message = 18;
+  ForeignMessage optional_foreign_message = 19;
+  protobuf_unittest_import.ImportMessage optional_import_message = 20;
+
+  NestedEnum optional_nested_enum = 21;
+  ForeignEnum optional_foreign_enum = 22;
+
+  // Omitted (compared to unittest.proto) because proto2 enums are not allowed
+  // inside proto2 messages.
+  //
+  // optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
+
+  string optional_string_piece = 24 [ctype = STRING_PIECE];
+  string optional_cord = 25 [ctype = CORD];
+
+  // Defined in unittest_import_public.proto
+  protobuf_unittest_import.PublicImportMessage optional_public_import_message =
+      26;
+
+  NestedMessage optional_lazy_message = 27 [lazy = true];
+  NestedMessage optional_unverified_lazy_message = 28 [unverified_lazy = true];
+  protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115
+  [lazy = true];
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+
+  // Groups are not allowed in proto3.
+  // repeated group RepeatedGroup = 46 {
+  //   optional int32 a = 47;
+  // }
+
+  repeated NestedMessage repeated_nested_message = 48;
+  repeated ForeignMessage repeated_foreign_message = 49;
+  repeated protobuf_unittest_import.ImportMessage repeated_import_message = 50;
+
+  repeated NestedEnum repeated_nested_enum = 51;
+  repeated ForeignEnum repeated_foreign_enum = 52;
+
+  // Omitted (compared to unittest.proto) because proto2 enums are not allowed
+  // inside proto2 messages.
+  //
+  // repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
+
+  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 55 [ctype = CORD];
+
+  repeated NestedMessage repeated_lazy_message = 57 [lazy = true];
+
+  oneof oneof_field {
+    uint32 oneof_uint32 = 111;
+    NestedMessage oneof_nested_message = 112;
+    string oneof_string = 113;
+    bytes oneof_bytes = 114;
+  }
+}
+
+// Test messages for packed fields
+
+message TestPackedTypes {
+  repeated int32 packed_int32 = 90 [packed = true];
+  repeated int64 packed_int64 = 91 [packed = true];
+  repeated uint32 packed_uint32 = 92 [packed = true];
+  repeated uint64 packed_uint64 = 93 [packed = true];
+  repeated sint32 packed_sint32 = 94 [packed = true];
+  repeated sint64 packed_sint64 = 95 [packed = true];
+  repeated fixed32 packed_fixed32 = 96 [packed = true];
+  repeated fixed64 packed_fixed64 = 97 [packed = true];
+  repeated sfixed32 packed_sfixed32 = 98 [packed = true];
+  repeated sfixed64 packed_sfixed64 = 99 [packed = true];
+  repeated float packed_float = 100 [packed = true];
+  repeated double packed_double = 101 [packed = true];
+  repeated bool packed_bool = 102 [packed = true];
+  repeated ForeignEnum packed_enum = 103 [packed = true];
+}
+
+// Explicitly set packed to false
+message TestUnpackedTypes {
+  repeated int32 repeated_int32 = 1 [packed = false];
+  repeated int64 repeated_int64 = 2 [packed = false];
+  repeated uint32 repeated_uint32 = 3 [packed = false];
+  repeated uint64 repeated_uint64 = 4 [packed = false];
+  repeated sint32 repeated_sint32 = 5 [packed = false];
+  repeated sint64 repeated_sint64 = 6 [packed = false];
+  repeated fixed32 repeated_fixed32 = 7 [packed = false];
+  repeated fixed64 repeated_fixed64 = 8 [packed = false];
+  repeated sfixed32 repeated_sfixed32 = 9 [packed = false];
+  repeated sfixed64 repeated_sfixed64 = 10 [packed = false];
+  repeated float repeated_float = 11 [packed = false];
+  repeated double repeated_double = 12 [packed = false];
+  repeated bool repeated_bool = 13 [packed = false];
+  repeated TestAllTypes.NestedEnum repeated_nested_enum = 14 [packed = false];
+}
+
+// This proto includes a recursively nested message.
+message NestedTestAllTypes {
+  NestedTestAllTypes child = 1;
+  TestAllTypes payload = 2;
+}
+
+// Define these after TestAllTypes to make sure the compiler can handle
+// that.
+message ForeignMessage {
+  int32 c = 1;
+}
+
+enum ForeignEnum {
+  FOREIGN_ZERO = 0;
+  FOREIGN_FOO = 4;
+  FOREIGN_BAR = 5;
+  FOREIGN_BAZ = 6;
+}
+
+// TestEmptyMessage is used to test behavior of unknown fields.
+message TestEmptyMessage {}
+
+// TestMessageWithDummy is also used to test behavior of unknown fields.
+message TestMessageWithDummy {
+  // This field is only here for triggering copy-on-write; it's not intended to
+  // be serialized.
+  bool dummy = 536870911;
+}
+
+// Same layout as TestOneof2 in unittest.proto to test unknown enum value
+// parsing behavior in oneof.
+message TestOneof2 {
+  oneof foo {
+    NestedEnum foo_enum = 6;
+  }
+
+  enum NestedEnum {
+    UNKNOWN = 0;
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+  }
+}


### PR DESCRIPTION
They need to be unsigned in order to be literals.