### PR TITLE
Fix broken equals method when a field is named `other`

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -219,7 +219,7 @@ private class MessageGenerator(
 
     private fun equalsLines(properties: List<PropertyInfo>) =
         properties.map {
-            CodeBlock.of("other.%N == %N &&\n".bindSpaces(), it.name, it.name)
+            CodeBlock.of("other.%N == this.%N &&\n".bindSpaces(), it.name, it.name)
         }
 
     private fun TypeSpec.Builder.handleHashCode(

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/field_named_other.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/field_named_other.proto
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.v1.testing;
+
+message HasFieldNamedOther {
+  int32 other = 1;
+}

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/FieldNamedOtherTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/FieldNamedOtherTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class FieldNamedOtherTest {
+    @Test
+    fun `message with a field named other compares correctly`() {
+        val obj = HasFieldNamedOther { other = 5 }
+        assertThat(obj).isEqualTo(HasFieldNamedOther { other = 5 })
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/open-toast/protokt/issues/408.