### PR TITLE
Update build badge, update kotlin in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        kotlin: [ 1.8.22, 1.9.20 ]
+        kotlin: [ 1.8.22, 1.9.23 ]
         jdk: [ 11, 17 ]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # protokt 
 
-[![CircleCI](https://circleci.com/gh/open-toast/protokt.svg?style=svg)](https://circleci.com/gh/open-toast/protokt)
+[![Github Actions](https://github.com/open-toast/protokt/actions/workflows/ci.yml/badge.svg)](https://github.com/open-toast/protokt/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/com.toasttab.protokt/protokt-runtime)](https://search.maven.org/artifact/com.toasttab.protokt/protokt-runtime)
 [![Gradle Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/toasttab/protokt/protokt-gradle-plugin/maven-metadata.xml.svg?label=gradle-portal&color=yellowgreen)](https://plugins.gradle.org/plugin/com.toasttab.protokt)
 

--- a/buildSrc/src/main/kotlin/LocalProtoktBuild.kt
+++ b/buildSrc/src/main/kotlin/LocalProtoktBuild.kt
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
+import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import protokt.v1.gradle.CODEGEN_NAME
 import protokt.v1.gradle.configureProtokt
 import java.io.File
@@ -53,6 +54,10 @@ fun KotlinJsTargetDsl.configureJsTests() {
         testTask {
             useKarma {
                 useFirefoxHeadless()
+
+                if (System.getProperty("os.name").lowercase().contains("mac")) {
+                    environment["FIREFOX_BIN"] = "/Applications/Firefox.app/Contents/MacOS/firefox"
+                }
             }
         }
     }

--- a/buildSrc/src/main/kotlin/LocalProtoktBuild.kt
+++ b/buildSrc/src/main/kotlin/LocalProtoktBuild.kt
@@ -19,7 +19,6 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
-import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import protokt.v1.gradle.CODEGEN_NAME
 import protokt.v1.gradle.configureProtokt
 import java.io.File

--- a/gradle-plugin-integration-test/multiplatform/build.gradle.kts
+++ b/gradle-plugin-integration-test/multiplatform/build.gradle.kts
@@ -31,6 +31,10 @@ kotlin {
             testTask {
                 useKarma {
                     useFirefoxHeadless()
+
+                    if (System.getProperty("os.name").lowercase().contains("mac")) {
+                        environment["FIREFOX_BIN"] = "/Applications/Firefox.app/Contents/MacOS/firefox"
+                    }
                 }
             }
         }
@@ -73,8 +77,10 @@ kotlin {
         all {
             compilations.all {
                 kotlinOptions {
-                    languageVersion = "1.8"
-                    apiVersion = "1.8"
+                    languageVersion = System.getProperty("kotlin-integration.version")
+                        ?.substringBeforeLast(".")
+                        ?: libs.versions.kotlin.get().substringBeforeLast(".")
+                    apiVersion = languageVersion
                 }
             }
         }


### PR DESCRIPTION
* Bump Kotlin 1.9 used in integration tests to 1.9.23
* Update the build badge
* Explicitly set FIREFOX_BIN for browser tests on MacOs 