### PR TITLE
Validate message delegation does not break serialization

### DIFF
--- a/testing/options-api/src/main/kotlin/protokt/v1/testing/IModel3.kt
+++ b/testing/options-api/src/main/kotlin/protokt/v1/testing/IModel3.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import protokt.v1.Message
+
+interface IModel3 : Message {
+    val id: String?
+}

--- a/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
@@ -48,3 +48,23 @@ message ImplementsWithNullableDelegate {
 
   ImplementsModel2 model_two = 1;
 }
+
+message ImplementsWithDelegate2 {
+  option (.protokt.v1.class).implements = "IModel3 by modelThree";
+
+  ImplementsModel3 model_three = 1 [
+    (.protokt.v1.property).generate_non_null_accessor = true
+  ];
+}
+
+message ImplementsWithNullableDelegate2 {
+  option (.protokt.v1.class).implements = "IModel3 by modelThree";
+
+  ImplementsModel3 model_three = 1;
+}
+
+message ImplementsModel3 {
+  option (.protokt.v1.class).implements = "IModel3";
+
+  string id = 1;
+}

--- a/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 class MessageImplementsTest {
     private val model = ImplementsModel { id = Id("asdf") }
     private val model2 = ImplementsModel2 { id = "asdf" }
+    private val model3 = ImplementsModel3 { id = "asdf" }
 
     @Test
     fun `message with wrapped field can be assigned to its interface`() {
@@ -65,6 +66,38 @@ class MessageImplementsTest {
         val serialized = byDelegate.serialize()
 
         assertThat(serialized.size).isGreaterThan(model2.messageSize())
-        assertThat(ImplementsWithDelegate.deserialize(serialized)).isEqualTo(byDelegate)
+        assertThat(ImplementsWithNullableDelegate.deserialize(serialized)).isEqualTo(byDelegate)
+    }
+
+    @Test
+    fun `message implementing message extender by a delegate can be assigned to its interface`() {
+        val byDelegate: IModel3 = ImplementsWithDelegate2 { modelThree = model3 }
+
+        assertThat(byDelegate.id).isEqualTo(model3.id)
+    }
+
+    @Test
+    fun `message implementing message extender by a delegate can serialized and deserialized`() {
+        val byDelegate = ImplementsWithDelegate2 { modelThree = model3 }
+        val serialized = byDelegate.serialize()
+
+        assertThat(serialized.size).isGreaterThan(model3.messageSize())
+        assertThat(ImplementsWithDelegate2.deserialize(serialized)).isEqualTo(byDelegate)
+    }
+
+    @Test
+    fun `message implementing message extender by a nullable delegate can be assigned to its interface`() {
+        val byDelegate: IModel3 = ImplementsWithNullableDelegate2 { modelThree = model3 }
+
+        assertThat(byDelegate.id).isEqualTo(model3.id)
+    }
+
+    @Test
+    fun `message implementing message extender by a nullable delegate can serialized and deserialized`() {
+        val byDelegate = ImplementsWithNullableDelegate2 { modelThree = model3 }
+        val serialized = byDelegate.serialize()
+
+        assertThat(serialized.size).isGreaterThan(model3.messageSize())
+        assertThat(ImplementsWithNullableDelegate2.deserialize(serialized)).isEqualTo(byDelegate)
     }
 }

--- a/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
@@ -44,9 +44,27 @@ class MessageImplementsTest {
     }
 
     @Test
+    fun `message implementing by a delegate can serialized and deserialized`() {
+        val byDelegate = ImplementsWithDelegate { modelTwo = model2 }
+        val serialized = byDelegate.serialize()
+
+        assertThat(serialized.size).isGreaterThan(model2.messageSize())
+        assertThat(ImplementsWithDelegate.deserialize(serialized)).isEqualTo(byDelegate)
+    }
+
+    @Test
     fun `message implementing by a nullable delegate can be assigned to its interface`() {
         val byDelegate: IModel2 = ImplementsWithNullableDelegate { modelTwo = model2 }
 
         assertThat(byDelegate.id).isEqualTo(model2.id)
+    }
+
+    @Test
+    fun `message implementing by a nullable delegate can serialized and deserialized`() {
+        val byDelegate = ImplementsWithNullableDelegate { modelTwo = model2 }
+        val serialized = byDelegate.serialize()
+
+        assertThat(serialized.size).isGreaterThan(model2.messageSize())
+        assertThat(ImplementsWithDelegate.deserialize(serialized)).isEqualTo(byDelegate)
     }
 }


### PR DESCRIPTION
This was fixed when we changed implementation by "delegation" to manually delegate each property. Fixes #288. The later tests (of the model extending Message) do fail when added to 0.12.1.