### PR TITLE
Forbid usage of non-null option on fields used for interface delegation

### DIFF
--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/ImplementDelegationTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/ImplementDelegationTest.kt
@@ -15,12 +15,16 @@
 
 package protokt.v1.codegen
 
+import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 class ImplementDelegationTest : AbstractProtoktCodegenTest() {
     @Test
     fun `delegate to interface with non-null property`() {
-        runPlugin("implement_by_delegate_with_non_null_property.proto").orFail()
+        val result = runPlugin("implement_by_delegate_with_non_null_property.proto") as Failure
+
+        assertThat(result.err)
+            .contains("Delegated properties must be nullable because message types are nullable; property id is non-nullable")
     }
 }
 

--- a/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
@@ -38,9 +38,7 @@ message ImplementsModel2 {
 message ImplementsWithDelegate {
   option (.protokt.v1.class).implements = "IModel2 by modelTwo";
 
-  ImplementsModel2 model_two = 1 [
-    (.protokt.v1.property).non_null = true
-  ];
+  ImplementsModel2 model_two = 1;
 }
 
 message ImplementsWithNullableDelegate {


### PR DESCRIPTION
https://github.com/open-toast/protokt/pull/281 changed generated code to delegate each field of a delegated interface to be explicitly accessed since you cannot delegate with `implements Foo by bar` if `bar` is nullable. We needed to delegate each property of `Foo` to `bar?.baz` instead.

This PR goes one step fu