### PR TITLE
Add back old wrapper type converters

### DIFF
--- a/protokt-core-lite/api/protokt-core-lite.api
+++ b/protokt-core-lite/api/protokt-core-lite.api
@@ -106,6 +106,16 @@ public final class com/toasttab/protokt/BoolValue$Deserializer : com/toasttab/pr
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/BoolValue;
 }
 
+public final class com/toasttab/protokt/BoolValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/BoolValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Z)Lcom/toasttab/protokt/BoolValue;
+	public fun wrap (Lcom/toasttab/protokt/BoolValue;)Ljava/lang/Boolean;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/toasttab/protokt/BytesValue : com/toasttab/protokt/rt/KtMessage {
 	public static final field Deserializer Lcom/toasttab/protokt/BytesValue$Deserializer;
 	public synthetic fun <init> (Lcom/toasttab/protokt/rt/Bytes;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -133,6 +143,16 @@ public final class com/toasttab/protokt/BytesValue$Deserializer : com/toasttab/p
 	public synthetic fun deserialize (Lcom/toasttab/protokt/rt/KtMessageDeserializer;)Lcom/toasttab/protokt/rt/KtMessage;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/toasttab/protokt/BytesValue;
+}
+
+public final class com/toasttab/protokt/BytesValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/BytesValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (Lcom/toasttab/protokt/rt/Bytes;)Lcom/toasttab/protokt/BytesValue;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/BytesValue;)Lcom/toasttab/protokt/rt/Bytes;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/toasttab/protokt/DescriptorProto : com/toasttab/protokt/rt/KtMessage {
@@ -285,6 +305,16 @@ public final class com/toasttab/protokt/DoubleValue$DoubleValueDsl {
 	public final fun getValue ()D
 	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
 	public final fun setValue (D)V
+}
+
+public final class com/toasttab/protokt/DoubleValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/DoubleValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (D)Lcom/toasttab/protokt/DoubleValue;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/DoubleValue;)Ljava/lang/Double;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/toasttab/protokt/Duration : com/toasttab/protokt/rt/KtMessage {
@@ -1352,6 +1382,16 @@ public final class com/toasttab/protokt/FloatValue$FloatValueDsl {
 	public final fun setValue (F)V
 }
 
+public final class com/toasttab/protokt/FloatValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/FloatValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (F)Lcom/toasttab/protokt/FloatValue;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/FloatValue;)Ljava/lang/Float;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/toasttab/protokt/GeneratedCodeInfo : com/toasttab/protokt/rt/KtMessage {
 	public static final field Deserializer Lcom/toasttab/protokt/GeneratedCodeInfo$Deserializer;
 	public synthetic fun <init> (Ljava/util/List;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1448,6 +1488,16 @@ public final class com/toasttab/protokt/Int32Value$Int32ValueDsl {
 	public final fun setValue (I)V
 }
 
+public final class com/toasttab/protokt/Int32ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/Int32ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (I)Lcom/toasttab/protokt/Int32Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/Int32Value;)Ljava/lang/Integer;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/toasttab/protokt/Int64Value : com/toasttab/protokt/rt/KtMessage {
 	public static final field Deserializer Lcom/toasttab/protokt/Int64Value$Deserializer;
 	public synthetic fun <init> (JLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1475,6 +1525,16 @@ public final class com/toasttab/protokt/Int64Value$Int64ValueDsl {
 	public final fun getValue ()J
 	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
 	public final fun setValue (J)V
+}
+
+public final class com/toasttab/protokt/Int64ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/Int64ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (J)Lcom/toasttab/protokt/Int64Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/Int64Value;)Ljava/lang/Long;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/toasttab/protokt/ListValue : com/toasttab/protokt/rt/KtMessage {
@@ -2041,6 +2101,16 @@ public final class com/toasttab/protokt/StringValue$StringValueDsl {
 	public final fun setValue (Ljava/lang/String;)V
 }
 
+public final class com/toasttab/protokt/StringValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/StringValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/lang/String;)Lcom/toasttab/protokt/StringValue;
+	public fun wrap (Lcom/toasttab/protokt/StringValue;)Ljava/lang/String;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/toasttab/protokt/Struct : com/toasttab/protokt/rt/KtMessage {
 	public static final field Deserializer Lcom/toasttab/protokt/Struct$Deserializer;
 	public synthetic fun <init> (Ljava/util/Map;Lcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2199,6 +2269,16 @@ public final class com/toasttab/protokt/UInt32Value$UInt32ValueDsl {
 	public final fun setValue (I)V
 }
 
+public final class com/toasttab/protokt/UInt32ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/UInt32ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (I)Lcom/toasttab/protokt/UInt32Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/UInt32Value;)Ljava/lang/Integer;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/toasttab/protokt/UInt64Value : com/toasttab/protokt/rt/KtMessage {
 	public static final field Deserializer Lcom/toasttab/protokt/UInt64Value$Deserializer;
 	public synthetic fun <init> (JLcom/toasttab/protokt/rt/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2226,6 +2306,16 @@ public final class com/toasttab/protokt/UInt64Value$UInt64ValueDsl {
 	public final fun getValue ()J
 	public final fun setUnknownFields (Lcom/toasttab/protokt/rt/UnknownFieldSet;)V
 	public final fun setValue (J)V
+}
+
+public final class com/toasttab/protokt/UInt64ValueConverter : com/toasttab/protokt/ext/Converter {
+	public static final field INSTANCE Lcom/toasttab/protokt/UInt64ValueConverter;
+	public fun getWrapped ()Lkotlin/reflect/KClass;
+	public fun getWrapper ()Lkotlin/reflect/KClass;
+	public fun unwrap (J)Lcom/toasttab/protokt/UInt64Value;
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Lcom/toasttab/protokt/UInt64Value;)Ljava/lang/Long;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/toasttab/protokt/UninterpretedOption : com/toasttab/protokt/rt/KtMessage {

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BoolValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BoolValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object BoolValueConverter : com.toasttab.protokt.ext.Converter<Boolean, BoolValue> {
     override val wrapper = Boolean::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BoolValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BoolValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object BoolValueConverter : com.toasttab.protokt.ext.Converter<Boolean, BoolValue> {
+    override val wrapper = Boolean::class
+
+    override val wrapped = BoolValue::class
+
+    override fun wrap(unwrapped: BoolValue) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Boolean) =
+        BoolValue { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BytesValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BytesValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object BytesValueConverter : com.toasttab.protokt.ext.Converter<com.toasttab.protokt.rt.Bytes, com.toasttab.protokt.rt.BytesValue> {
+    override val wrapper = com.toasttab.protokt.rt.Bytes::class
+
+    override val wrapped = BytesValue::class
+
+    override fun wrap(unwrapped: BytesValue) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: com.toasttab.protokt.rt.Bytes) =
+        BytesValue { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BytesValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BytesValueConverter.kt
@@ -17,7 +17,7 @@ package com.toasttab.protokt
 
 @Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
-object BytesValueConverter : com.toasttab.protokt.ext.Converter<com.toasttab.protokt.rt.Bytes, com.toasttab.protokt.rt.BytesValue> {
+object BytesValueConverter : com.toasttab.protokt.ext.Converter<com.toasttab.protokt.rt.Bytes, BytesValue> {
     override val wrapper = com.toasttab.protokt.rt.Bytes::class
 
     override val wrapped = BytesValue::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BytesValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/BytesValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object BytesValueConverter : com.toasttab.protokt.ext.Converter<com.toasttab.protokt.rt.Bytes, com.toasttab.protokt.rt.BytesValue> {
     override val wrapper = com.toasttab.protokt.rt.Bytes::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/DoubleValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/DoubleValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object DoubleValueConverter : com.toasttab.protokt.ext.Converter<Double, DoubleValue> {
     override val wrapper = Double::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/DoubleValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/DoubleValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object DoubleValueConverter : com.toasttab.protokt.ext.Converter<Double, DoubleValue> {
+    override val wrapper = Double::class
+
+    override val wrapped = DoubleValue::class
+
+    override fun wrap(unwrapped: DoubleValue) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Double) =
+        DoubleValue { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/FloatValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/FloatValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object FloatValueConverter : com.toasttab.protokt.ext.Converter<Float, FloatValue> {
     override val wrapper = Float::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/FloatValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/FloatValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object FloatValueConverter : com.toasttab.protokt.ext.Converter<Float, FloatValue> {
+    override val wrapper = Float::class
+
+    override val wrapped = FloatValue::class
+
+    override fun wrap(unwrapped: FloatValue) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Float) =
+        FloatValue { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int32ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int32ValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object Int32ValueConverter : com.toasttab.protokt.ext.Converter<Int, Int32Value> {
     override val wrapper = Int::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int32ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int32ValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object Int32ValueConverter : com.toasttab.protokt.ext.Converter<Int, Int32Value> {
+    override val wrapper = Int::class
+
+    override val wrapped = Int32Value::class
+
+    override fun wrap(unwrapped: Int32Value) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Int) =
+        Int32Value { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int64ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int64ValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object Int64ValueConverter : com.toasttab.protokt.ext.Converter<Long, Int64Value> {
     override val wrapper = Long::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int64ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/Int64ValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object Int64ValueConverter : com.toasttab.protokt.ext.Converter<Long, Int64Value> {
+    override val wrapper = Long::class
+
+    override val wrapped = Int64Value::class
+
+    override fun wrap(unwrapped: Int64Value) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Long) =
+        Int64Value { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/StringValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/StringValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object StringValueConverter : com.toasttab.protokt.ext.Converter<String, StringValue> {
+    override val wrapper = String::class
+
+    override val wrapped = StringValue::class
+
+    override fun wrap(unwrapped: StringValue) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: String) =
+        StringValue { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/StringValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/StringValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object StringValueConverter : com.toasttab.protokt.ext.Converter<String, StringValue> {
     override val wrapper = String::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt32ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt32ValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object UInt32ValueConverter : com.toasttab.protokt.ext.Converter<Int, UInt32Value> {
     override val wrapper = Int::class

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt32ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt32ValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object UInt32ValueConverter : com.toasttab.protokt.ext.Converter<Int, UInt32Value> {
+    override val wrapper = Int::class
+
+    override val wrapped = UInt32Value::class
+
+    override fun wrap(unwrapped: UInt32Value) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Int) =
+        UInt32Value { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt64ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt64ValueConverter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.protokt
+
+@Suppress("DEPRECATION")
+object UInt64ValueConverter : com.toasttab.protokt.ext.Converter<Long, UInt64Value> {
+    override val wrapper = Long::class
+
+    override val wrapped = UInt64Value::class
+
+    override fun wrap(unwrapped: UInt64Value) =
+        unwrapped.value
+
+    override fun unwrap(wrapped: Long) =
+        UInt64Value { value = wrapped }
+}

--- a/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt64ValueConverter.kt
+++ b/protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/UInt64ValueConverter.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.protokt
 
+@Deprecated("for backwards compatibility only")
 @Suppress("DEPRECATION")
 object UInt64ValueConverter : com.toasttab.protokt.ext.Converter<Long, UInt64Value> {
     override val wrapper = Long::class

--- a/protokt-core-lite/src/jvmMain/resources/META-INF/services/com.toasttab.protokt.ext.Converter
+++ b/protokt-core-lite/src/jvmMain/resources/META-INF/services/com.toasttab.protokt.ext.Converter
@@ -1,9 +1,0 @@
-com.toasttab.protokt.BoolValueConverter
-com.toasttab.protokt.BytesValueConverter
-com.toasttab.protokt.DoubleValueConverter
-com.toasttab.protokt.FloatValueConverter
-com.toasttab.protokt.Int32ValueConverter
-com.toasttab.protokt.Int64ValueConverter
-com.toasttab.protokt.StringValueConverter
-com.toasttab.protokt.UInt32ValueConverter
-com.toasttab.protokt.UInt64ValueConverter

--- a/protokt-core-lite/src/jvmMain/resources/META-INF/services/com.toasttab.protokt.ext.Converter
+++ b/protokt-core-lite/src/jvmMain/resources/META-INF/services/com.toasttab.protokt.ext.Converter
@@ -1,0 +1,9 @@
+com.toasttab.protokt.BoolValueConverter
+com.toasttab.protokt.BytesValueConverter
+com.toasttab.protokt.DoubleValueConverter
+com.toasttab.protokt.FloatValueConverter
+com.toasttab.protokt.Int32ValueConverter
+com.toasttab.protokt.Int64ValueConverter
+com.toasttab.protokt.StringValueConverter
+com.toasttab.protokt.UInt32ValueConverter
+com.toasttab.protokt.UInt64ValueConverter


### PR DESCRIPTION
These got lost at some point and are needed for old generated code that uses the default wrappers.