### PR TITLE
Final updates to runtime and codegen fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supports only version 3 of the Protocol Buffers language.
 
 ### Features
 - Idiomatic and concise [Kotlin builder DSL](#generated-code)
-- Protokt-specific options: [non-null types (dangerous)](#non-null-fields),
+- Protokt-specific options: [non-null accessors](#non-null-accessors),
 [wrapper types](#wrapper-types),
 [interface implementation](#interface-implementation),
 and more
@@ -636,8 +636,9 @@ dependencies {
 ```
 
 Wrapper types that wrap protobuf messages are nullable. For example,
-`java.time.Instant` wraps the well-known type `google.protobuf.Timestamp`. They
-can be made non-nullable by using the non-null option described below.
+`java.time.Instant` wraps the well-known type `google.protobuf.Timestamp`. You 
+can generate non-null accessors with the `generate_non_null_accessor` option
+described below.
 
 Wrapper types that wrap protobuf primitives, for example `java.util.UUID`
 which wraps `bytes`, are nullable when they cannot wrap their wrapped type's
@@ -659,7 +660,8 @@ google.protobuf.BytesValue nullable_uuid = 3 [
 ];
 ```
 
-This behavior can be overridden with the [`non_null` option](#non-null-fields).
+As for message types, you can generate non-null accessors with the 
+`generate_non_null_accessor` option.
 
 Wrapper types can be repeated:
 
@@ -687,7 +689,7 @@ _N.b. Well-known type nullability is implemented with
 for each message defined in
 [wrappers.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/wrappers.proto)._
 
-### Non-null fields
+### Non-null accessors
 If a message has no meaning whatsoever when a particular non-scalar field is
 missing, you can emulate proto2's `required` key word by using the
 `(protokt.v1.property).generate_non_null_accessor` option:
@@ -704,6 +706,20 @@ message NonNullSampleMessage {
 
 Generated code will include a non-null accessor prefixed with `require`, so the field can be referenced
 without using Kotlin's `!!`.
+
+This option also works on oneof fields:
+
+```protobuf
+message Sample {}
+
+message NonNullSampleMessage {
+  oneof non_null_sample {
+    option (protokt.v1.oneof).generate_non_null_accessor = true;
+    
+    Sample sample = 1;
+  }
+}
+```
 
 ### Interface implementation
 

--- a/buildSrc/src/main/kotlin/RemotePublishing.kt
+++ b/buildSrc/src/main/kotlin/RemotePublishing.kt
@@ -89,7 +89,7 @@ fun Project.enablePublishing(defaultJars: Boolean = true) {
                 configure(KotlinMultiplatform(JavadocJar.Empty()))
             }
             pluginManager.withPlugin(KotlinPlugins.JVM) {
-                configure(KotlinJvm(JavadocJar.Empty(), true))
+                configure(KotlinJvm(JavadocJar.Empty()))
             }
         }
 

--- a/buildSrc/src/main/kotlin/protokt.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/protokt.spotless-conventions.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
             targetExclude("buildSrc/build/**")
             licenseHeaderFile(
                 rootProject.file("gradle/license-header-c-style"),
-                "(package |@file|import |fun )|buildscript |plugins |subprojects |spotless "
+                "(package |@file|import |fun )|buildscript |plugins |subprojects |spotless |group ="
             )
         }
 

--- a/buildSrc/src/main/kotlin/protokt.third-party-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/protokt.third-party-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Toast, Inc.
+ * Copyright (c) 2022 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-subprojects {
-    group = "${rootProject.group}.thirdparty"
-}
+group = "com.toasttab.protokt.thirdparty"

--- a/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
+++ b/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
@@ -675,3 +675,303 @@ public final class protokt/v1/UuidBytesValueConverter : protokt/v1/AbstractConve
 	public fun wrap (Lprotokt/v1/google/protobuf/BytesValue;)Ljava/util/UUID;
 }
 
+public final class protokt/v1/protokt/ProtoktEnumOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktEnumOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktEnumOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumValueOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktEnumValueOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumValueOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktEnumValueOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktFieldOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktFieldOptions$Deserializer;
+	public synthetic fun <init> (ZLjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytesSlice ()Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getKeyWrap ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun getValueWrap ()Ljava/lang/String;
+	public final fun getWrap ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktFieldOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public final fun getBytesSlice ()Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getKeyWrap ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun getValueWrap ()Ljava/lang/String;
+	public final fun getWrap ()Ljava/lang/String;
+	public final fun setBytesSlice (Z)V
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setKeyWrap (Ljava/lang/String;)V
+	public final fun setNonNull (Z)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+	public final fun setValueWrap (Ljava/lang/String;)V
+	public final fun setWrap (Ljava/lang/String;)V
+}
+
+public final class protokt/v1/protokt/ProtoktFieldOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktFileOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktFileOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public final fun getKotlinPackage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktFileOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktFileOptions;
+	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public final fun getKotlinPackage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setFileDescriptorObjectName (Ljava/lang/String;)V
+	public final fun setKotlinPackage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktFileOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFileOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktMessageOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktMessageOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktMessageOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setImplements (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktMessageOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktMethodOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktMethodOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestMarshaller ()Ljava/lang/String;
+	public final fun getResponseMarshaller ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktMethodOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public final fun getRequestMarshaller ()Ljava/lang/String;
+	public final fun getResponseMarshaller ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setRequestMarshaller (Ljava/lang/String;)V
+	public final fun setResponseMarshaller (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktMethodOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktOneofOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktOneofOptions$Deserializer;
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktOneofOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setImplements (Ljava/lang/String;)V
+	public final fun setNonNull (Z)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktOneofOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktServiceOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktServiceOptions$Deserializer;
+	public synthetic fun <init> (Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktServiceOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktServiceOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+}
+
+public final class protokt/v1/protokt/ext/InetSocketAddress : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ext/InetSocketAddress$Deserializer;
+	public synthetic fun <init> (Lprotokt/v1/Bytes;ILprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ext/InetSocketAddress;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ext/InetSocketAddress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lprotokt/v1/Bytes;
+	public final fun getPort ()I
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ext/InetSocketAddress;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ext/InetSocketAddress$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ext/InetSocketAddress;
+	public final fun getAddress ()Lprotokt/v1/Bytes;
+	public final fun getPort ()I
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setAddress (Lprotokt/v1/Bytes;)V
+	public final fun setPort (I)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ext/InetSocketAddress$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ext/InetSocketAddress;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ext/InetSocketAddress;
+}
+

--- a/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
+++ b/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
@@ -593,11 +593,12 @@ public final class protokt/v1/MethodOptions$Deserializer : protokt/v1/AbstractDe
 
 public final class protokt/v1/OneofOptions : protokt/v1/AbstractMessage {
 	public static final field Deserializer Lprotokt/v1/OneofOptions$Deserializer;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/OneofOptions;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/OneofOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
 	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
@@ -611,9 +612,11 @@ public final class protokt/v1/OneofOptions$Builder {
 	public fun <init> ()V
 	public final fun build ()Lprotokt/v1/OneofOptions;
 	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
 	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setGenerateNonNullAccessor (Z)V
 	public final fun setImplements (Ljava/lang/String;)V
 	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
 }

--- a/extensions/protokt-extensions-lite/src/extensions-proto/protokt/protokt.proto
+++ b/extensions/protokt-extensions-lite/src/extensions-proto/protokt/protokt.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast, Inc.
+ * Copyright (c) 2019 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,54 +15,68 @@
 
 syntax = "proto3";
 
-package protokt.v1;
+package protokt;
 
 import "google/protobuf/descriptor.proto";
 
-option java_package = "com.toasttab.protokt.v1";
-option java_outer_classname = "ProtoktProtos";
+option java_package = "com.toasttab.protokt.ext";
+option java_outer_classname = "ProtoktProto";
 
-message FileOptions {
+option deprecated = true;
+
+message ProtoktFileOptions {
+  option deprecated = true;
+
+  // Specify the Kotlin package for the generated file. Precedence is given
+  // first to this Kotlin package, then to the Java package if enabled in
+  // the plugin options, and finally to the protobuf package.
+  string kotlin_package = 1 [deprecated = true];
+
   // Specify the name of the Kotlin object that contains the reference to this
   // file's FileDescriptor object.
-  string file_descriptor_object_name = 1;
+  string file_descriptor_object_name = 2 [deprecated = true];
 }
 
 extend google.protobuf.FileOptions {
-  FileOptions file = 1253;
+  ProtoktFileOptions file = 1072 [deprecated = true];
 }
 
-message MessageOptions {
+message ProtoktMessageOptions {
+  option deprecated = true;
+
   // Declares that the message class implements an interface. Scoping rules
   // are the same as those for declaring wrapper types.
-  string implements = 1;
+  string implements = 1 [deprecated = true];
 
   // Provides a message for deprecation
-  string deprecation_message = 2;
+  string deprecation_message = 2 [deprecated = true];
 }
 
 extend google.protobuf.MessageOptions {
-  MessageOptions class = 1253;
+  ProtoktMessageOptions class = 1072 [deprecated = true];
 }
 
-message FieldOptions {
-  // Generates a non-nullable accessor.
+message ProtoktFieldOptions {
+  option deprecated = true;
+
+  // Makes a message-type field non-nullable in the generated Kotlin code.
+  // Beware that deserialization will NPE if the field is missing from the
+  // protobuf payload. Adding a non-null field to an existing message is a
+  // backwards-incompatible change.
   //
   // For example:
   //
   // message Foo {
-  //   Bar id = 1 [(protokt.v1.property).generate_non_null_accessor = true];
+  //   string id = 1 [(protokt.property).non_null = true];
   // }
-  //
-  // will generate an accessor called [requireId] that has the non-nullable type [Bar] (as opposed to [Bar?]).
-  bool generate_non_null_accessor = 1;
+  bool non_null = 1 [deprecated = true];
 
   // Expose a wrapper class instead of a raw protobuf type.
   //
   // For example:
   //
   // message Foo {
-  //   string id = 1 [(protokt.v1.property).wrap = "com.foo.FooId"];
+  //   string id = 1 [(protokt.property).wrap = "com.foo.FooId"];
   // }
   //
   // data class FooId(val value: String)
@@ -75,14 +89,14 @@ message FieldOptions {
   // full qualification is optional.
   //
   // This option can be applied to repeated fields.
-  string wrap = 2;
+  string wrap = 2 [deprecated = true];
 
   // Maps a bytes field to BytesSlice. If deserialized from a byte array,
   // BytesSlice will point to the source array without copying the subarray.
-  bool bytes_slice = 3;
+  bool bytes_slice = 3 [deprecated = true];
 
   // Provides a message for deprecation
-  string deprecation_message = 4;
+  string deprecation_message = 4 [deprecated = true];
 
   // Expose a wrapper class instead of a raw protobuf type for the key type of
   // a map.
@@ -90,7 +104,7 @@ message FieldOptions {
   // For example:
   //
   // message Foo {
-  //   map<string, int32> map = 1 [(protokt.v1.property).key_wrap = "com.foo.FooId"];
+  //   map<string, int32> map = 1 [(protokt.property).key_wrap = "com.foo.FooId"];
   // }
   //
   // data class FooId(val value: String)
@@ -99,7 +113,7 @@ message FieldOptions {
   // class Foo(val map: Map<FooId, String>) ...
   //
   // Scoping rules  are the same as those for declaring regular field wrapper types.
-  string key_wrap = 5;
+  string key_wrap = 5 [deprecated = true];
 
   // Expose a wrapper class instead of a raw protobuf type for the value type of
   // a map.
@@ -107,7 +121,7 @@ message FieldOptions {
   // For example:
   //
   // message Foo {
-  //   map<int32, string> map = 1 [(protokt.v1.property).value_wrap = "com.foo.FooId"];
+  //   map<int32, strig> map = 1 [(protokt.property).value_wrap = "com.foo.FooId"];
   // }
   //
   // data class FooId(val value: String)
@@ -116,77 +130,90 @@ message FieldOptions {
   // class Foo(val map: Map<Int, FooId>) ...
   //
   // Scoping rules  are the same as those for declaring regular field wrapper types.
-  string value_wrap = 6;
+  string value_wrap = 6 [deprecated = true];
 }
 
 extend google.protobuf.FieldOptions {
-  FieldOptions property = 1253;
+  ProtoktFieldOptions property = 1072 [deprecated = true];
 }
 
-message OneofOptions {
-  // Generates a non-nullable accessor for a oneof field.
+message ProtoktOneofOptions {
+  option deprecated = true;
+
+  // Makes a oneof field non-nullable in generated Kotlin code. Beware that
+  // deserialization will NPE if the field is missing from the protobuf payload.
+  // Adding a non-null field to an existing message is a backwards-incompatible
+  // change.
   //
   // For example:
   //
   // message Message {
   //   oneof some_field_name {
-  //     option (protokt.v1.oneof).generate_non_null_accessor = true;
+  //     option (protokt.oneof).non_null = true;
   //
   //     string id = 1;
   //   }
   // }
   //
-  bool generate_non_null_accessor = 1;
+  bool non_null = 1 [deprecated = true];
 
   // Make the sealed class implement an interface, enforcing the presence of a
   // property in each possible variant. Scoping rules  are the same as those
   // for declaring wrapper types.
-  string implements = 2;
+  string implements = 2 [deprecated = true];
 
   // Provides a message for deprecation
-  string deprecation_message = 3;
+  string deprecation_message = 3 [deprecated = true];
 }
 
 extend google.protobuf.OneofOptions {
-  OneofOptions oneof = 1253;
+  ProtoktOneofOptions oneof = 1072 [deprecated = true];
 }
 
-message EnumOptions {
+message ProtoktEnumOptions {
+  option deprecated = true;
+
   // Provides a message for deprecation
-  string deprecation_message = 1;
+  string deprecation_message = 1 [deprecated = true];
 }
 
 extend google.protobuf.EnumOptions {
-  EnumOptions enum = 1253;
+  ProtoktEnumOptions enum = 1072 [deprecated = true];
 }
 
-message EnumValueOptions {
+message ProtoktEnumValueOptions {
+  option deprecated = true;
+
   // Provides a message for deprecation
-  string deprecation_message = 1;
+  string deprecation_message = 1 [deprecated = true];
 }
 
 extend google.protobuf.EnumValueOptions {
-  EnumValueOptions enum_value = 1253;
+  ProtoktEnumValueOptions enum_value = 1072 [deprecated = true];
 }
 
-message ServiceOptions {}
+message ProtoktServiceOptions {
+  option deprecated = true;
+}
 
 extend google.protobuf.ServiceOptions {
-  ServiceOptions service = 1253;
+  ProtoktServiceOptions service = 1072 [deprecated = true];
 }
 
-message MethodOptions {
+message ProtoktMethodOptions {
+  option deprecated = true;
+
   // Provides a custom request marshaller for the generated method descriptor.
   // Substitutes the provided expression directly for
   // `com.toasttab.protokt.grpc.KtMarshaller(<request_type>)`
-  string request_marshaller = 1;
+  string request_marshaller = 1 [deprecated = true];
 
   // Provides a custom response marshaller for the generated method descriptor.
   // Substitutes the provided expression directly for
   // `com.toasttab.protokt.grpc.KtMarshaller(<response_type>)`
-  string response_marshaller = 2;
+  string response_marshaller = 2 [deprecated = true];
 }
 
 extend google.protobuf.MethodOptions {
-  MethodOptions method = 1253;
+  ProtoktMethodOptions method = 1072 [deprecated = true];
 }

--- a/extensions/protokt-extensions-lite/src/extensions-proto/protokt/protokt.proto
+++ b/extensions/protokt-extensions-lite/src/extensions-proto/protokt/protokt.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast Inc.
+ * Copyright (c) 2019 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/protokt-extensions-lite/src/extensions-proto/protokt/v1/protokt.proto
+++ b/extensions/protokt-extensions-lite/src/extensions-proto/protokt/v1/protokt.proto
@@ -124,7 +124,19 @@ extend google.protobuf.FieldOptions {
 }
 
 message OneofOptions {
-  reserved 1;
+  // Generates a non-nullable accessor for a oneof field.
+  //
+  // For example:
+  //
+  // message Message {
+  //   oneof some_field_name {
+  //     option (protokt.v1.oneof).generate_non_null_accessor = true;
+  //
+  //     string id = 1;
+  //   }
+  // }
+  //
+  bool generate_non_null_accessor = 1;
 
   // Make the sealed class implement an interface, enforcing the presence of a
   // property in each possible variant. Scoping rules  are the same as those

--- a/extensions/protokt-extensions-lite/src/main/proto/protokt/ext/inet_socket_address.proto
+++ b/extensions/protokt-extensions-lite/src/main/proto/protokt/ext/inet_socket_address.proto
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.ext;
+
+import "protokt/protokt.proto";
+
+option java_package = "com.toasttab.protokt.ext";
+option java_outer_classname = "InetSocketAddressProto";
+
+option (protokt.file).kotlin_package = "com.toasttab.protokt.ext";
+option (protokt.file).file_descriptor_object_name = "InetSocketAddressProto";
+
+option deprecated = true;
+
+message InetSocketAddress {
+  option deprecated = true;
+
+  bytes address = 1 [
+    deprecated = true,
+    (protokt.property).wrap = "java.net.InetAddress"
+  ];
+
+  int32 port = 2 [deprecated = true];
+}

--- a/extensions/protokt-extensions-lite/src/main/proto/protokt/ext/inet_socket_address.proto
+++ b/extensions/protokt-extensions-lite/src/main/proto/protokt/ext/inet_socket_address.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Toast Inc.
+ * Copyright (c) 2019 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/protokt-extensions/api/protokt-extensions.api
+++ b/extensions/protokt-extensions/api/protokt-extensions.api
@@ -43,6 +43,31 @@ public final class protokt/v1/Protokt_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/ServiceOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
+public final class protokt/v1/protokt/Protokt_descriptorsKt {
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktEnumOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktEnumValueOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktFieldOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktFileOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktMessageOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktMethodOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktOneofOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktServiceOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+}
+
+public final class protokt/v1/protokt/ext/Inet_socket_address_descriptorsKt {
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ext/InetSocketAddress$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+}
+
+public final class protokt/v1/protokt/ext/inet_socket_address_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/protokt/ext/inet_socket_address_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/protokt/protokt_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/protokt/protokt_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
 public final class protokt/v1/protokt_file_descriptor {
 	public static final field INSTANCE Lprotokt/v1/protokt_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;

--- a/extensions/protokt-extensions/api/protokt-extensions.api
+++ b/extensions/protokt-extensions/api/protokt-extensions.api
@@ -32,11 +32,6 @@ public final class protokt/v1/Inet_socket_address_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/InetSocketAddress$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/ProtoktProtos {
-	public static final field INSTANCE Lprotokt/v1/ProtoktProtos;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/Protokt_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/EnumOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/EnumValueOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
@@ -46,5 +41,10 @@ public final class protokt/v1/Protokt_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/MethodOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/OneofOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/ServiceOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+}
+
+public final class protokt/v1/protokt_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/protokt_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/Implements.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/Implements.kt
@@ -27,24 +27,15 @@ import protokt.v1.codegen.generate.Nullability.nonNullPropName
 import protokt.v1.codegen.util.Message
 import protokt.v1.codegen.util.StandardField
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty
 
 internal object Implements {
-    class OverriddenProperty(
-        val property: KProperty<*>
-    )
-
     fun StandardField.overrides(
         ctx: Context,
         msg: Message
     ) =
         msg.superInterface(ctx)
-            ?.let {
-                ctx.info.context.classLookup
-                    .properties(it.canonicalName)
-                    .find { p -> p.name == fieldName }
-                    ?.let(::OverriddenProperty)
-            }
+            ?.let { fieldName in ctx.info.context.classLookup.properties(it.canonicalName).map { p -> p.name } }
+            ?: false
 
     fun TypeSpec.Builder.handleSuperInterface(implements: ClassName?, v: OneofGeneratorInfo? = null) =
         apply {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -167,7 +167,7 @@ private class MessageGenerator(
             PropertySpec.builder(nonNullPropName(property.name), property.propertyType.copy(nullable = false)).apply {
                 getter(
                     FunSpec.getterBuilder()
-                        .addCode("return ${dereferenceNullableBackingProperty(property.name)}")
+                        .addCode("return ${dereferenceNullableBackingProperty(property.name, property.oneof)}")
                         .build()
                 )
                 property.documentation?.let { addKdoc(formatDoc(it)) }
@@ -175,8 +175,8 @@ private class MessageGenerator(
             }.build()
         )
 
-    private fun dereferenceNullableBackingProperty(propName: String) =
-        "requireNotNull($propName) { \"$propName is assumed non-null with (protokt.v1.property).generate_non_null_accessor but was null\" }".bindSpaces()
+    private fun dereferenceNullableBackingProperty(propName: String, oneof: Boolean) =
+        "requireNotNull($propName) { \"$propName is assumed non-null with (protokt.v1.${if (oneof) "oneof" else "property"}).generate_non_null_accessor but was null\" }".bindSpaces()
 
     private fun TypeSpec.Builder.handleMessageSize(propertySpecs: List<PropertySpec>) {
         addProperty(generateMessageSize(msg, propertySpecs, ctx))

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -141,7 +141,7 @@ private class MessageGenerator(
                     )
                 }
                 initializer(property.name)
-                if (property.overrides != null) {
+                if (property.overrides) {
                     addModifiers(KModifier.OVERRIDE)
                 }
                 property.documentation?.let { addKdoc(formatDoc(it)) }
@@ -159,7 +159,7 @@ private class MessageGenerator(
                             .build()
                     )
                 }
-                if (property.overrides != null) {
+                if (property.overrides) {
                     addModifiers(KModifier.OVERRIDE)
                 }
                 initializer(property.name)

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -141,7 +141,7 @@ private class MessageGenerator(
                     )
                 }
                 initializer(property.name)
-                if (property.overrides) {
+                if (property.overrides != null) {
                     addModifiers(KModifier.OVERRIDE)
                 }
                 property.documentation?.let { addKdoc(formatDoc(it)) }
@@ -159,6 +159,9 @@ private class MessageGenerator(
                             .build()
                     )
                 }
+                if (property.overrides != null) {
+                    addModifiers(KModifier.OVERRIDE)
+                }
                 initializer(property.name)
             }.build(),
             PropertySpec.builder(nonNullPropName(property.name), property.propertyType.copy(nullable = false)).apply {
@@ -167,16 +170,13 @@ private class MessageGenerator(
                         .addCode("return ${dereferenceNullableBackingProperty(property.name)}")
                         .build()
                 )
-                if (property.overrides) {
-                    addModifiers(KModifier.OVERRIDE)
-                }
                 property.documentation?.let { addKdoc(formatDoc(it)) }
                 handleDeprecation(property.deprecation)
             }.build()
         )
 
     private fun dereferenceNullableBackingProperty(propName: String) =
-        "requireNotNull($propName) { \"$propName is assumed non-null with (protokt.property).generate_non_null_accessor but was null\" }".bindSpaces()
+        "requireNotNull($propName) { \"$propName is assumed non-null with (protokt.v1.property).generate_non_null_accessor but was null\" }".bindSpaces()
 
     private fun TypeSpec.Builder.handleMessageSize(propertySpecs: List<PropertySpec>) {
         addProperty(generateMessageSize(msg, propertySpecs, ctx))

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/Nullability.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/Nullability.kt
@@ -24,7 +24,9 @@ import protokt.v1.reflect.FieldType
 
 internal object Nullability {
     val Field.generateNonNullAccessor
-        get() = this is StandardField && options.protokt.generateNonNullAccessor
+        get() =
+            (this is StandardField && options.protokt.generateNonNullAccessor) ||
+                (this is Oneof && options.protokt.generateNonNullAccessor)
 
     val Field.nullable
         get() = isKotlinRepresentationNullable
@@ -43,11 +45,7 @@ internal object Nullability {
                 type !in setOf(FieldType.Message, FieldType.Enum)
 
     fun propertyType(o: Oneof) =
-        if (o.generateNonNullAccessor) {
-            o.className
-        } else {
-            o.className.copy(nullable = true)
-        }
+        o.className.copy(nullable = true)
 
     fun propertyType(f: StandardField, type: TypeName, wrapperRequiresNullability: Boolean) =
         if (f.nullable || wrapperRequiresNullability) {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
@@ -147,7 +147,7 @@ internal class PropertyInfo(
     val mapEntry: Message? = null,
     val oneof: Boolean = false,
     val wrapped: Boolean = false,
-    val overrides: OverriddenProperty? = null,
+    val overrides: Boolean = false,
     val documentation: List<String>?,
     val deprecation: Deprecation.RenderOptions? = null
 ) {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
@@ -21,6 +21,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 import protokt.v1.codegen.generate.CodeGenerator.Context
 import protokt.v1.codegen.generate.Deprecation.renderOptions
+import protokt.v1.codegen.generate.Implements.OverriddenProperty
 import protokt.v1.codegen.generate.Implements.overrides
 import protokt.v1.codegen.generate.Nullability.deserializeType
 import protokt.v1.codegen.generate.Nullability.dslPropertyType
@@ -146,7 +147,7 @@ internal class PropertyInfo(
     val mapEntry: Message? = null,
     val oneof: Boolean = false,
     val wrapped: Boolean = false,
-    val overrides: Boolean = false,
+    val overrides: OverriddenProperty? = null,
     val documentation: List<String>?,
     val deprecation: Deprecation.RenderOptions? = null
 ) {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
@@ -21,7 +21,6 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 import protokt.v1.codegen.generate.CodeGenerator.Context
 import protokt.v1.codegen.generate.Deprecation.renderOptions
-import protokt.v1.codegen.generate.Implements.OverriddenProperty
 import protokt.v1.codegen.generate.Implements.overrides
 import protokt.v1.codegen.generate.Nullability.deserializeType
 import protokt.v1.codegen.generate.Nullability.dslPropertyType

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
@@ -79,6 +79,7 @@ private class PropertyAnnotator(
                 PropertyInfo(
                     name = field.fieldName,
                     propertyType = propertyType(field),
+                    generateNullableBackingProperty = field.generateNonNullAccessor,
                     deserializeType = field.className.copy(nullable = true),
                     builderPropertyType = field.className.copy(nullable = true),
                     defaultValue = field.defaultValue(ctx, false),

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GeneratorContext.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GeneratorContext.kt
@@ -56,7 +56,6 @@ private fun generateFdpObjectNames(files: List<FileDescriptorProto>): Map<String
         Pair(
             fdp.name,
             fdp.fileOptions.protokt.fileDescriptorObjectName.takeIf { it.isNotEmpty() }
-                ?: fdp.fileOptions.default.javaOuterClassname.takeIf { it.isNotEmpty() }
                 ?: (fdp.name.substringBefore(".proto").substringAfterLast('/') + "_file_descriptor")
         )
     }

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/any.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/any.kt
@@ -85,6 +85,7 @@ import kotlin.Unit
  *      {       "@type": "type.googleapis.com/google.protobuf.Duration",       "value": "1.212s"
  * }
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Any")
 class Any private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/api.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/api.kt
@@ -46,6 +46,7 @@ import kotlin.collections.MutableList
  * They are also sometimes simply referred to as "APIs" in other contexts, such as the name of this
  * message itself. See https://cloud.google.com/apis/design/glossary for detailed terminology.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Api")
 class Api private constructor(
     /**
@@ -281,6 +282,7 @@ class Api private constructor(
 /**
  * Method represents a method of an API interface.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Method")
 class Method private constructor(
     /**
@@ -538,6 +540,7 @@ class Method private constructor(
  * returns (Acl) {         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";       }
  *  ...     }
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Mixin")
 class Mixin private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/compiler/plugin.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/compiler/plugin.kt
@@ -47,6 +47,7 @@ import kotlin.collections.MutableList
 /**
  * The version number of protocol compiler.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.compiler.Version")
 class Version private constructor(
     val major: Int?,
@@ -345,6 +346,7 @@ class CodeGeneratorRequest private constructor(
 /**
  * The plugin writes an encoded CodeGeneratorResponse to stdout.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.compiler.CodeGeneratorResponse")
 class CodeGeneratorResponse private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/descriptor.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/descriptor.kt
@@ -51,6 +51,7 @@ import kotlin.collections.MutableList
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto files it parses.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.FileDescriptorSet")
 class FileDescriptorSet private constructor(
     val `file`: List<FileDescriptorProto>,
@@ -136,6 +137,7 @@ class FileDescriptorSet private constructor(
 /**
  * Describes a complete .proto file.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.FileDescriptorProto")
 class FileDescriptorProto private constructor(
     val name: String?,
@@ -487,6 +489,7 @@ class FileDescriptorProto private constructor(
 /**
  * Describes a message type.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.DescriptorProto")
 class DescriptorProto private constructor(
     val name: String?,
@@ -987,6 +990,7 @@ class DescriptorProto private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.ExtensionRangeOptions")
 class ExtensionRangeOptions private constructor(
     /**
@@ -1078,6 +1082,7 @@ class ExtensionRangeOptions private constructor(
 /**
  * Describes a field within a message.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.FieldDescriptorProto")
 class FieldDescriptorProto private constructor(
     val name: String?,
@@ -1490,6 +1495,7 @@ class FieldDescriptorProto private constructor(
 /**
  * Describes a oneof.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.OneofDescriptorProto")
 class OneofDescriptorProto private constructor(
     val name: String?,
@@ -1584,6 +1590,7 @@ class OneofDescriptorProto private constructor(
 /**
  * Describes an enum type.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.EnumDescriptorProto")
 class EnumDescriptorProto private constructor(
     val name: String?,
@@ -1859,6 +1866,7 @@ class EnumDescriptorProto private constructor(
 /**
  * Describes a value within an enum.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.EnumValueDescriptorProto")
 class EnumValueDescriptorProto private constructor(
     val name: String?,
@@ -1971,6 +1979,7 @@ class EnumValueDescriptorProto private constructor(
 /**
  * Describes a service.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.ServiceDescriptorProto")
 class ServiceDescriptorProto private constructor(
     val name: String?,
@@ -2091,6 +2100,7 @@ class ServiceDescriptorProto private constructor(
 /**
  * Describes a method of a service.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.MethodDescriptorProto")
 class MethodDescriptorProto private constructor(
     val name: String?,
@@ -2801,6 +2811,7 @@ class FileOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.MessageOptions")
 class MessageOptions private constructor(
     /**
@@ -2994,6 +3005,7 @@ class MessageOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.FieldOptions")
 class FieldOptions private constructor(
     /**
@@ -3323,6 +3335,7 @@ class FieldOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.OneofOptions")
 class OneofOptions private constructor(
     /**
@@ -3408,6 +3421,7 @@ class OneofOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.EnumOptions")
 class EnumOptions private constructor(
     /**
@@ -3535,6 +3549,7 @@ class EnumOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.EnumValueOptions")
 class EnumValueOptions private constructor(
     /**
@@ -3643,6 +3658,7 @@ class EnumValueOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.ServiceOptions")
 class ServiceOptions private constructor(
     /**
@@ -3751,6 +3767,7 @@ class ServiceOptions private constructor(
     }
 }
 
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.MethodOptions")
 class MethodOptions private constructor(
     /**
@@ -3911,6 +3928,7 @@ class MethodOptions private constructor(
  * objects. Therefore, options protos in descriptor objects (e.g. returned by Descriptor::options(), or
  * produced by Descriptor::CopyTo()) will never have UninterpretedOptions in them.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.UninterpretedOption")
 class UninterpretedOption private constructor(
     val name: List<NamePart>,
@@ -4200,6 +4218,7 @@ class UninterpretedOption private constructor(
  * Encapsulates information about the original source file from which a FileDescriptorProto was
  * generated.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.SourceCodeInfo")
 class SourceCodeInfo private constructor(
     /**
@@ -4552,6 +4571,7 @@ class SourceCodeInfo private constructor(
  * GeneratedCodeInfo message is associated with only one generated source file, but may contain
  * references to different source .proto files.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.GeneratedCodeInfo")
 class GeneratedCodeInfo private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/duration.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/duration.kt
@@ -82,6 +82,7 @@ import kotlin.Unit
  *
  *
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Duration")
 class Duration private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/empty.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/empty.kt
@@ -38,6 +38,7 @@ import kotlin.Unit
  *
  *      service Foo {       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);     }
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Empty")
 class Empty private constructor(
     val unknownFields: UnknownFieldSet = UnknownFieldSet.empty(),

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/field_mask.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/field_mask.kt
@@ -168,6 +168,7 @@ import kotlin.collections.MutableList
  *  The implementation of any API method which has a FieldMask type field in the request should
  * verify the included field paths, and return an `INVALID_ARGUMENT` error if any path is unmappable.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.FieldMask")
 class FieldMask private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/source_context.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/source_context.kt
@@ -37,6 +37,7 @@ import kotlin.Unit
  * `SourceContext` represents information about the source of a protobuf element, like the file in
  * which it is defined.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.SourceContext")
 class SourceContext private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/struct.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/struct.kt
@@ -53,6 +53,7 @@ import kotlin.collections.MutableMap
  *
  *  The JSON representation for `Struct` is JSON object.
  */
+@Deprecated("for backwards compatibility only")
 sealed class NullValue(
     override val `value`: Int,
     override val name: String,
@@ -82,6 +83,7 @@ sealed class NullValue(
  *
  *  The JSON representation for `Struct` is JSON object.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Struct")
 class Struct private constructor(
     /**
@@ -210,6 +212,7 @@ class Struct private constructor(
  *
  *  The JSON representation for `Value` is JSON value.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Value")
 class Value private constructor(
     /**
@@ -371,6 +374,7 @@ class Value private constructor(
  *
  *  The JSON representation for `ListValue` is JSON array.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.ListValue")
 class ListValue private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/timestamp.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/timestamp.kt
@@ -120,6 +120,7 @@ import kotlin.Unit
  *
  *
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Timestamp")
 class Timestamp private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/type.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/type.kt
@@ -42,6 +42,7 @@ import kotlin.collections.MutableList
 /**
  * A protocol buffer message type.
  */
+@Deprecated("for backwards compatibility only")
 sealed class Syntax(
     override val `value`: Int,
     override val name: String,
@@ -72,6 +73,7 @@ sealed class Syntax(
 /**
  * A protocol buffer message type.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Type")
 class Type private constructor(
     /**
@@ -271,6 +273,7 @@ class Type private constructor(
 /**
  * A single field of a message type.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Field")
 class Field private constructor(
     /**
@@ -712,6 +715,7 @@ class Field private constructor(
 /**
  * Enum type definition.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Enum")
 class Enum_ private constructor(
     /**
@@ -884,6 +888,7 @@ class Enum_ private constructor(
 /**
  * Enum value definition.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.EnumValue")
 class EnumValue private constructor(
     /**
@@ -1010,6 +1015,7 @@ class EnumValue private constructor(
 /**
  * A protocol buffer option, which can be attached to a message, field, enumeration, etc.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Option")
 class Option private constructor(
     /**

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/wrappers.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/wrappers.kt
@@ -46,6 +46,7 @@ import kotlin.Unit
  *
  *  The JSON representation for `DoubleValue` is JSON number.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.DoubleValue")
 class DoubleValue private constructor(
     /**
@@ -127,6 +128,7 @@ class DoubleValue private constructor(
  *
  *  The JSON representation for `FloatValue` is JSON number.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.FloatValue")
 class FloatValue private constructor(
     /**
@@ -208,6 +210,7 @@ class FloatValue private constructor(
  *
  *  The JSON representation for `Int64Value` is JSON string.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Int64Value")
 class Int64Value private constructor(
     /**
@@ -289,6 +292,7 @@ class Int64Value private constructor(
  *
  *  The JSON representation for `UInt64Value` is JSON string.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.UInt64Value")
 class UInt64Value private constructor(
     /**
@@ -370,6 +374,7 @@ class UInt64Value private constructor(
  *
  *  The JSON representation for `Int32Value` is JSON number.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.Int32Value")
 class Int32Value private constructor(
     /**
@@ -451,6 +456,7 @@ class Int32Value private constructor(
  *
  *  The JSON representation for `UInt32Value` is JSON number.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.UInt32Value")
 class UInt32Value private constructor(
     /**
@@ -532,6 +538,7 @@ class UInt32Value private constructor(
  *
  *  The JSON representation for `BoolValue` is JSON `true` and `false`.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.BoolValue")
 class BoolValue private constructor(
     /**
@@ -613,6 +620,7 @@ class BoolValue private constructor(
  *
  *  The JSON representation for `StringValue` is JSON string.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.StringValue")
 class StringValue private constructor(
     /**
@@ -694,6 +702,7 @@ class StringValue private constructor(
  *
  *  The JSON representation for `BytesValue` is JSON string.
  */
+@Deprecated("for backwards compatibility only")
 @KtGeneratedMessage("google.protobuf.BytesValue")
 class BytesValue private constructor(
     /**

--- a/protokt-core/api/protokt-core.api
+++ b/protokt-core/api/protokt-core.api
@@ -214,18 +214,8 @@ public final class protokt/v1/google/protobuf/Anies {
 	public static synthetic fun pack$default (Lprotokt/v1/google/protobuf/Any$Deserializer;Lprotokt/v1/Message;Ljava/lang/String;ILjava/lang/Object;)Lprotokt/v1/google/protobuf/Any;
 }
 
-public final class protokt/v1/google/protobuf/AnyProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/AnyProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/protobuf/Any_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Any$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/protobuf/ApiProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/ApiProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Api_descriptorsKt {
@@ -241,11 +231,6 @@ public final class protokt/v1/google/protobuf/Descriptor {
 	public final fun getIndex ()I
 	public final fun getNestedTypes ()Ljava/util/List;
 	public final fun getProto ()Lprotokt/v1/google/protobuf/DescriptorProto;
-}
-
-public final class protokt/v1/google/protobuf/DescriptorProtos {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/DescriptorProtos;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Descriptor_descriptorsKt {
@@ -301,18 +286,8 @@ public final class protokt/v1/google/protobuf/Descriptor_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/UninterpretedOption$NamePart$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/protobuf/DurationProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/DurationProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/protobuf/Duration_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Duration$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/protobuf/EmptyProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/EmptyProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Empty_descriptorsKt {
@@ -324,11 +299,6 @@ public final class protokt/v1/google/protobuf/EnumDescriptor {
 	public final fun getFullName ()Ljava/lang/String;
 	public final fun getIndex ()I
 	public final fun getProto ()Lprotokt/v1/google/protobuf/EnumDescriptorProto;
-}
-
-public final class protokt/v1/google/protobuf/FieldMaskProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/FieldMaskProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Field_mask_descriptorsKt {
@@ -357,18 +327,8 @@ public final class protokt/v1/google/protobuf/ServiceDescriptor {
 	public final fun getProto ()Lprotokt/v1/google/protobuf/ServiceDescriptorProto;
 }
 
-public final class protokt/v1/google/protobuf/SourceContextProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/SourceContextProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/protobuf/Source_context_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/SourceContext$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/protobuf/StructProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/StructProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Struct_descriptorsKt {
@@ -378,18 +338,8 @@ public final class protokt/v1/google/protobuf/Struct_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Value$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/protobuf/TimestampProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/TimestampProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/protobuf/Timestamp_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Timestamp$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/protobuf/TypeProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/TypeProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Type_descriptorsKt {
@@ -401,11 +351,6 @@ public final class protokt/v1/google/protobuf/Type_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Option$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Syntax$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/Type$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/protobuf/WrappersProto {
-	public static final field INSTANCE Lprotokt/v1/google/protobuf/WrappersProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/protobuf/Wrappers_descriptorsKt {
@@ -420,13 +365,68 @@ public final class protokt/v1/google/protobuf/Wrappers_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/protobuf/UInt64Value$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/pb/JavaFeaturesProto {
-	public static final field INSTANCE Lprotokt/v1/pb/JavaFeaturesProto;
+public final class protokt/v1/google/protobuf/any_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/any_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/api_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/api_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/descriptor_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/descriptor_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/duration_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/duration_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/empty_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/empty_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/field_mask_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/field_mask_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/source_context_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/source_context_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/struct_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/struct_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/timestamp_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/timestamp_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/type_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/type_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/protobuf/wrappers_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/protobuf/wrappers_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/pb/Java_features_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/pb/JavaFeatures$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/pb/JavaFeatures$Utf8Validation$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
+}
+
+public final class protokt/v1/pb/java_features_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/pb/java_features_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 

--- a/protokt-reflect/api/protokt-reflect.api
+++ b/protokt-reflect/api/protokt-reflect.api
@@ -943,11 +943,6 @@ public final class protokt/v1/ProtoktKt {
 	public static final fun getDescriptor (Lprotokt/v1/ServiceOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/ProtoktProtos {
-	public static final field INSTANCE Lprotokt/v1/ProtoktProtos;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/ServiceOptions : protokt/v1/AbstractMessage {
 	public static final field Deserializer Lprotokt/v1/ServiceOptions$Deserializer;
 	public synthetic fun <init> (Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -984,5 +979,10 @@ public final class protokt/v1/google/protobuf/Messages {
 public final class protokt/v1/google/protobuf/RuntimeContext {
 	public fun <init> (Ljava/lang/Iterable;)V
 	public final fun convertValue (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class protokt/v1/protokt_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/protokt_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 

--- a/protokt-reflect/api/protokt-reflect.api
+++ b/protokt-reflect/api/protokt-reflect.api
@@ -546,6 +546,7 @@ public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$MethodOpti
 
 public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$OneofOptionsOrBuilder {
 	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field GENERATE_NON_NULL_ACCESSOR_FIELD_NUMBER I
 	public static final field IMPLEMENTS_FIELD_NUMBER I
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
@@ -555,6 +556,7 @@ public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions : com/goog
 	public fun getDeprecationMessage ()Ljava/lang/String;
 	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
 	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getGenerateNonNullAccessor ()Z
 	public fun getImplements ()Ljava/lang/String;
 	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
 	public fun getParserForType ()Lcom/google/protobuf/Parser;
@@ -598,6 +600,7 @@ public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder : 
 	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
 	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
+	public fun clearGenerateNonNullAccessor ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public fun clearImplements ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
 	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
@@ -606,6 +609,7 @@ public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder : 
 	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
 	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
 	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getGenerateNonNullAccessor ()Z
 	public fun getImplements ()Ljava/lang/String;
 	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
 	public final fun isInitialized ()Z
@@ -620,6 +624,7 @@ public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder : 
 	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
+	public fun setGenerateNonNullAccessor (Z)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public fun setImplements (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
 }
@@ -627,6 +632,7 @@ public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder : 
 public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$OneofOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
 	public abstract fun getDeprecationMessage ()Ljava/lang/String;
 	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getGenerateNonNullAccessor ()Z
 	public abstract fun getImplements ()Ljava/lang/String;
 	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
 }
@@ -901,11 +907,12 @@ public final class protokt/v1/MethodOptions$Deserializer : protokt/v1/AbstractDe
 
 public final class protokt/v1/OneofOptions : protokt/v1/AbstractMessage {
 	public static final field Deserializer Lprotokt/v1/OneofOptions$Deserializer;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/OneofOptions;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/OneofOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
 	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
@@ -919,9 +926,11 @@ public final class protokt/v1/OneofOptions$Builder {
 	public fun <init> ()V
 	public final fun build ()Lprotokt/v1/OneofOptions;
 	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
 	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setGenerateNonNullAccessor (Z)V
 	public final fun setImplements (Ljava/lang/String;)V
 	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
 }

--- a/protokt-reflect/api/protokt-reflect.api
+++ b/protokt-reflect/api/protokt-reflect.api
@@ -1,3 +1,719 @@
+public final class com/toasttab/protokt/ext/ProtoktProto {
+	public static final field CLASS_FIELD_NUMBER I
+	public static final field ENUM_FIELD_NUMBER I
+	public static final field ENUM_VALUE_FIELD_NUMBER I
+	public static final field FILE_FIELD_NUMBER I
+	public static final field METHOD_FIELD_NUMBER I
+	public static final field ONEOF_FIELD_NUMBER I
+	public static final field PROPERTY_FIELD_NUMBER I
+	public static final field SERVICE_FIELD_NUMBER I
+	public static final field class_ Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field enumValue Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field enum_ Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field file Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field method Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field oneof Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field property Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field service Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static fun getDescriptor ()Lcom/google/protobuf/Descriptors$FileDescriptor;
+	public static fun registerAllExtensions (Lcom/google/protobuf/ExtensionRegistry;)V
+	public static fun registerAllExtensions (Lcom/google/protobuf/ExtensionRegistryLite;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktEnumValueOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptionsOrBuilder {
+	public static final field BYTES_SLICE_FIELD_NUMBER I
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field KEY_WRAP_FIELD_NUMBER I
+	public static final field NON_NULL_FIELD_NUMBER I
+	public static final field VALUE_WRAP_FIELD_NUMBER I
+	public static final field WRAP_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesSlice ()Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getKeyWrap ()Ljava/lang/String;
+	public fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getNonNull ()Z
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun getValueWrap ()Ljava/lang/String;
+	public fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getWrap ()Ljava/lang/String;
+	public fun getWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun clearBytesSlice ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun clearKeyWrap ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun clearNonNull ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun clearValueWrap ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun clearWrap ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun getBytesSlice ()Z
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getKeyWrap ()Ljava/lang/String;
+	public fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getNonNull ()Z
+	public fun getValueWrap ()Ljava/lang/String;
+	public fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getWrap ()Ljava/lang/String;
+	public fun getWrapBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setBytesSlice (Z)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setKeyWrap (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setKeyWrapBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setNonNull (Z)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setValueWrap (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setValueWrapBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setWrap (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+	public fun setWrapBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktFieldOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getBytesSlice ()Z
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getKeyWrap ()Ljava/lang/String;
+	public abstract fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getNonNull ()Z
+	public abstract fun getValueWrap ()Ljava/lang/String;
+	public abstract fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getWrap ()Ljava/lang/String;
+	public abstract fun getWrapBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptionsOrBuilder {
+	public static final field FILE_DESCRIPTOR_OBJECT_NAME_FIELD_NUMBER I
+	public static final field KOTLIN_PACKAGE_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
+	public fun getKotlinPackage ()Ljava/lang/String;
+	public fun getKotlinPackageBytes ()Lcom/google/protobuf/ByteString;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun clearFileDescriptorObjectName ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun clearKotlinPackage ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
+	public fun getKotlinPackage ()Ljava/lang/String;
+	public fun getKotlinPackageBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun setFileDescriptorObjectName (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun setFileDescriptorObjectNameBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun setKotlinPackage (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+	public fun setKotlinPackageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktFileOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public abstract fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getKotlinPackage ()Ljava/lang/String;
+	public abstract fun getKotlinPackageBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field IMPLEMENTS_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun clearImplements ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun setImplements (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktMessageOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getImplements ()Ljava/lang/String;
+	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptionsOrBuilder {
+	public static final field REQUEST_MARSHALLER_FIELD_NUMBER I
+	public static final field RESPONSE_MARSHALLER_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getRequestMarshaller ()Ljava/lang/String;
+	public fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public fun getResponseMarshaller ()Ljava/lang/String;
+	public fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun clearRequestMarshaller ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun clearResponseMarshaller ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getRequestMarshaller ()Ljava/lang/String;
+	public fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public fun getResponseMarshaller ()Ljava/lang/String;
+	public fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun setRequestMarshaller (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun setRequestMarshallerBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun setResponseMarshaller (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+	public fun setResponseMarshallerBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktMethodOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getRequestMarshaller ()Ljava/lang/String;
+	public abstract fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getResponseMarshaller ()Ljava/lang/String;
+	public abstract fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field IMPLEMENTS_FIELD_NUMBER I
+	public static final field NON_NULL_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public fun getNonNull ()Z
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun clearImplements ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun clearNonNull ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public fun getNonNull ()Z
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun setImplements (Ljava/lang/String;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+	public fun setNonNull (Z)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktOneofOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getImplements ()Ljava/lang/String;
+	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getNonNull ()Z
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptionsOrBuilder {
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public static fun newBuilder (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom ([B)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class com/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+	public fun mergeFrom (Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions;)Lcom/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptions$Builder;
+}
+
+public abstract interface class com/toasttab/protokt/ext/ProtoktProto$ProtoktServiceOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+}
+
 public final class com/toasttab/protokt/v1/ProtoktProtos {
 	public static final field CLASS_FIELD_NUMBER I
 	public static final field ENUM_FIELD_NUMBER I
@@ -988,6 +1704,289 @@ public final class protokt/v1/google/protobuf/Messages {
 public final class protokt/v1/google/protobuf/RuntimeContext {
 	public fun <init> (Ljava/lang/Iterable;)V
 	public final fun convertValue (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktEnumOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktEnumOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumValueOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktEnumValueOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktEnumValueOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktEnumValueOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktEnumValueOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktFieldOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktFieldOptions$Deserializer;
+	public synthetic fun <init> (ZLjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytesSlice ()Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getKeyWrap ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun getValueWrap ()Ljava/lang/String;
+	public final fun getWrap ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktFieldOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public final fun getBytesSlice ()Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getKeyWrap ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun getValueWrap ()Ljava/lang/String;
+	public final fun getWrap ()Ljava/lang/String;
+	public final fun setBytesSlice (Z)V
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setKeyWrap (Ljava/lang/String;)V
+	public final fun setNonNull (Z)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+	public final fun setValueWrap (Ljava/lang/String;)V
+	public final fun setWrap (Ljava/lang/String;)V
+}
+
+public final class protokt/v1/protokt/ProtoktFieldOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFieldOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktFileOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktFileOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public final fun getKotlinPackage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktFileOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktFileOptions;
+	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public final fun getKotlinPackage ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setFileDescriptorObjectName (Ljava/lang/String;)V
+	public final fun setKotlinPackage (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktFileOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktFileOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktFileOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktKt {
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktEnumOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktEnumValueOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktFieldOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktFileOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktMessageOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktMethodOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktOneofOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+	public static final fun getDescriptor (Lprotokt/v1/protokt/ProtoktServiceOptions$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+}
+
+public final class protokt/v1/protokt/ProtoktMessageOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktMessageOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktMessageOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setImplements (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktMessageOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMessageOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktMethodOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktMethodOptions$Deserializer;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestMarshaller ()Ljava/lang/String;
+	public final fun getResponseMarshaller ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktMethodOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public final fun getRequestMarshaller ()Ljava/lang/String;
+	public final fun getResponseMarshaller ()Ljava/lang/String;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setRequestMarshaller (Ljava/lang/String;)V
+	public final fun setResponseMarshaller (Ljava/lang/String;)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktMethodOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktMethodOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktOneofOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktOneofOptions$Deserializer;
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktOneofOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getImplements ()Ljava/lang/String;
+	public final fun getNonNull ()Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setDeprecationMessage (Ljava/lang/String;)V
+	public final fun setImplements (Ljava/lang/String;)V
+	public final fun setNonNull (Z)V
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktOneofOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktOneofOptions;
+}
+
+public final class protokt/v1/protokt/ProtoktServiceOptions : protokt/v1/AbstractMessage {
+	public static final field Deserializer Lprotokt/v1/protokt/ProtoktServiceOptions$Deserializer;
+	public synthetic fun <init> (Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun hashCode ()I
+	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public fun messageSize ()I
+	public fun serialize (Lprotokt/v1/Writer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class protokt/v1/protokt/ProtoktServiceOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public final fun setUnknownFields (Lprotokt/v1/UnknownFieldSet;)V
+}
+
+public final class protokt/v1/protokt/ProtoktServiceOptions$Deserializer : protokt/v1/AbstractDeserializer {
+	public synthetic fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/Message;
+	public fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/protokt/ProtoktServiceOptions;
+}
+
+public final class protokt/v1/protokt/protokt_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/protokt/protokt_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/protokt_file_descriptor {

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
@@ -71,7 +71,11 @@ internal object ProtoktReflect {
                 oneofPropertiesSealedClasses.forEach { sealedClass ->
                     val oneofPropertyGetter =
                         messageClass.declaredMemberProperties
-                            .single { it.returnType.classifier == sealedClass }
+                            .single {
+                                it.returnType.classifier == sealedClass &&
+                                    // prevent selection of non-null accessor
+                                    it.returnType.isMarkedNullable
+                            }
                             .let {
                                 @Suppress("UNCHECKED_CAST")
                                 it as KProperty1<Message, *>

--- a/protokt-runtime/src/jvmMain/kotlin/com/toasttab/protokt/rt/KtMessage.kt
+++ b/protokt-runtime/src/jvmMain/kotlin/com/toasttab/protokt/rt/KtMessage.kt
@@ -18,6 +18,7 @@ package com.toasttab.protokt.rt
 import com.google.protobuf.CodedOutputStream
 import java.io.OutputStream
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 interface KtMessage {
     val messageSize: Int

--- a/protokt-runtime/src/jvmMain/kotlin/com/toasttab/protokt/rt/KtMessageDeserializer.kt
+++ b/protokt-runtime/src/jvmMain/kotlin/com/toasttab/protokt/rt/KtMessageDeserializer.kt
@@ -61,10 +61,12 @@ interface KtMessageDeserializer {
         e.from(readInt32())
 }
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 fun deserializer(bytes: Bytes) =
     deserializer(bytes.value)
 
+@Deprecated("for backwards compatibility only")
 fun deserializer(bytes: ByteArray) =
     deserializer(CodedInputStream.newInstance(bytes), bytes)
 

--- a/shared-src/lite-util/protokt/v1/util/ProtoktExtentions.kt
+++ b/shared-src/lite-util/protokt/v1/util/ProtoktExtentions.kt
@@ -15,4 +15,4 @@
 
 package protokt.v1.util
 
-const val PROTOKT_EXTENSIONS_CLASS_NAME = "protokt.v1.ProtoktProtos"
+const val PROTOKT_EXTENSIONS_CLASS_NAME = "protokt.v1.protokt_file_descriptor"

--- a/testing/interop/src/main/proto/protokt/v1/testing/wrappers_dynamic.proto
+++ b/testing/interop/src/main/proto/protokt/v1/testing/wrappers_dynamic.proto
@@ -75,6 +75,8 @@ message Wrappers {
 
 message OneofWrappers {
   oneof wrapped_oneof {
+    option (.protokt.v1.oneof).generate_non_null_accessor = true;
+
     bytes uuid_oneof = 2 [
       (.protokt.v1.property).wrap = "java.util.UUID"
     ];

--- a/testing/options-api/src/main/kotlin/protokt/v1/testing/IModel4.kt
+++ b/testing/options-api/src/main/kotlin/protokt/v1/testing/IModel4.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Toast, Inc.
+ * Copyright (c) 2025 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-package com.toasttab.protokt.rt
+package protokt.v1.testing
 
-@Deprecated("for backwards compatibility only")
-annotation class KtGeneratedFileDescriptor
+interface IModel4 {
+    val bar: IModel?
+}

--- a/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
@@ -70,15 +70,25 @@ message ImplementsModel3 {
 }
 
 // name conflict between `bar` and `requireBar` during code generation
-message ImplementsModelAgain {
+message ImplementsModel4 {
   option (.protokt.v1.class).implements = "IModel4";
 
   ImplementsModel bar = 1 [(protokt.v1.property).generate_non_null_accessor = true];
 }
 
 // type conflict: delegated property `bar` must be nullable
-message ImplementsModelAgainAgain {
+message ImplementsModel4Again {
   option (.protokt.v1.class).implements = "IModel4 by baz";
 
-  ImplementsModelAgain baz = 1 [(protokt.v1.property).generate_non_null_accessor = true];
+  ImplementsModel4 baz = 1 [(protokt.v1.property).generate_non_null_accessor = true];
+}
+
+message ImplementsModel4DelegatingToOneof {
+  option (.protokt.v1.class).implements = "IModel4 by baz";
+
+  oneof baz {
+    option (.protokt.v1.oneof).implements = "IModel4";
+
+    ImplementsModel4 qux = 1;
+  }
 }

--- a/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/message_implements.proto
@@ -68,3 +68,17 @@ message ImplementsModel3 {
 
   string id = 1;
 }
+
+// name conflict between `bar` and `requireBar` during code generation
+message ImplementsModelAgain {
+  option (.protokt.v1.class).implements = "IModel4";
+
+  ImplementsModel bar = 1 [(protokt.v1.property).generate_non_null_accessor = true];
+}
+
+// type conflict: delegated property `bar` must be nullable
+message ImplementsModelAgainAgain {
+  option (.protokt.v1.class).implements = "IModel4 by baz";
+
+  ImplementsModelAgain baz = 1 [(protokt.v1.property).generate_non_null_accessor = true];
+}

--- a/testing/options/src/main/proto/protokt/v1/testing/non_null_property_and_oneof.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/non_null_property_and_oneof.proto
@@ -24,6 +24,12 @@ message NonNullModel {
   google.protobuf.StringValue non_null_string_value = 1 [
     (.protokt.v1.property).generate_non_null_accessor = true
   ];
+
+  oneof non_null_oneof {
+    option (.protokt.v1.oneof).generate_non_null_accessor = true;
+
+    string message = 2;
+  }
 }
 
 message NonNullModelMirror {

--- a/testing/options/src/main/proto/protokt/v1/testing/oneof_implements.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/oneof_implements.proto
@@ -40,6 +40,7 @@ message ImplementsOneof2 {
 message ContainsOneofThatImplements {
   oneof implementing_oneof {
     option (.protokt.v1.oneof).implements = "OneofModel";
+    option (.protokt.v1.oneof).generate_non_null_accessor = true;
 
     ImplementsOneof1 implements_one = 1;
     ImplementsOneof2 implements_two = 2;

--- a/testing/options/src/main/proto/protokt/v1/testing/wrapper_types.proto
+++ b/testing/options/src/main/proto/protokt/v1/testing/wrapper_types.proto
@@ -105,6 +105,8 @@ message Wrappers {
 
 message OneofWrappers {
   oneof wrapped_oneof {
+    option (.protokt.v1.oneof).generate_non_null_accessor = true;
+
     bytes id_oneof = 1 [
       (.protokt.v1.property).wrap = "protokt.v1.testing.Id"
     ];

--- a/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
@@ -54,6 +54,11 @@ class MessageImplementsTest {
     }
 
     @Test
+    fun `message implementing by a nullable delegate has its delegated property nullable when the delegate has a non-null accessor`() {
+        assertThat(ImplementsModelAgainAgain::class.propertyIsMarkedNullable("bar")).isTrue()
+    }
+
+    @Test
     fun `message implementing by a nullable delegate can be assigned to its interface`() {
         val byDelegate: IModel2 = ImplementsWithNullableDelegate { modelTwo = model2 }
 

--- a/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/MessageImplementsTest.kt
@@ -17,6 +17,7 @@ package protokt.v1.testing
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
+import protokt.v1.testing.ImplementsModel4DelegatingToOneof.Baz.Qux
 
 class MessageImplementsTest {
     private val model = ImplementsModel { id = Id("asdf") }
@@ -55,7 +56,18 @@ class MessageImplementsTest {
 
     @Test
     fun `message implementing by a nullable delegate has its delegated property nullable when the delegate has a non-null accessor`() {
-        assertThat(ImplementsModelAgainAgain::class.propertyIsMarkedNullable("bar")).isTrue()
+        assertThat(ImplementsModel4Again::class.propertyIsMarkedNullable("bar")).isTrue()
+    }
+
+    @Test
+    fun `message implementing by a nullable delegate oneof`() {
+        val byDelegate: IModel4 = ImplementsModel4DelegatingToOneof { baz = Qux(ImplementsModel4 {}) }
+        val fromDelegate: IModel4? = ImplementsModel4DelegatingToOneof { baz = Qux(ImplementsModel4 {}) }.baz
+
+        assertThat(byDelegate).isNotNull()
+        assertThat(fromDelegate).isNotNull()
+
+        assertThat(ImplementsModel4DelegatingToOneof::class.propertyIsMarkedNullable("bar")).isTrue()
     }
 
     @Test

--- a/testing/options/src/test/kotlin/protokt/v1/testing/NonNullableTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/NonNullableTest.kt
@@ -29,6 +29,10 @@ class NonNullableTest {
         assertThat(
             NonNullModel::class.propertyIsMarkedNullable("nonNullStringValue")
         ).isTrue()
+
+        assertThat(
+            NonNullModel::class.propertyIsMarkedNullable("requireNonNullOneof")
+        ).isFalse()
     }
 
     @Test
@@ -50,6 +54,28 @@ class NonNullableTest {
             contains("nonNullStringValue")
             contains("was null")
             contains("(protokt.v1.property).generate_non_null_accessor")
+        }
+    }
+
+    @Test
+    fun `detailed error when attempting to access null oneof`() {
+        val model =
+            NonNullModel.deserialize(
+                NonNullModelMirror {
+                    nonNullStringValue = "asdf"
+                    nonNullOneof = null
+                }.serialize()
+            )
+
+        val thrown =
+            assertThrows<IllegalArgumentException> {
+                model.requireNonNullOneof
+            }
+
+        assertThat(thrown).hasMessageThat().apply {
+            contains("nonNullOneof")
+            contains("was null")
+            contains("(protokt.v1.oneof).generate_non_null_accessor")
         }
     }
 }

--- a/testing/options/src/test/kotlin/protokt/v1/testing/NonNullableTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/NonNullableTest.kt
@@ -49,7 +49,7 @@ class NonNullableTest {
         assertThat(thrown).hasMessageThat().apply {
             contains("nonNullStringValue")
             contains("was null")
-            contains("(protokt.property).generate_non_null_accessor")
+            contains("(protokt.v1.property).generate_non_null_accessor")
         }
     }
 }

--- a/testing/options/src/test/kotlin/protokt/v1/testing/OneofImplementsTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/OneofImplementsTest.kt
@@ -32,4 +32,11 @@ class OneofImplementsTest {
 
         assertThat(assigned?.id).isEqualTo(Id("val"))
     }
+
+    @Test
+    fun `property shared between oneof types can be assigned and accessed without switching using non-null accessor`() {
+        val assigned: OneofModel = obj.requireImplementingOneof
+
+        assertThat(assigned.id).isEqualTo(Id("val"))
+    }
 }

--- a/testing/options/src/test/kotlin/protokt/v1/testing/ProtoktExtensionsTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/ProtoktExtensionsTest.kt
@@ -17,12 +17,12 @@ package protokt.v1.testing
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
-import protokt.v1.ProtoktProtos
+import protokt.v1.protokt_file_descriptor
 import protokt.v1.util.PROTOKT_EXTENSIONS_CLASS_NAME
 
 class ProtoktExtensionsTest {
     @Test
     fun `protokt extensions class name is correct`() {
-        assertThat(PROTOKT_EXTENSIONS_CLASS_NAME).isEqualTo(ProtoktProtos::class.qualifiedName)
+        assertThat(PROTOKT_EXTENSIONS_CLASS_NAME).isEqualTo(protokt_file_descriptor::class.qualifiedName)
     }
 }

--- a/testing/options/src/test/kotlin/protokt/v1/testing/WrapperTypesTest.kt
+++ b/testing/options/src/test/kotlin/protokt/v1/testing/WrapperTypesTest.kt
@@ -352,7 +352,7 @@ class WrapperTypesTest {
 
         assertThat(thrown)
             .hasMessageThat()
-            .isEqualTo("instant is assumed non-null with (protokt.property).generate_non_null_accessor but was null")
+            .isEqualTo("instant is assumed non-null with (protokt.v1.property).generate_non_null_accessor but was null")
     }
 
     @Test

--- a/third-party/proto-google-common-protos-extensions-lite/build.gradle.kts
+++ b/third-party/proto-google-common-protos-extensions-lite/build.gradle.kts
@@ -15,6 +15,7 @@
 
 plugins {
     id("protokt.jvm-conventions")
+    id("protokt.third-party-conventions")
     kotlin("kapt")
 }
 

--- a/third-party/proto-google-common-protos-extensions/build.gradle.kts
+++ b/third-party/proto-google-common-protos-extensions/build.gradle.kts
@@ -15,6 +15,7 @@
 
 plugins {
     id("protokt.jvm-conventions")
+    id("protokt.third-party-conventions")
 }
 
 enablePublishing()

--- a/third-party/proto-google-common-protos-grpc-kotlin/build.gradle.kts
+++ b/third-party/proto-google-common-protos-grpc-kotlin/build.gradle.kts
@@ -18,6 +18,7 @@ import protokt.v1.gradle.protokt
 
 plugins {
     id("protokt.jvm-conventions")
+    id("protokt.third-party-conventions")
 }
 
 localProtokt()

--- a/third-party/proto-google-common-protos-grpc/build.gradle.kts
+++ b/third-party/proto-google-common-protos-grpc/build.gradle.kts
@@ -17,6 +17,7 @@ import protokt.v1.gradle.protokt
 
 plugins {
     id("protokt.jvm-conventions")
+    id("protokt.third-party-conventions")
 }
 
 localProtokt()

--- a/third-party/proto-google-common-protos-lite/build.gradle.kts
+++ b/third-party/proto-google-common-protos-lite/build.gradle.kts
@@ -17,6 +17,7 @@ import protokt.v1.gradle.protokt
 
 plugins {
     id("protokt.multiplatform-published-conventions")
+    id("protokt.third-party-conventions")
 }
 
 localProtokt()

--- a/third-party/proto-google-common-protos/api/proto-google-common-protos.api
+++ b/third-party/proto-google-common-protos/api/proto-google-common-protos.api
@@ -1,8 +1,3 @@
-public final class protokt/v1/google/api/AuthProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/AuthProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Auth_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/AuthProvider$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/AuthRequirement$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
@@ -12,30 +7,15 @@ public final class protokt/v1/google/api/Auth_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/OAuthRequirements$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/BackendProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/BackendProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Backend_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Backend$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/BackendRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/BackendRule$PathTranslation$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/api/BillingProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/BillingProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Billing_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Billing$BillingDestination$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Billing$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/ClientProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ClientProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Client_descriptorsKt {
@@ -58,20 +38,10 @@ public final class protokt/v1/google/api/Client_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/SelectiveGapicGeneration$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/ConfigChangeProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ConfigChangeProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Config_change_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Advice$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/ChangeType$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/ConfigChange$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/ConsumerProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ConsumerProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Consumer_descriptorsKt {
@@ -80,28 +50,13 @@ public final class protokt/v1/google/api/Consumer_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Property$PropertyType$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/api/ContextProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ContextProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Context_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Context$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/ContextRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/ControlProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ControlProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Control_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Control$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/DistributionProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/DistributionProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Distribution_descriptorsKt {
@@ -114,43 +69,18 @@ public final class protokt/v1/google/api/Distribution_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Distribution$Range$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/DocumentationProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/DocumentationProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Documentation_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Documentation$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/DocumentationRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Page$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/EndpointProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/EndpointProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Endpoint_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Endpoint$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/ErrorReasonProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ErrorReasonProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Error_reason_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/ErrorReason$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
-}
-
-public final class protokt/v1/google/api/FieldBehaviorProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/FieldBehaviorProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
-public final class protokt/v1/google/api/FieldInfoProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/FieldInfoProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Field_behavior_descriptorsKt {
@@ -163,16 +93,6 @@ public final class protokt/v1/google/api/Field_info_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/TypeReference$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/HttpBodyProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/HttpBodyProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
-public final class protokt/v1/google/api/HttpProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/HttpProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Http_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/CustomHttpPattern$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Http$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
@@ -183,47 +103,22 @@ public final class protokt/v1/google/api/Httpbody_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/HttpBody$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/LabelProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/LabelProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Label_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/LabelDescriptor$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/LabelDescriptor$ValueType$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
-}
-
-public final class protokt/v1/google/api/LaunchStageProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/LaunchStageProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Launch_stage_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/LaunchStage$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/api/LogProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/LogProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Log_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/LogDescriptor$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/LoggingProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/LoggingProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Logging_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Logging$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Logging$LoggingDestination$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/MetricProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/MetricProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Metric_descriptorsKt {
@@ -235,20 +130,10 @@ public final class protokt/v1/google/api/Metric_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/MetricDescriptor$ValueType$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/api/MonitoredResourceProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/MonitoredResourceProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Monitored_resource_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/MonitoredResource$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/MonitoredResourceDescriptor$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/MonitoredResourceMetadata$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/MonitoringProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/MonitoringProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Monitoring_descriptorsKt {
@@ -256,30 +141,15 @@ public final class protokt/v1/google/api/Monitoring_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Monitoring$MonitoringDestination$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/PolicyProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/PolicyProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Policy_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/FieldPolicy$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/MethodPolicy$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/QuotaProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/QuotaProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Quota_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/MetricRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Quota$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/QuotaLimit$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/ResourceProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ResourceProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Resource_descriptorsKt {
@@ -289,37 +159,17 @@ public final class protokt/v1/google/api/Resource_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/ResourceReference$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/RoutingProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/RoutingProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Routing_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/RoutingParameter$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/RoutingRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/ServiceProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/ServiceProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Service_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Service$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/SourceInfoProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/SourceInfoProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Source_info_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/SourceInfo$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/SystemParameterProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/SystemParameterProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/System_parameter_descriptorsKt {
@@ -328,19 +178,9 @@ public final class protokt/v1/google/api/System_parameter_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/SystemParameters$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/api/UsageProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/UsageProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/api/Usage_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/Usage$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 	public static final fun getDescriptor (Lprotokt/v1/google/api/UsageRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/api/VisibilityProto {
-	public static final field INSTANCE Lprotokt/v1/google/api/VisibilityProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/api/Visibility_descriptorsKt {
@@ -348,8 +188,163 @@ public final class protokt/v1/google/api/Visibility_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/api/VisibilityRule$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/apps/card/v1/CardProto {
-	public static final field INSTANCE Lprotokt/v1/google/apps/card/v1/CardProto;
+public final class protokt/v1/google/api/auth_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/auth_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/backend_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/backend_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/billing_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/billing_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/client_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/client_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/config_change_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/config_change_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/consumer_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/consumer_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/context_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/context_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/control_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/control_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/distribution_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/distribution_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/documentation_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/documentation_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/endpoint_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/endpoint_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/error_reason_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/error_reason_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/field_behavior_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/field_behavior_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/field_info_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/field_info_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/http_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/http_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/httpbody_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/httpbody_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/label_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/label_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/launch_stage_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/launch_stage_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/log_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/log_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/logging_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/logging_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/metric_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/metric_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/monitored_resource_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/monitored_resource_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/monitoring_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/monitoring_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/policy_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/policy_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/quota_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/quota_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/resource_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/resource_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/routing_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/routing_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/service_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/service_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/source_info_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/source_info_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/system_parameter_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/system_parameter_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/usage_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/usage_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/api/visibility_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/api/visibility_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
@@ -408,18 +403,13 @@ public final class protokt/v1/google/apps/card/v1/Card_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/apps/card/v1/Widget$ImageType$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/cloud/ExtendedOperationsProto {
-	public static final field INSTANCE Lprotokt/v1/google/cloud/ExtendedOperationsProto;
+public final class protokt/v1/google/apps/card/v1/card_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/apps/card/v1/card_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/cloud/Extended_operations_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/cloud/OperationResponseMapping$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
-}
-
-public final class protokt/v1/google/cloud/audit/AuditLogProto {
-	public static final field INSTANCE Lprotokt/v1/google/cloud/audit/AuditLogProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/cloud/audit/Audit_log_descriptorsKt {
@@ -437,14 +427,19 @@ public final class protokt/v1/google/cloud/audit/Audit_log_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/cloud/audit/ViolationInfo$PolicyType$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
+public final class protokt/v1/google/cloud/audit/audit_log_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/cloud/audit/audit_log_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/cloud/extended_operations_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/cloud/extended_operations_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
 public final class protokt/v1/google/cloud/location/Locations {
 	public static final field INSTANCE Lprotokt/v1/google/cloud/location/Locations;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/ServiceDescriptor;
-}
-
-public final class protokt/v1/google/cloud/location/LocationsProto {
-	public static final field INSTANCE Lprotokt/v1/google/cloud/location/LocationsProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/cloud/location/Locations_descriptorsKt {
@@ -454,8 +449,8 @@ public final class protokt/v1/google/cloud/location/Locations_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/cloud/location/Location$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/geo/type/ViewportProto {
-	public static final field INSTANCE Lprotokt/v1/google/geo/type/ViewportProto;
+public final class protokt/v1/google/cloud/location/locations_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/cloud/location/locations_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
@@ -463,8 +458,8 @@ public final class protokt/v1/google/geo/type/Viewport_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/geo/type/Viewport$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/logging/type/HttpRequestProto {
-	public static final field INSTANCE Lprotokt/v1/google/logging/type/HttpRequestProto;
+public final class protokt/v1/google/geo/type/viewport_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/geo/type/viewport_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
@@ -472,23 +467,23 @@ public final class protokt/v1/google/logging/type/Http_request_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/logging/type/HttpRequest$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/logging/type/LogSeverityProto {
-	public static final field INSTANCE Lprotokt/v1/google/logging/type/LogSeverityProto;
+public final class protokt/v1/google/logging/type/Log_severity_descriptorsKt {
+	public static final fun getDescriptor (Lprotokt/v1/google/logging/type/LogSeverity$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
+}
+
+public final class protokt/v1/google/logging/type/http_request_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/logging/type/http_request_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
-public final class protokt/v1/google/logging/type/Log_severity_descriptorsKt {
-	public static final fun getDescriptor (Lprotokt/v1/google/logging/type/LogSeverity$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
+public final class protokt/v1/google/logging/type/log_severity_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/logging/type/log_severity_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/longrunning/Operations {
 	public static final field INSTANCE Lprotokt/v1/google/longrunning/Operations;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/ServiceDescriptor;
-}
-
-public final class protokt/v1/google/longrunning/OperationsProto {
-	public static final field INSTANCE Lprotokt/v1/google/longrunning/OperationsProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/longrunning/Operations_descriptorsKt {
@@ -502,18 +497,13 @@ public final class protokt/v1/google/longrunning/Operations_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/longrunning/WaitOperationRequest$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/rpc/CodeProto {
-	public static final field INSTANCE Lprotokt/v1/google/rpc/CodeProto;
+public final class protokt/v1/google/longrunning/operations_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/longrunning/operations_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/rpc/Code_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/rpc/Code$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
-}
-
-public final class protokt/v1/google/rpc/ErrorDetailsProto {
-	public static final field INSTANCE Lprotokt/v1/google/rpc/ErrorDetailsProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/rpc/Error_details_descriptorsKt {
@@ -533,17 +523,12 @@ public final class protokt/v1/google/rpc/Error_details_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/rpc/RetryInfo$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/rpc/StatusProto {
-	public static final field INSTANCE Lprotokt/v1/google/rpc/StatusProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/rpc/Status_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/rpc/Status$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/rpc/context/AttributeContextProto {
-	public static final field INSTANCE Lprotokt/v1/google/rpc/context/AttributeContextProto;
+public final class protokt/v1/google/rpc/code_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/rpc/code_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
@@ -557,17 +542,27 @@ public final class protokt/v1/google/rpc/context/Attribute_context_descriptorsKt
 	public static final fun getDescriptor (Lprotokt/v1/google/rpc/context/AttributeContext$Response$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/rpc/context/AuditContextProto {
-	public static final field INSTANCE Lprotokt/v1/google/rpc/context/AuditContextProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/rpc/context/Audit_context_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/rpc/context/AuditContext$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/shopping/type/TypesProto {
-	public static final field INSTANCE Lprotokt/v1/google/shopping/type/TypesProto;
+public final class protokt/v1/google/rpc/context/attribute_context_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/rpc/context/attribute_context_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/rpc/context/audit_context_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/rpc/context/audit_context_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/rpc/error_details_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/rpc/error_details_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/rpc/status_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/rpc/status_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
@@ -584,8 +579,8 @@ public final class protokt/v1/google/shopping/type/Types_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/shopping/type/Weight$WeightUnit$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/type/CalendarPeriodProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/CalendarPeriodProto;
+public final class protokt/v1/google/shopping/type/types_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/shopping/type/types_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
@@ -593,23 +588,8 @@ public final class protokt/v1/google/type/Calendar_period_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/CalendarPeriod$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
 }
 
-public final class protokt/v1/google/type/ColorProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/ColorProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Color_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Color$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/type/DateProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/DateProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
-public final class protokt/v1/google/type/DateTimeProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/DateTimeProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Date_descriptorsKt {
@@ -621,90 +601,40 @@ public final class protokt/v1/google/type/Datetime_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/TimeZone$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/DayOfWeekProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/DayOfWeekProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Dayofweek_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/DayOfWeek$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
-}
-
-public final class protokt/v1/google/type/DecimalProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/DecimalProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Decimal_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Decimal$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/ExprProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/ExprProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Expr_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Expr$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/type/FractionProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/FractionProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Fraction_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Fraction$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/IntervalProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/IntervalProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Interval_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Interval$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/type/LatLngProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/LatLngProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Latlng_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/LatLng$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/LocalizedTextProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/LocalizedTextProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Localized_text_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/LocalizedText$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/type/MoneyProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/MoneyProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Money_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Money$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/MonthProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/MonthProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Month_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Month$Deserializer;)Lprotokt/v1/google/protobuf/EnumDescriptor;
-}
-
-public final class protokt/v1/google/type/PhoneNumberProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/PhoneNumberProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Phone_number_descriptorsKt {
@@ -712,30 +642,100 @@ public final class protokt/v1/google/type/Phone_number_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/PhoneNumber$ShortCode$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/PostalAddressProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/PostalAddressProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
-}
-
 public final class protokt/v1/google/type/Postal_address_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/PostalAddress$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
-}
-
-public final class protokt/v1/google/type/QuaternionProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/QuaternionProto;
-	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
 public final class protokt/v1/google/type/Quaternion_descriptorsKt {
 	public static final fun getDescriptor (Lprotokt/v1/google/type/Quaternion$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
 }
 
-public final class protokt/v1/google/type/TimeOfDayProto {
-	public static final field INSTANCE Lprotokt/v1/google/type/TimeOfDayProto;
+public final class protokt/v1/google/type/Timeofday_descriptorsKt {
+	public static final fun getDescriptor (Lprotokt/v1/google/type/TimeOfDay$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+}
+
+public final class protokt/v1/google/type/calendar_period_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/calendar_period_file_descriptor;
 	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 
-public final class protokt/v1/google/type/Timeofday_descriptorsKt {
-	public static final fun getDescriptor (Lprotokt/v1/google/type/TimeOfDay$Deserializer;)Lprotokt/v1/google/protobuf/Descriptor;
+public final class protokt/v1/google/type/color_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/color_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/date_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/date_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/datetime_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/datetime_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/dayofweek_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/dayofweek_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/decimal_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/decimal_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/expr_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/expr_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/fraction_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/fraction_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/interval_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/interval_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/latlng_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/latlng_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/localized_text_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/localized_text_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/money_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/money_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/month_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/month_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/phone_number_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/phone_number_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/postal_address_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/postal_address_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/quaternion_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/quaternion_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
+}
+
+public final class protokt/v1/google/type/timeofday_file_descriptor {
+	public static final field INSTANCE Lprotokt/v1/google/type/timeofday_file_descriptor;
+	public final fun getDescriptor ()Lprotokt/v1/google/protobuf/FileDescriptor;
 }
 

--- a/third-party/proto-google-common-protos/build.gradle.kts
+++ b/third-party/proto-google-common-protos/build.gradle.kts
@@ -17,6 +17,7 @@ import protokt.v1.gradle.protokt
 
 plugins {
     id("protokt.multiplatform-published-conventions")
+    id("protokt.third-party-conventions")
 }
 
 localProtokt()

--- a/third-party/proto-google-common-protos/src/commonTest/kotlin/protokt/v1/google/api/ExistenceTest.kt
+++ b/third-party/proto-google-common-protos/src/commonTest/kotlin/protokt/v1/google/api/ExistenceTest.kt
@@ -21,6 +21,6 @@ import kotlin.test.assertNotNull
 class ExistenceTest {
     @Test
     fun descriptors_exist() {
-        assertNotNull(AuthProto::class)
+        assertNotNull(auth_file_descriptor::class)
     }
 }


### PR DESCRIPTION
Uncovered a few bugs when starting to demonstrate some internal upgrades.
- A few message interface implementation bugs
- Removed files break Buf breaking checks

Puts back a non-null accessor generator option for oneof fields.

New extension number reservation has been approved: https://github.com/protocolbuffers/protobuf/pull/20485