### PR TITLE
Fix property naming inconsistency with protobuf-java

### DIFF
--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/PoorNamingConventionsTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/PoorNamingConventionsTest.kt
@@ -13,17 +13,16 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
+package protokt.v1.testing
 
-package protokt.v1.testing;
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
 
-import "google/protobuf/empty.proto";
-
-service Greeter {
-  // Lower case initial 's'
-  rpc sayHello (google.protobuf.Empty) returns (google.protobuf.Empty) {}
-}
-
-message BadFieldName {
-  string fooBar = 1;
+class PoorNamingConventionsTest {
+    @Test
+    fun `camel case proto name matches protobuf-java convention`() {
+        val foo = BadFieldName { fooBar = "foobar" }
+        assertThat(foo.fooBar).isEqualTo("foobar")
+        assertThat(BadFieldName::class.propertyNamed("fooBar")).isNotNull()
+    }
 }


### PR DESCRIPTION
Name properties equivalently to how protobuf-java names them. Unfortunately the grpc-kotlin utility for this is broken.

Fixes #286.