### PR TITLE
Pin macos runner to 14 / intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-14 ]
         kotlin: [ 1.8.22, 1.9.23 ]
         jdk: [ 11, 17 ]
 


### PR DESCRIPTION
macos-latest, aka macos-14-arm does not ship with Firefox