### PR TITLE
Implement oneofs as abstract classes instead of sealed classes

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/OneofGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/OneofGenerator.kt
@@ -46,7 +46,12 @@ private class OneofGenerator(
                     ?.let { inferClassName(it, ctx) }
 
             TypeSpec.classBuilder(oneof.name)
-                .addModifiers(KModifier.SEALED)
+                .addModifiers(KModifier.ABSTRACT)
+                .primaryConstructor(
+                    FunSpec.constructorBuilder()
+                        .addModifiers(KModifier.INTERNAL)
+                        .build()
+                )
                 .handleSuperInterface(implements)
                 .addTypes(
                     types.map { (k, v) ->

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/SerializeAndSizeSupport.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/SerializeAndSizeSupport.kt
@@ -106,7 +106,7 @@ private fun oneofInstanceConditionals(f: Oneof, stmt: (StandardField) -> CodeBlo
             buildCodeBlock {
                 addStatement("is·%T·->\n%L", f.qualify(it), stmt(it))
             }
-        } + buildCodeBlock { addStatement("null·->·Unit") }
+        } + buildCodeBlock { addStatement("else·->·Unit") }
 
 internal fun Oneof.qualify(f: StandardField) =
     className.nestedClass(fieldTypeNames.getValue(f.fieldName))

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
@@ -64,7 +64,7 @@ internal object ProtoktReflect {
         val oneofPropertiesSealedClasses =
             messageClass
                 .nestedClasses
-                .filter { it.isSealed && !it.isSubclassOf(Enum::class) }
+                .filter { it.isAbstract && !it.isSubclassOf(Enum::class) }
 
         val gettersByNumber =
             buildMap {

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/OneofTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/OneofTest.kt
@@ -30,11 +30,14 @@ class OneofTest {
 
         val oneof = OneofExerciseModel {}.oneof
 
+        @Suppress("UNUSED_EXPRESSION")
         when (oneof) {
             // empty is permitted
         }
 
+        @Suppress("UNUSED_VARIABLE")
         val foo =
+            @Suppress("UNUSED_EXPRESSION")
             when (oneof) {
                 // this is forced
                 else -> Unit

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/OneofTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/OneofTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import protokt.v1.testing.oneof.OneofExerciseModel
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.primaryConstructor
+
+class OneofTest {
+    @Test
+    fun `oneofs are abstract and have internal constructors`() {
+        assertThat(OneofExerciseModel.Oneof::class.isAbstract).isTrue()
+        assertThat(OneofExerciseModel.Oneof::class.isSealed).isFalse()
+        assertThat(OneofExerciseModel.Oneof::class.primaryConstructor!!.visibility).isEqualTo(KVisibility.INTERNAL)
+
+        val oneof = OneofExerciseModel {}.oneof
+
+
+        when (oneof) {
+            // empty is permitted
+        }
+
+        val foo =
+            when (oneof) {
+                // this is forced
+                else -> Unit
+            }
+    }
+}

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/OneofTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/OneofTest.kt
@@ -30,7 +30,6 @@ class OneofTest {
 
         val oneof = OneofExerciseModel {}.oneof
 
-
         when (oneof) {
             // empty is permitted
         }


### PR DESCRIPTION
This makes generated code compatible with new options added in future schema versions. See https://github.com/lowasser/protobuf/blame/master/kotlin-design.md#L113-L161

I don't love that this permits empty `when` blocks - I was under the impression that this would require _something_ to be there... then again, it looks like protobuf-kotlin didn't end up doing it this way and relies on a `when` over an enum description of the oneof state, which is ugly and doesn't get smart casting.