### PR TITLE
Always pass `java_multiple_files = true` to grpc-kotlin generator

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GrpcKotlinGeneratorSupport.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GrpcKotlinGeneratorSupport.kt
@@ -46,6 +46,7 @@ private fun stripPackages(request: CodeGeneratorRequest) =
                     .setOptions(
                         fdp.options.toBuilder()
                             .setJavaPackage(resolvePackage(fdp.`package`))
+                            .setJavaMultipleFiles(true)
                             .build()
                     )
                     .build()

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_false.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_false.proto
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.v1.testing;
+
+service TestService2 {
+  rpc SayHello (TestRequest2) returns (TestReply2) {}
+}
+
+message TestRequest2 {
+  string message = 1;
+}
+
+message TestReply2 {
+  string message = 1;
+}

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_false.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_false.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Toast, Inc.
+ * Copyright (c) 2024 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_true.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_true.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Toast, Inc.
+ * Copyright (c) 2024 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_true.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/service_with_java_multiple_files_true.proto
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+
+package protokt.v1.testing;
+
+service TestService3 {
+  rpc SayHello (TestRequest3) returns (TestReply3) {}
+}
+
+message TestRequest3 {
+  string message = 1;
+}
+
+message TestReply3 {
+  string message = 1;
+}


### PR DESCRIPTION
Fixes #285.