### PR TITLE
Discourage `+` string concatenation from FileDescriptors

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileDescriptorResolver.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileDescriptorResolver.kt
@@ -78,14 +78,14 @@ private constructor(
         return FileDescriptorInfo(type, properties)
     }
 
-    private fun descriptorLines() =
-        fileDescriptorParts()
-            .map { arrayParts ->
-                arrayParts
-                    .map { CodeBlock.of("\"%L\"", it) }
-                    .joinToCode(" +\n")
-            }
-            .joinToCode(",\n")
+    private fun descriptorLines(): CodeBlock {
+        return fileDescriptorParts().map { arrayParts ->
+            val sb = StringBuilder()
+            arrayParts
+                .forEach { sb.append(it) }
+            CodeBlock.of("\"%L\"", sb.toString().bindSpaces())
+        }.joinToCode(",\n")
+    }
 
     private fun fileDescriptorParts() =
         encodeFileDescriptor(


### PR DESCRIPTION
## Why? ##

Due to a bug in the Kotlin Compiler, there's a high chance of stack overflow with protos medium+ sized protos (example tested: 1 service, ~20 RPCs, ~45 messages). When concatenating using the `+` operator in Kotlin, [the complier can throw a stack overflow exception when generating the bytecode](https://youtrack.jetbrains.com/issue/KT-1858/Stackoverflow-while-analyzing-on-very-deeply-nested-binary-expression.).

## What changed? ##

This change is simple: it just makes the file descriptors into one long string rather than generating a broken string with `+` concatenation operators. This allows for larger protos before hitting a stack overflow exception. 

## Testing ##

All existing tests pass, including tests that validate descriptors match between ProtoKt and protobuf-java. Manual testing was conducted locally to verify that the proto that originally exposed this issue still caused a stack overflow on a branch without this change, but does not with this change

### What about a test to capture a large proto? ###

One is written [here](https://github.com/seanreid-toast/protokt/compare/main...seanreid-toast:protokt:very_large_proto_test?expand=1). It has a new proto with a single message that has 319 string fields. 319 is one more than the maximum that works on my machine (macos 14.3, intel, amazon corretto 11.0.9.11.1) without causing another stack overflow in the compiler.

The number of fields needed to produce a string long enough to cause automatic rollover into a second line that requires concatenation is ~900-1000. So the point at which line wrapping is significantly larger than what seems to currently overflow the compiler stack. The branch linked above can be used to demonstrate this behavior.