### PR TITLE
Fix method name capitalization inconsistency with protobuf-java

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
@@ -43,6 +43,7 @@ import io.grpc.kotlin.AbstractCoroutineServerImpl
 import io.grpc.kotlin.AbstractCoroutineStub
 import io.grpc.kotlin.ClientCalls
 import io.grpc.kotlin.ServerCalls
+import io.grpc.kotlin.generator.protoc.ProtoMethodName
 import kotlinx.coroutines.flow.Flow
 import protokt.v1.codegen.generate.CodeGenerator.Context
 import protokt.v1.codegen.util.KotlinPlugin
@@ -68,13 +69,27 @@ private class ServiceGenerator(
     fun generate(): List<TypeSpec> =
         (grpcImplementations() + serviceDescriptor()).filterNotNull()
 
+    private fun ProtoMethodName.withMethodSuffix() =
+        toMemberSimpleName().withSuffix("Method")
+
+    private val ProtoMethodName.decapitalizedMethod
+        get() = withMethodSuffix().name.decapitalize()
+
+    private val ProtoMethodName.decapitalized
+        get() = toMemberSimpleName().name.decapitalize()
+
     private fun grpcImplementations(): List<TypeSpec> =
         if (supportedPlugin()) {
             val getMethodFunctions =
                 s.methods.map { method ->
-                    buildFunSpec("get" + method.name + "Method") {
+                    buildFunSpec(
+                        method.name
+                            .withMethodSuffix()
+                            .withPrefix("get")
+                            .name
+                    ) {
                         returns(pivotClassName(MethodDescriptor::class).parameterizedBy(method.inputType, method.outputType))
-                        addCode("return _" + method.name.decapitalize() + "Method")
+                        addCode("return _${method.name.decapitalizedMethod}")
                         staticIfAppropriate()
                     }
                 }
@@ -156,7 +171,7 @@ private class ServiceGenerator(
         addProperties(
             s.methods.map { method ->
                 PropertySpec.builder(
-                    "_" + method.name.decapitalize() + "Method",
+                    "_${method.name.decapitalizedMethod}",
                     pivotClassName(MethodDescriptor::class).parameterizedBy(method.inputType, method.outputType)
                 )
                     .addModifiers(KModifier.PRIVATE)
@@ -221,7 +236,7 @@ private class ServiceGenerator(
 
     private fun serverImplementations() =
         s.methods.map { method ->
-            buildFunSpec(method.name.replaceFirstChar { it.lowercase() }) {
+            buildFunSpec(method.name.decapitalized) {
                 addModifiers(KModifier.OPEN)
                 when (methodType(method)) {
                     MethodType.CLIENT_STREAMING, MethodType.UNARY ->
@@ -338,7 +353,7 @@ private class ServiceGenerator(
         getMethodFunctions: List<FunSpec>
     ) =
         s.methods.mapIndexed { idx, method ->
-            buildFunSpec(method.name.replaceFirstChar { it.lowercase() }) {
+            buildFunSpec(method.name.decapitalized) {
                 when (methodType(method)) {
                     MethodType.CLIENT_STREAMING, MethodType.UNARY ->
                         addModifiers(KModifier.SUSPEND)
@@ -431,7 +446,7 @@ private class ServiceGenerator(
 
     private fun serviceLines(ctx: Context) =
         s.methods.map {
-            CodeBlock.of(".addMethod(_${it.name.decapitalize()}Method)\n")
+            CodeBlock.of(".addMethod(_${it.name.decapitalizedMethod})\n")
         } +
             if (pivotPlugin(jvm = true, js = false)) {
                 CodeBlock.of(

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/ServiceParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/ServiceParser.kt
@@ -19,6 +19,7 @@ import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto
 import com.squareup.kotlinpoet.ClassName
 import com.toasttab.protokt.v1.ProtoktProtos
+import io.grpc.kotlin.generator.protoc.ProtoMethodName
 import protokt.v1.reflect.requalifyProtoType
 
 class ServiceParser(
@@ -39,7 +40,7 @@ class ServiceParser(
 
     private fun toMethod(desc: MethodDescriptorProto) =
         Method(
-            name = desc.name,
+            name = ProtoMethodName(desc.name),
             inputType = ClassName.bestGuess(requalifyProtoType(desc.inputType)),
             outputType = ClassName.bestGuess(requalifyProtoType(desc.outputType)),
             clientStreaming = desc.clientStreaming,

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/Types.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/Types.kt
@@ -19,6 +19,7 @@ import com.google.protobuf.DescriptorProtos
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 import com.toasttab.protokt.v1.ProtoktProtos
+import io.grpc.kotlin.generator.protoc.ProtoMethodName
 import protokt.v1.reflect.FieldType
 
 sealed class TopLevelType
@@ -79,7 +80,7 @@ class ServiceOptions(
 )
 
 class Method(
-    val name: String,
+    val name: ProtoMethodName,
     val inputType: ClassName,
     val outputType: ClassName,
     val clientStreaming: Boolean,

--- a/testing/protokt-generation/build.gradle.kts
+++ b/testing/protokt-generation/build.gradle.kts
@@ -27,6 +27,7 @@ protokt {
         types = true
         descriptors = true
         grpcDescriptors = true
+        grpcKotlinStubs = true
     }
 }
 
@@ -34,6 +35,7 @@ dependencies {
     implementation(kotlin("reflect"))
     implementation(project(":protokt-runtime-grpc"))
     implementation(project(":testing:protobuf-java"))
+    implementation(libs.grpc.kotlin.stub)
     implementation(libs.grpc.stub)
 
     testImplementation(libs.jackson)

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/poor_naming_conventions.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/poor_naming_conventions.proto
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.v1.testing;
+
+import "google/protobuf/empty.proto";
+
+service Greeter {
+  // Lower case initial 's'
+  rpc sayHello (google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}


### PR DESCRIPTION
Use `grpc-kotlin`'s naming utilities for gRPC method names. I'll port the other name generators eventually as well.

Fixes #284.