### PR TITLE
Fix LazyConvertingMap hashCode instability breaking AndroidX DataStore

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx4096M
 kotlin.mpp.stability.nowarn=true
 org.gradle.caching=true
 android.experimental.enableTestFixturesKotlinSupport=true
+android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,9 @@ jmh = "1.37"
 wire = "6.0.0"
 
 # test
+androidx-datastore = "1.1.7"
 buf = "1.47.2"
+okio = "3.12.0"
 classgraph = "4.8.184"
 grpc-js = "1.12.4"
 jackson = "2.21.1"
@@ -101,7 +103,10 @@ wireRuntime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" 
 protoGoogleCommonProtos = { module = "com.google.api.grpc:proto-google-common-protos", version.ref = "protoGoogleCommonProtos" }
 
 # test
+androidx-datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "androidx-datastore" }
+androidx-datastore-core-okio = { module = "androidx.datastore:datastore-core-okio", version.ref = "androidx-datastore" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
+okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpc-kotlin" }
 grpc-testing = { module = "io.grpc:grpc-testing", version.ref = "grpc-java" }
 jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageSizeGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageSizeGenerator.kt
@@ -184,7 +184,7 @@ private class MessageSizeGenerator(
         val wireValueType = mapWireValueType(f, info)
         return buildCodeBlock {
             add("@%T(\"UNCHECKED_CAST\")\n", Suppress::class)
-            add("(%N as %T<%T, %T>).let·{·map·->\n", p, LazyConvertingMap::class, com.squareup.kotlinpoet.ANY.copy(nullable = true), com.squareup.kotlinpoet.ANY.copy(nullable = true))
+            add("(%N as %T<%T, %T>).let·{·map·->\n", p, LazyConvertingMap::class, com.squareup.kotlinpoet.ANY, com.squareup.kotlinpoet.ANY)
             indent()
             add("var·sum·=·0\n")
             val sizeOfCall = sizeOfCall(f.mapKey, f.mapValue, CodeBlock.of("wireK"), CodeBlock.of("wireV"))

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/SerializerGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/SerializerGenerator.kt
@@ -118,7 +118,7 @@ private class SerializerGenerator(
             val wireValueType = mapWireValueType(f, info)
             beginControlFlow("if (%N.isNotEmpty())", p)
             add("@%T(\"UNCHECKED_CAST\")\n", Suppress::class)
-            add("(%N as %T<%T, %T>).wireEntryForEach<%T, %T>·{·wireK,·wireV·->\n", p, LazyConvertingMap::class, com.squareup.kotlinpoet.ANY.copy(nullable = true), com.squareup.kotlinpoet.ANY.copy(nullable = true), wireKeyType, wireValueType)
+            add("(%N as %T<%T, %T>).wireEntryForEach<%T, %T>·{·wireK,·wireV·->\n", p, LazyConvertingMap::class, com.squareup.kotlinpoet.ANY, com.squareup.kotlinpoet.ANY, wireKeyType, wireValueType)
             indent()
             add("$WRITER.writeTag(${f.tag.value}u).write(%T(wireK, wireV))\n", f.className)
             unindent()

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/BuilderScope.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/BuilderScope.kt
@@ -41,7 +41,7 @@ interface BuilderScope {
         }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <K, V> Map<K, V>.plus(pair: Pair<K, V>): Map<K, V> =
+    operator fun <K : Any, V : Any> Map<K, V>.plus(pair: Pair<K, V>): Map<K, V> =
         if (this is LazyConvertingMap<*, *>) {
             (this as LazyConvertingMap<K, V>).plus(pair)
         } else {
@@ -49,11 +49,11 @@ interface BuilderScope {
         }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <K, V> Map<K, V>.plus(pairs: Iterable<Pair<K, V>>): Map<K, V> =
+    operator fun <K : Any, V : Any> Map<K, V>.plus(pairs: Iterable<Pair<K, V>>): Map<K, V> =
         collectionFactory.mapPlusAll(this, pairs)
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <K, V> Map<K, V>.plus(other: Map<out K, V>): Map<K, V> =
+    operator fun <K : Any, V : Any> Map<K, V>.plus(other: Map<out K, V>): Map<K, V> =
         if (this is LazyConvertingMap<*, *>) {
             (this as LazyConvertingMap<K, V>).plus(other)
         } else {

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/LazyConvertingMap.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/LazyConvertingMap.kt
@@ -17,7 +17,7 @@ package protokt.v1
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 @OnlyForUseByGeneratedProtoCode
-class LazyConvertingMap<KotlinK, KotlinV>(
+class LazyConvertingMap<KotlinK : Any, KotlinV : Any>(
     private val backing: Map<Any?, Any?>,
     private val keyWrapped: Boolean,
     private val valueWrapped: Boolean,
@@ -95,6 +95,15 @@ class LazyConvertingMap<KotlinK, KotlinV>(
                     return object : Map.Entry<KotlinK, KotlinV> {
                         override val key: KotlinK = key
                         override val value: KotlinV = value
+
+                        override fun hashCode(): Int =
+                            key.hashCode() xor value.hashCode()
+
+                        override fun equals(other: Any?): Boolean =
+                            other is Map.Entry<*, *> && key == other.key && value == other.value
+
+                        override fun toString(): String =
+                            "$key=$value"
                     }
                 }
             }
@@ -103,7 +112,7 @@ class LazyConvertingMap<KotlinK, KotlinV>(
 
     companion object {
         @Suppress("UNCHECKED_CAST")
-        fun <KotlinK, KotlinV> fromKotlin(
+        fun <KotlinK : Any, KotlinV : Any> fromKotlin(
             kotlinMap: Map<KotlinK, KotlinV>,
             keyWrapped: Boolean,
             valueWrapped: Boolean,

--- a/testing/android-test-configurations/build.gradle.kts
+++ b/testing/android-test-configurations/build.gradle.kts
@@ -29,6 +29,10 @@ localProtokt()
 pureKotlin()
 
 dependencies {
+    testImplementation(libs.androidx.datastore.core)
+    testImplementation(libs.androidx.datastore.core.okio)
+    testImplementation(libs.okio.fakefilesystem)
+    testImplementation(libs.kotlinx.coroutines.test)
     testRuntimeOnly(libs.protobuf.lite)
     testRuntimeOnly(libs.kotlinx.io)
 }

--- a/testing/android-test-configurations/src/test/proto/protokt/v1/testing/android/test.proto
+++ b/testing/android-test-configurations/src/test/proto/protokt/v1/testing/android/test.proto
@@ -22,3 +22,7 @@ option java_package = "com.toasttab.protokt.v1.testing.android";
 message TestMessage {
   string foo = 1;
 }
+
+message MapMessage {
+  map<string, TestMessage> entries = 1;
+}

--- a/testing/android/build.gradle.kts
+++ b/testing/android/build.gradle.kts
@@ -24,3 +24,10 @@ android {
 }
 
 localProtokt()
+
+dependencies {
+    testImplementation(libs.androidx.datastore.core)
+    testImplementation(libs.androidx.datastore.core.okio)
+    testImplementation(libs.okio.fakefilesystem)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/testing/android/src/main/proto/protokt/v1/testing/android/test.proto
+++ b/testing/android/src/main/proto/protokt/v1/testing/android/test.proto
@@ -22,3 +22,7 @@ option java_package = "com.toasttab.protokt.v1.testing.android";
 message TestMessage {
   string foo = 1;
 }
+
+message MapMessage {
+  map<string, TestMessage> entries = 1;
+}

--- a/testing/android/src/test/java/protokt/v1/testing/android/DataStoreHashCodeTest.kt
+++ b/testing/android/src/test/java/protokt/v1/testing/android/DataStoreHashCodeTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing.android
+
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Serializer
+import androidx.datastore.core.okio.OkioSerializer
+import androidx.datastore.core.okio.OkioStorage
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+import java.io.InputStream
+import java.io.OutputStream
+
+class DataStoreHashCodeTest {
+    object MapMessageSerializer : Serializer<MapMessage> {
+        override val defaultValue = MapMessage {}
+
+        override suspend fun readFrom(input: InputStream) =
+            MapMessage.deserialize(input)
+
+        override suspend fun writeTo(t: MapMessage, output: OutputStream) =
+            t.serialize(output)
+    }
+
+    private class OkioSerializerWrapper<T>(
+        private val delegate: Serializer<T>
+    ) : OkioSerializer<T> {
+        override val defaultValue: T
+            get() = delegate.defaultValue
+
+        override suspend fun readFrom(source: BufferedSource) =
+            delegate.readFrom(source.inputStream())
+
+        override suspend fun writeTo(t: T, sink: BufferedSink) =
+            delegate.writeTo(t, sink.outputStream())
+    }
+
+    @Test
+    fun `second write to DataStore succeeds without hashCode mutation error`() =
+        runTest {
+            val fileSystem = FakeFileSystem()
+            val dataStore = DataStoreFactory.create(
+                OkioStorage(
+                    fileSystem,
+                    OkioSerializerWrapper(MapMessageSerializer),
+                    producePath = { "/test-cache".toPath() }
+                )
+            )
+
+            dataStore.updateData {
+                MapMessage {
+                    entries = mapOf("a" to TestMessage { foo = "1" })
+                }
+            }
+
+            dataStore.updateData {
+                MapMessage {
+                    entries = mapOf("b" to TestMessage { foo = "2" })
+                }
+            }
+
+            val result = dataStore.data.first()
+            assertThat(result.entries).containsKey("b")
+        }
+}

--- a/testing/interop/src/test/kotlin/protokt/v1/testing/LazyConvertingCollectionHashCodeTest.kt
+++ b/testing/interop/src/test/kotlin/protokt/v1/testing/LazyConvertingCollectionHashCodeTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import protokt.v1.Bytes
+import protokt.v1.testing.Test as KtTest
+
+class LazyConvertingCollectionHashCodeTest {
+    @Nested
+    inner class Map {
+        @Test
+        fun `hashCode is stable across calls before deserialization`() {
+            val mapTest = MapTest {
+                map = mapOf(
+                    "foo" to KtTest { `val` = Bytes.from("bar".toByteArray()) }
+                )
+            }
+
+            val hash1 = mapTest.hashCode()
+            val hash2 = mapTest.hashCode()
+            assertThat(hash1).isEqualTo(hash2)
+        }
+
+        @Test
+        fun `hashCode is stable after serialization round trip`() {
+            val original = MapTest {
+                map = mapOf(
+                    "foo" to KtTest { `val` = Bytes.from("bar".toByteArray()) }
+                )
+            }
+
+            val deserialized = MapTest.deserialize(original.serialize())
+
+            val hash1 = deserialized.hashCode()
+            // Access the map entries to trigger lazy conversion
+            deserialized.map.forEach { (k, v) -> k.length + v.`val`.bytes.size }
+            val hash2 = deserialized.hashCode()
+
+            assertThat(hash1).isEqualTo(hash2)
+        }
+
+        @Test
+        fun `equals is consistent after serialization round trip`() {
+            val original = MapTest {
+                map = mapOf(
+                    "foo" to KtTest { `val` = Bytes.from("bar".toByteArray()) }
+                )
+            }
+
+            val deserialized = MapTest.deserialize(original.serialize())
+
+            assertThat(deserialized).isEqualTo(original)
+            assertThat(original).isEqualTo(deserialized)
+        }
+    }
+
+    @Nested
+    inner class List {
+        @Test
+        fun `hashCode is stable across calls before deserialization`() {
+            val listTest = ListTest {
+                list = listOf(
+                    KtTest { `val` = Bytes.from("bar".toByteArray()) }
+                )
+            }
+
+            val hash1 = listTest.hashCode()
+            val hash2 = listTest.hashCode()
+            assertThat(hash1).isEqualTo(hash2)
+        }
+
+        @Test
+        fun `hashCode is stable after serialization round trip`() {
+            val original = ListTest {
+                list = listOf(
+                    KtTest { `val` = Bytes.from("bar".toByteArray()) }
+                )
+            }
+
+            val deserialized = ListTest.deserialize(original.serialize())
+
+            val hash1 = deserialized.hashCode()
+            // Access the list entries to trigger lazy conversion
+            deserialized.list.forEach { it.`val`.bytes.size }
+            val hash2 = deserialized.hashCode()
+
+            assertThat(hash1).isEqualTo(hash2)
+        }
+
+        @Test
+        fun `equals is consistent after serialization round trip`() {
+            val original = ListTest {
+                list = listOf(
+                    KtTest { `val` = Bytes.from("bar".toByteArray()) }
+                )
+            }
+
+            val deserialized = ListTest.deserialize(original.serialize())
+
+            assertThat(deserialized).isEqualTo(original)
+            assertThat(original).isEqualTo(deserialized)
+        }
+    }
+}


### PR DESCRIPTION
The anonymous Map.Entry objects in ConvertingEntrySet didn't override hashCode()/equals(), so AbstractMap.hashCode() used identity-based hashes that changed on every call. This caused AndroidX DataStore to throw "Data in DataStore was mutated but DataStore is only compatible with Immutable types" on the second write.

Add proper hashCode/equals/toString to the Map.Entry implementation following the Map.Entry contract. Tighten LazyConvertingMap and BuilderScope map type parameters to non-nullable bounds.