### PR TITLE
Extension API and UnknownFieldSet cleanup

### DIFF
--- a/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
+++ b/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
@@ -13,7 +13,7 @@ public final class protokt/v1/EnumOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -48,7 +48,7 @@ public final class protokt/v1/EnumValueOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumValueOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumValueOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -86,7 +86,7 @@ public final class protokt/v1/FieldOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getKeyWrap ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueWrap ()Ljava/lang/String;
 	public final fun getWrap ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -133,7 +133,7 @@ public final class protokt/v1/FileOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/FileOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/FileOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -185,7 +185,7 @@ public final class protokt/v1/InetSocketAddress : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lprotokt/v1/Bytes;
 	public final fun getPort ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/InetSocketAddress;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -255,7 +255,7 @@ public final class protokt/v1/MessageOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MessageOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -293,7 +293,7 @@ public final class protokt/v1/MethodOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestMarshaller ()Ljava/lang/String;
 	public final fun getResponseMarshaller ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MethodOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -332,7 +332,7 @@ public final class protokt/v1/OneofOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/OneofOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -370,7 +370,7 @@ public final class protokt/v1/ServiceOptions : protokt/v1/AbstractMessage {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/ServiceOptions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MapEntryGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MapEntryGenerator.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
@@ -28,6 +29,7 @@ import protokt.v1.AbstractMessage
 import protokt.v1.Bytes
 import protokt.v1.Reader
 import protokt.v1.StringConverter
+import protokt.v1.UnknownFieldSet
 import protokt.v1.Writer
 import protokt.v1.codegen.generate.CodeGenerator.Context
 import protokt.v1.codegen.generate.Wrapper.interceptDefaultValue
@@ -80,6 +82,12 @@ private class MapEntryGenerator(
             superclass(AbstractMessage::class)
             addProperty(keyProp)
             addProperty(valProp)
+            addProperty(
+                PropertySpec.builder("unknownFields", UnknownFieldSet::class)
+                    .addModifiers(KModifier.OVERRIDE)
+                    .initializer("%T.empty()", UnknownFieldSet::class)
+                    .build()
+            )
             addConstructor()
             addMessageSize()
             addSerialize()

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -92,6 +92,7 @@ private class MessageGenerator(
             addProperties(props.constructorPropertySpecs)
             addProperty(
                 PropertySpec.builder("unknownFields", UnknownFieldSet::class)
+                    .addModifiers(KModifier.OVERRIDE)
                     .initializer("unknownFields")
                     .build()
             )

--- a/protokt-core-lite/api/protokt-core-lite.api
+++ b/protokt-core-lite/api/protokt-core-lite.api
@@ -5,7 +5,7 @@ public final class protokt/v1/google/protobuf/Any : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Any;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTypeUrl ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Lprotokt/v1/Bytes;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Any;
@@ -48,7 +48,7 @@ public final class protokt/v1/google/protobuf/Api : protokt/v1/AbstractMessage {
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getSourceContext ()Lprotokt/v1/google/protobuf/SourceContext;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Api;
@@ -95,7 +95,7 @@ public final class protokt/v1/google/protobuf/BoolValue : protokt/v1/AbstractMes
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BoolValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/BoolValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Z
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BoolValue;
@@ -140,7 +140,7 @@ public final class protokt/v1/google/protobuf/BytesValue : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BytesValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/BytesValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Lprotokt/v1/Bytes;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BytesValue;
@@ -195,7 +195,7 @@ public final class protokt/v1/google/protobuf/DescriptorProto : protokt/v1/Abstr
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/MessageOptions;
 	public final fun getReservedName ()Ljava/util/List;
 	public final fun getReservedRange ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -250,7 +250,7 @@ public final class protokt/v1/google/protobuf/DescriptorProto$ExtensionRange : p
 	public final fun getEnd ()Ljava/lang/Integer;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/ExtensionRangeOptions;
 	public final fun getStart ()Ljava/lang/Integer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DescriptorProto$ExtensionRange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -290,7 +290,7 @@ public final class protokt/v1/google/protobuf/DescriptorProto$ReservedRange : pr
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnd ()Ljava/lang/Integer;
 	public final fun getStart ()Ljava/lang/Integer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DescriptorProto$ReservedRange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -326,7 +326,7 @@ public final class protokt/v1/google/protobuf/DoubleValue : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DoubleValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/DoubleValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()D
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DoubleValue;
@@ -373,7 +373,7 @@ public final class protokt/v1/google/protobuf/Duration : protokt/v1/AbstractMess
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNanos ()I
 	public final fun getSeconds ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Duration;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -473,7 +473,7 @@ public final class protokt/v1/google/protobuf/Empty : protokt/v1/AbstractMessage
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Empty;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Empty;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Empty;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -511,7 +511,7 @@ public final class protokt/v1/google/protobuf/Enum : protokt/v1/AbstractMessage 
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getSourceContext ()Lprotokt/v1/google/protobuf/SourceContext;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Enum;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -559,7 +559,7 @@ public final class protokt/v1/google/protobuf/EnumDescriptorProto : protokt/v1/A
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/EnumOptions;
 	public final fun getReservedName ()Ljava/util/List;
 	public final fun getReservedRange ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumDescriptorProto;
@@ -604,7 +604,7 @@ public final class protokt/v1/google/protobuf/EnumDescriptorProto$EnumReservedRa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnd ()Ljava/lang/Integer;
 	public final fun getStart ()Ljava/lang/Integer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumDescriptorProto$EnumReservedRange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -645,7 +645,7 @@ public final class protokt/v1/google/protobuf/EnumOptions : protokt/v1/AbstractM
 	public final fun getDeprecatedLegacyJsonFieldConflicts ()Ljava/lang/Boolean;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -690,7 +690,7 @@ public final class protokt/v1/google/protobuf/EnumValue : protokt/v1/AbstractMes
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNumber ()I
 	public final fun getOptions ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumValue;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -731,7 +731,7 @@ public final class protokt/v1/google/protobuf/EnumValueDescriptorProto : protokt
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNumber ()Ljava/lang/Integer;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/EnumValueOptions;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumValueDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -774,7 +774,7 @@ public final class protokt/v1/google/protobuf/EnumValueOptions : protokt/v1/Abst
 	public final fun getFeatureSupport ()Lprotokt/v1/google/protobuf/FieldOptions$FeatureSupport;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumValueOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -819,7 +819,7 @@ public final class protokt/v1/google/protobuf/ExtensionRangeOptions : protokt/v1
 	public final fun getDeclaration ()Ljava/util/List;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVerification ()Lprotokt/v1/google/protobuf/ExtensionRangeOptions$VerificationState;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ExtensionRangeOptions;
@@ -859,7 +859,7 @@ public final class protokt/v1/google/protobuf/ExtensionRangeOptions$Declaration 
 	public final fun getRepeated ()Ljava/lang/Boolean;
 	public final fun getReserved ()Ljava/lang/Boolean;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ExtensionRangeOptions$Declaration;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -937,7 +937,7 @@ public final class protokt/v1/google/protobuf/FeatureSet : protokt/v1/AbstractMe
 	public final fun getJsonFormat ()Lprotokt/v1/google/protobuf/FeatureSet$JsonFormat;
 	public final fun getMessageEncoding ()Lprotokt/v1/google/protobuf/FeatureSet$MessageEncoding;
 	public final fun getRepeatedFieldEncoding ()Lprotokt/v1/google/protobuf/FeatureSet$RepeatedFieldEncoding;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUtf8Validation ()Lprotokt/v1/google/protobuf/FeatureSet$Utf8Validation;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FeatureSet;
@@ -1187,7 +1187,7 @@ public final class protokt/v1/google/protobuf/FeatureSetDefaults : protokt/v1/Ab
 	public final fun getDefaults ()Ljava/util/List;
 	public final fun getMaximumEdition ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getMinimumEdition ()Lprotokt/v1/google/protobuf/Edition;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FeatureSetDefaults;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1228,7 +1228,7 @@ public final class protokt/v1/google/protobuf/FeatureSetDefaults$FeatureSetEditi
 	public final fun getEdition ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getFixedFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getOverridableFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FeatureSetDefaults$FeatureSetEditionDefault;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1276,7 +1276,7 @@ public final class protokt/v1/google/protobuf/Field : protokt/v1/AbstractMessage
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getPacked ()Z
 	public final fun getTypeUrl ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Field;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1463,7 +1463,7 @@ public final class protokt/v1/google/protobuf/FieldDescriptorProto : protokt/v1/
 	public final fun getProto3Optional ()Ljava/lang/Boolean;
 	public final fun getType ()Lprotokt/v1/google/protobuf/FieldDescriptorProto$Type;
 	public final fun getTypeName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1634,7 +1634,7 @@ public final class protokt/v1/google/protobuf/FieldMask : protokt/v1/AbstractMes
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FieldMask;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPaths ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldMask;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1680,7 +1680,7 @@ public final class protokt/v1/google/protobuf/FieldOptions : protokt/v1/Abstract
 	public final fun getRetention ()Lprotokt/v1/google/protobuf/FieldOptions$OptionRetention;
 	public final fun getTargets ()Ljava/util/List;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUnverifiedLazy ()Ljava/lang/Boolean;
 	public final fun getWeak ()Ljava/lang/Boolean;
 	public fun hashCode ()I
@@ -1771,7 +1771,7 @@ public final class protokt/v1/google/protobuf/FieldOptions$EditionDefault : prot
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FieldOptions$EditionDefault;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEdition ()Lprotokt/v1/google/protobuf/Edition;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldOptions$EditionDefault;
@@ -1812,7 +1812,7 @@ public final class protokt/v1/google/protobuf/FieldOptions$FeatureSupport : prot
 	public final fun getEditionDeprecated ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getEditionIntroduced ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getEditionRemoved ()Lprotokt/v1/google/protobuf/Edition;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldOptions$FeatureSupport;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1976,7 +1976,7 @@ public final class protokt/v1/google/protobuf/FileDescriptorProto : protokt/v1/A
 	public final fun getService ()Ljava/util/List;
 	public final fun getSourceCodeInfo ()Lprotokt/v1/google/protobuf/SourceCodeInfo;
 	public final fun getSyntax ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWeakDependency ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FileDescriptorProto;
@@ -2036,7 +2036,7 @@ public final class protokt/v1/google/protobuf/FileDescriptorSet : protokt/v1/Abs
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FileDescriptorSet;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFile ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FileDescriptorSet;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2091,7 +2091,7 @@ public final class protokt/v1/google/protobuf/FileOptions : protokt/v1/AbstractM
 	public final fun getRubyPackage ()Ljava/lang/String;
 	public final fun getSwiftPrefix ()Ljava/lang/String;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FileOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2193,7 +2193,7 @@ public final class protokt/v1/google/protobuf/FloatValue : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FloatValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FloatValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()F
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FloatValue;
@@ -2239,7 +2239,7 @@ public final class protokt/v1/google/protobuf/GeneratedCodeInfo : protokt/v1/Abs
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/GeneratedCodeInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnnotation ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/GeneratedCodeInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2259,7 +2259,7 @@ public final class protokt/v1/google/protobuf/GeneratedCodeInfo$Annotation : pro
 	public final fun getPath ()Ljava/util/List;
 	public final fun getSemantic ()Lprotokt/v1/google/protobuf/GeneratedCodeInfo$Annotation$Semantic;
 	public final fun getSourceFile ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/GeneratedCodeInfo$Annotation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2348,7 +2348,7 @@ public final class protokt/v1/google/protobuf/Int32Value : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int32Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Int32Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int32Value;
@@ -2393,7 +2393,7 @@ public final class protokt/v1/google/protobuf/Int64Value : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int64Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Int64Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()J
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int64Value;
@@ -2438,7 +2438,7 @@ public final class protokt/v1/google/protobuf/ListValue : protokt/v1/AbstractMes
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ListValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/ListValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ListValue;
@@ -2480,7 +2480,7 @@ public final class protokt/v1/google/protobuf/MessageOptions : protokt/v1/Abstra
 	public final fun getMessageSetWireFormat ()Ljava/lang/Boolean;
 	public final fun getNoStandardDescriptorAccessor ()Ljava/lang/Boolean;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/MessageOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2533,7 +2533,7 @@ public final class protokt/v1/google/protobuf/Method : protokt/v1/AbstractMessag
 	public final fun getResponseStreaming ()Z
 	public final fun getResponseTypeUrl ()Ljava/lang/String;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Method;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2585,7 +2585,7 @@ public final class protokt/v1/google/protobuf/MethodDescriptorProto : protokt/v1
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/MethodOptions;
 	public final fun getOutputType ()Ljava/lang/String;
 	public final fun getServerStreaming ()Ljava/lang/Boolean;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/MethodDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2633,7 +2633,7 @@ public final class protokt/v1/google/protobuf/MethodOptions : protokt/v1/Abstrac
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getIdempotencyLevel ()Lprotokt/v1/google/protobuf/MethodOptions$IdempotencyLevel;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/MethodOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2703,7 +2703,7 @@ public final class protokt/v1/google/protobuf/Mixin : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRoot ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Mixin;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2761,7 +2761,7 @@ public final class protokt/v1/google/protobuf/OneofDescriptorProto : protokt/v1/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/OneofOptions;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/OneofDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2799,7 +2799,7 @@ public final class protokt/v1/google/protobuf/OneofOptions : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/OneofOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2836,7 +2836,7 @@ public final class protokt/v1/google/protobuf/Option : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Option;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Lprotokt/v1/google/protobuf/Any;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Option;
@@ -2876,7 +2876,7 @@ public final class protokt/v1/google/protobuf/ServiceDescriptorProto : protokt/v
 	public final fun getMethod ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/ServiceOptions;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ServiceDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2917,7 +2917,7 @@ public final class protokt/v1/google/protobuf/ServiceOptions : protokt/v1/Abstra
 	public final fun getDeprecated ()Ljava/lang/Boolean;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ServiceOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2956,7 +2956,7 @@ public final class protokt/v1/google/protobuf/SourceCodeInfo : protokt/v1/Abstra
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/SourceCodeInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLocation ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/SourceCodeInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2995,7 +2995,7 @@ public final class protokt/v1/google/protobuf/SourceCodeInfo$Location : protokt/
 	public final fun getPath ()Ljava/util/List;
 	public final fun getSpan ()Ljava/util/List;
 	public final fun getTrailingComments ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/SourceCodeInfo$Location;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3038,7 +3038,7 @@ public final class protokt/v1/google/protobuf/SourceContext : protokt/v1/Abstrac
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/SourceContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFileName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/SourceContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3072,7 +3072,7 @@ public final class protokt/v1/google/protobuf/StringValue : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/StringValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/StringValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/StringValue;
@@ -3118,7 +3118,7 @@ public final class protokt/v1/google/protobuf/Struct : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Struct;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFields ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Struct;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3182,7 +3182,7 @@ public final class protokt/v1/google/protobuf/Timestamp : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNanos ()I
 	public final fun getSeconds ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Timestamp;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3225,7 +3225,7 @@ public final class protokt/v1/google/protobuf/Type : protokt/v1/AbstractMessage 
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getSourceContext ()Lprotokt/v1/google/protobuf/SourceContext;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Type;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3271,7 +3271,7 @@ public final class protokt/v1/google/protobuf/UInt32Value : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt32Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/UInt32Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue-pVg5ArA ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt32Value;
@@ -3316,7 +3316,7 @@ public final class protokt/v1/google/protobuf/UInt64Value : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt64Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/UInt64Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue-s-VKNKU ()J
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt64Value;
@@ -3368,7 +3368,7 @@ public final class protokt/v1/google/protobuf/UninterpretedOption : protokt/v1/A
 	public final fun getNegativeIntValue ()Ljava/lang/Long;
 	public final fun getPositiveIntValue-6VbMDqA ()Lkotlin/ULong;
 	public final fun getStringValue ()Lprotokt/v1/Bytes;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UninterpretedOption;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3415,7 +3415,7 @@ public final class protokt/v1/google/protobuf/UninterpretedOption$NamePart : pro
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/UninterpretedOption$NamePart;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNamePart ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UninterpretedOption$NamePart;
 	public final fun isExtension ()Z
@@ -3453,7 +3453,7 @@ public final class protokt/v1/google/protobuf/Value : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Value;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKind ()Lprotokt/v1/google/protobuf/Value$Kind;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Value;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3557,7 +3557,7 @@ public final class protokt/v1/pb/JavaFeatures : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/pb/JavaFeatures;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLegacyClosedEnum ()Ljava/lang/Boolean;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUseOldOuterClassnameDefault ()Ljava/lang/Boolean;
 	public final fun getUtf8Validation ()Lprotokt/v1/pb/JavaFeatures$Utf8Validation;
 	public fun hashCode ()I

--- a/protokt-reflect/api/protokt-reflect.api
+++ b/protokt-reflect/api/protokt-reflect.api
@@ -711,7 +711,7 @@ public final class protokt/v1/EnumOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -746,7 +746,7 @@ public final class protokt/v1/EnumValueOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumValueOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumValueOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -784,7 +784,7 @@ public final class protokt/v1/FieldOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getKeyWrap ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueWrap ()Ljava/lang/String;
 	public final fun getWrap ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -831,7 +831,7 @@ public final class protokt/v1/FileOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/FileOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/FileOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -867,7 +867,7 @@ public final class protokt/v1/MessageOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MessageOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -905,7 +905,7 @@ public final class protokt/v1/MethodOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestMarshaller ()Ljava/lang/String;
 	public final fun getResponseMarshaller ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MethodOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -944,7 +944,7 @@ public final class protokt/v1/OneofOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/OneofOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -993,7 +993,7 @@ public final class protokt/v1/ServiceOptions : protokt/v1/AbstractMessage {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/ServiceOptions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
@@ -23,7 +23,6 @@ import protokt.v1.Fixed64Val
 import protokt.v1.GeneratedProperty
 import protokt.v1.LengthDelimitedVal
 import protokt.v1.Message
-import protokt.v1.UnknownFieldSet
 import protokt.v1.VarintVal
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
@@ -99,7 +98,7 @@ internal object ProtoktReflect {
     }
 
     private fun getUnknownField(field: FieldDescriptor, message: Message) =
-        getUnknownFields(message)[field.number.toUInt()]?.let { value ->
+        message.unknownFields[field.number.toUInt()]?.let { value ->
             when {
                 value.varint.isNotEmpty() ->
                     value.varint
@@ -146,14 +145,3 @@ internal object ProtoktReflect {
     fun getField(message: Message, field: FieldDescriptor): Any? =
         getReflectedGettersByClass(message::class)(field, message)
 }
-
-internal fun getUnknownFields(message: Message) =
-    message::class
-        .declaredMemberProperties
-        .firstOrNull { it.returnType.classifier == UnknownFieldSet::class }
-        .let {
-            @Suppress("UNCHECKED_CAST")
-            it as KProperty1<Message, UnknownFieldSet>
-        }
-        .get(message)
-        .unknownFields

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
@@ -227,10 +227,11 @@ private fun convertMap(
     }
 }
 
+@OptIn(protokt.v1.OnlyForUseByGeneratedProtoCode::class)
 private fun mapUnknownFields(message: Message): UnknownFieldSet {
     val unknownFields = UnknownFieldSet.newBuilder()
 
-    getUnknownFields(message).forEach { (number, field) ->
+    message.unknownFields.forEach { number, field ->
         unknownFields.mergeField(
             number.toInt(),
             Field.newBuilder()

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -130,6 +130,43 @@ public abstract interface class protokt/v1/EnumDeserializer {
 	public abstract fun deserialize (I)Lprotokt/v1/Enum;
 }
 
+public final class protokt/v1/Extension {
+	public synthetic fun <init> (ILprotokt/v1/ExtensionCodec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getNumber-pVg5ArA ()I
+}
+
+public abstract interface class protokt/v1/ExtensionCodec {
+	public abstract fun decodeRepeated (Lprotokt/v1/UnknownFieldSet$Field;)Ljava/util/List;
+	public abstract fun decodeSingular (Lprotokt/v1/UnknownFieldSet$Field;)Ljava/lang/Object;
+	public abstract fun encode-qim9Vi0 (ILjava/lang/Object;)Lprotokt/v1/UnknownField;
+}
+
+public final class protokt/v1/ExtensionCodecs {
+	public static final field INSTANCE Lprotokt/v1/ExtensionCodecs;
+	public final fun enum (Lprotokt/v1/EnumDeserializer;)Lprotokt/v1/ExtensionCodec;
+	public final fun getBool ()Lprotokt/v1/ExtensionCodec;
+	public final fun getBytes ()Lprotokt/v1/ExtensionCodec;
+	public final fun getDouble ()Lprotokt/v1/ExtensionCodec;
+	public final fun getFixed32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getFixed64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getFloat ()Lprotokt/v1/ExtensionCodec;
+	public final fun getInt32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getInt64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSfixed32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSfixed64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSint32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSint64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getString ()Lprotokt/v1/ExtensionCodec;
+	public final fun getUint32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getUint64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun message (Lprotokt/v1/Deserializer;)Lprotokt/v1/ExtensionCodec;
+}
+
+public final class protokt/v1/ExtensionKt {
+	public static final fun get (Lprotokt/v1/Message;Lprotokt/v1/Extension;)Ljava/lang/Object;
+	public static final fun get (Lprotokt/v1/Message;Lprotokt/v1/RepeatedExtension;)Ljava/util/List;
+}
+
 public final class protokt/v1/Fixed32Val : protokt/v1/UnknownValue {
 	public static final synthetic fun box-impl (I)Lprotokt/v1/Fixed32Val;
 	public static fun constructor-impl (I)I
@@ -248,6 +285,7 @@ public abstract interface class protokt/v1/MapBuilder {
 }
 
 public abstract interface class protokt/v1/Message {
+	public abstract fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public abstract fun serialize ()[B
 	public fun serialize (Ljava/io/OutputStream;)V
 	public abstract fun serialize (Lprotokt/v1/Writer;)V
@@ -280,6 +318,11 @@ public abstract interface class protokt/v1/Reader {
 	public fun readUInt32-pVg5ArA ()I
 	public abstract fun readUInt64-s-VKNKU ()J
 	public fun readUnknown ()Lprotokt/v1/UnknownField;
+}
+
+public final class protokt/v1/RepeatedExtension {
+	public synthetic fun <init> (ILprotokt/v1/ExtensionCodec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getNumber-pVg5ArA ()I
 }
 
 public final class protokt/v1/Sizes {
@@ -331,8 +374,10 @@ public final class protokt/v1/UnknownField$Companion {
 public final class protokt/v1/UnknownFieldSet {
 	public static final field Companion Lprotokt/v1/UnknownFieldSet$Companion;
 	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun contains-WZ4Q5Ns (I)Z
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Ljava/util/Map;
+	public final fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public final fun get-WZ4Q5Ns (I)Lprotokt/v1/UnknownFieldSet$Field;
 	public fun hashCode ()I
 	public final fun isEmpty ()Z
 	public final fun size ()I

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Extension.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Extension.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+@Beta
+class Extension<in E : Message, out T>(
+    val number: UInt,
+    internal val codec: ExtensionCodec<@UnsafeVariance T>
+)
+
+@Beta
+class RepeatedExtension<in E : Message, out T>(
+    val number: UInt,
+    internal val codec: ExtensionCodec<@UnsafeVariance T>
+)
+
+@Beta
+operator fun <E : Message, T> E.get(ext: Extension<E, T>): T? {
+    val field = unknownFields[ext.number] ?: return null
+    return ext.codec.decodeSingular(field)
+}
+
+@Beta
+operator fun <E : Message, T> E.get(ext: RepeatedExtension<E, T>): List<T> {
+    val field = unknownFields[ext.number] ?: return emptyList()
+    return ext.codec.decodeRepeated(field)
+}

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+@Beta
+sealed interface ExtensionCodec<T> {
+    fun decodeSingular(field: UnknownFieldSet.Field): T?
+    fun decodeRepeated(field: UnknownFieldSet.Field): List<T>
+    fun encode(fieldNumber: UInt, value: T): UnknownField
+}
+
+@Beta
+object ExtensionCodecs {
+    val int32: ExtensionCodec<Int> =
+        VarintCodec({ it.toLong().toInt() }, { it.toLong().toULong() })
+
+    val int64: ExtensionCodec<Long> =
+        VarintCodec({ it.toLong() }, { it.toULong() })
+
+    val uint32: ExtensionCodec<UInt> =
+        VarintCodec({ it.toUInt() }, { it.toULong() })
+
+    val uint64: ExtensionCodec<ULong> =
+        VarintCodec({ it }, { it })
+
+    val sint32: ExtensionCodec<Int> =
+        VarintCodec(
+            {
+                val n = it.toInt()
+                (n ushr 1) xor -(n and 1)
+            },
+            {
+                val v = it
+                ((v shl 1) xor (v shr 31)).toUInt().toULong()
+            }
+        )
+
+    val sint64: ExtensionCodec<Long> =
+        VarintCodec(
+            {
+                val n = it.toLong()
+                (n ushr 1) xor -(n and 1)
+            },
+            {
+                val v = it
+                ((v shl 1) xor (v shr 63)).toULong()
+            }
+        )
+
+    val bool: ExtensionCodec<Boolean> =
+        VarintCodec({ it != 0uL }, { if (it) 1uL else 0uL })
+
+    val fixed32: ExtensionCodec<UInt> =
+        Fixed32Codec({ it }, { it })
+
+    val sfixed32: ExtensionCodec<Int> =
+        Fixed32Codec({ it.toInt() }, { it.toUInt() })
+
+    val float: ExtensionCodec<Float> =
+        Fixed32Codec({ Float.fromBits(it.toInt()) }, { it.toRawBits().toUInt() })
+
+    val fixed64: ExtensionCodec<ULong> =
+        Fixed64Codec({ it }, { it })
+
+    val sfixed64: ExtensionCodec<Long> =
+        Fixed64Codec({ it.toLong() }, { it.toULong() })
+
+    val double: ExtensionCodec<Double> =
+        Fixed64Codec({ Double.fromBits(it.toLong()) }, { it.toRawBits().toULong() })
+
+    val string: ExtensionCodec<String> =
+        LengthDelimitedCodec(
+            { it.value.value.decodeToString() },
+            { LengthDelimitedVal(Bytes(it.encodeToByteArray())) }
+        )
+
+    val bytes: ExtensionCodec<Bytes> =
+        LengthDelimitedCodec(
+            { it.value },
+            { LengthDelimitedVal(it) }
+        )
+
+    fun <T : Message> message(deserializer: Deserializer<T>): ExtensionCodec<T> =
+        LengthDelimitedCodec(
+            { deserializer.deserialize(it.value) },
+            { LengthDelimitedVal(Bytes(it.serialize())) }
+        )
+
+    fun <T : Enum> enum(deserializer: EnumDeserializer<T>): ExtensionCodec<T> =
+        VarintCodec({ deserializer.deserialize(it.toInt()) }, { it.value.toULong() })
+}
+
+private class VarintCodec<T>(
+    private val decode: (ULong) -> T,
+    private val encode: (T) -> ULong
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.varint.lastOrNull()?.let { decode(it.value) }
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.varint.map { decode(it.value) }
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.varint(fieldNumber, encode(value).toLong())
+}
+
+private class Fixed32Codec<T>(
+    private val decode: (UInt) -> T,
+    private val encode: (T) -> UInt
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.fixed32.lastOrNull()?.let { decode(it.value) }
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.fixed32.map { decode(it.value) }
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.fixed32(fieldNumber, encode(value))
+}
+
+private class Fixed64Codec<T>(
+    private val decode: (ULong) -> T,
+    private val encode: (T) -> ULong
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.fixed64.lastOrNull()?.let { decode(it.value) }
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.fixed64.map { decode(it.value) }
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.fixed64(fieldNumber, encode(value))
+}
+
+private class LengthDelimitedCodec<T>(
+    private val decode: (LengthDelimitedVal) -> T,
+    private val encode: (T) -> LengthDelimitedVal
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.lengthDelimited.lastOrNull()?.let(decode)
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.lengthDelimited.map(decode)
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.lengthDelimited(fieldNumber, encode(value).value.value)
+}

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Message.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Message.kt
@@ -16,6 +16,8 @@
 package protokt.v1
 
 expect interface Message {
+    val unknownFields: UnknownFieldSet
+
     fun serializedSize(): Int
 
     fun serialize(writer: Writer)

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
@@ -20,23 +20,35 @@ import protokt.v1.Collections.freezeMap
 import protokt.v1.Sizes.sizeOf
 
 class UnknownFieldSet private constructor(
-    val unknownFields: Map<UInt, Field>
+    private val fieldMap: Map<UInt, Field>
 ) {
-    fun size() =
-        unknownFields.entries.sumOf { (k, v) -> v.size(k) }
+    operator fun get(fieldNumber: UInt): Field? =
+        fieldMap[fieldNumber]
 
-    fun isEmpty() =
-        unknownFields.isEmpty()
+    operator fun contains(fieldNumber: UInt): Boolean =
+        fieldNumber in fieldMap
+
+    fun isEmpty(): Boolean =
+        fieldMap.isEmpty()
+
+    @OnlyForUseByGeneratedProtoCode
+    fun size() =
+        fieldMap.entries.sumOf { (k, v) -> v.size(k) }
+
+    @OnlyForUseByGeneratedProtoCode
+    fun forEach(action: (UInt, Field) -> Unit) {
+        fieldMap.forEach { (k, v) -> action(k, v) }
+    }
 
     override fun equals(other: Any?) =
         other is UnknownFieldSet &&
-            other.unknownFields == unknownFields
+            other.fieldMap == fieldMap
 
     override fun hashCode() =
-        unknownFields.hashCode()
+        fieldMap.hashCode()
 
     override fun toString() =
-        "UnknownFieldSet(unknownFields=$unknownFields)"
+        "UnknownFieldSet(fields=$fieldMap)"
 
     companion object {
         private val EMPTY = UnknownFieldSet(emptyMap())

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Writer.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Writer.kt
@@ -72,7 +72,7 @@ interface Writer {
     }
 
     fun writeUnknown(u: UnknownFieldSet) {
-        u.unknownFields.forEach { (k, v) -> v.write(k, this) }
+        u.forEach { k, v -> v.write(k, this) }
     }
 
     fun toByteArray(): ByteArray

--- a/protokt-runtime/src/jvmMain/kotlin/protokt/v1/Message.kt
+++ b/protokt-runtime/src/jvmMain/kotlin/protokt/v1/Message.kt
@@ -18,6 +18,8 @@ package protokt.v1
 import java.io.OutputStream
 
 actual interface Message {
+    actual val unknownFields: UnknownFieldSet
+
     actual fun serializedSize(): Int
 
     actual fun serialize(writer: Writer)

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ExtensionTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ExtensionTest.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ExtensionTest {
+    @Test
+    fun `decode singular varint int32`() {
+        val field = fieldOf(VarintVal(42uL))
+        assertThat(ExtensionCodecs.int32.decodeSingular(field)).isEqualTo(42)
+    }
+
+    @Test
+    fun `decode singular varint int64`() {
+        val field = fieldOf(VarintVal(Long.MAX_VALUE.toULong()))
+        assertThat(ExtensionCodecs.int64.decodeSingular(field)).isEqualTo(Long.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular varint uint32`() {
+        val field = fieldOf(VarintVal(UInt.MAX_VALUE.toULong()))
+        assertThat(ExtensionCodecs.uint32.decodeSingular(field)).isEqualTo(UInt.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular varint uint64`() {
+        val field = fieldOf(VarintVal(ULong.MAX_VALUE))
+        assertThat(ExtensionCodecs.uint64.decodeSingular(field)).isEqualTo(ULong.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular varint sint32`() {
+        val encoded = ((-1 shl 1) xor (-1 shr 31)).toUInt().toULong()
+        val field = fieldOf(VarintVal(encoded))
+        assertThat(ExtensionCodecs.sint32.decodeSingular(field)).isEqualTo(-1)
+    }
+
+    @Test
+    fun `decode singular varint sint64`() {
+        val encoded = ((-1L shl 1) xor (-1L shr 63)).toULong()
+        val field = fieldOf(VarintVal(encoded))
+        assertThat(ExtensionCodecs.sint64.decodeSingular(field)).isEqualTo(-1L)
+    }
+
+    @Test
+    fun `decode singular varint bool`() {
+        assertThat(ExtensionCodecs.bool.decodeSingular(fieldOf(VarintVal(1uL)))).isTrue()
+        assertThat(ExtensionCodecs.bool.decodeSingular(fieldOf(VarintVal(0uL)))).isFalse()
+    }
+
+    @Test
+    fun `decode singular fixed32`() {
+        val field = fieldOf(Fixed32Val(0xDEADBEEFu))
+        assertThat(ExtensionCodecs.fixed32.decodeSingular(field)).isEqualTo(0xDEADBEEFu)
+    }
+
+    @Test
+    fun `decode singular sfixed32`() {
+        val field = fieldOf(Fixed32Val((-1).toUInt()))
+        assertThat(ExtensionCodecs.sfixed32.decodeSingular(field)).isEqualTo(-1)
+    }
+
+    @Test
+    fun `decode singular float`() {
+        val field = fieldOf(Fixed32Val(1.5f.toRawBits().toUInt()))
+        assertThat(ExtensionCodecs.float.decodeSingular(field)).isEqualTo(1.5f)
+    }
+
+    @Test
+    fun `decode singular fixed64`() {
+        val field = fieldOf(Fixed64Val(ULong.MAX_VALUE))
+        assertThat(ExtensionCodecs.fixed64.decodeSingular(field)).isEqualTo(ULong.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular sfixed64`() {
+        val field = fieldOf(Fixed64Val((-1L).toULong()))
+        assertThat(ExtensionCodecs.sfixed64.decodeSingular(field)).isEqualTo(-1L)
+    }
+
+    @Test
+    fun `decode singular double`() {
+        val field = fieldOf(Fixed64Val(3.14.toRawBits().toULong()))
+        assertThat(ExtensionCodecs.double.decodeSingular(field)).isEqualTo(3.14)
+    }
+
+    @Test
+    fun `decode singular string`() {
+        val field = fieldOf(LengthDelimitedVal(Bytes("hello".encodeToByteArray())))
+        assertThat(ExtensionCodecs.string.decodeSingular(field)).isEqualTo("hello")
+    }
+
+    @Test
+    fun `decode singular bytes`() {
+        val data = byteArrayOf(1, 2, 3)
+        val field = fieldOf(LengthDelimitedVal(Bytes(data)))
+        assertThat(ExtensionCodecs.bytes.decodeSingular(field)?.bytes).isEqualTo(data)
+    }
+
+    @Test
+    fun `decode repeated varints`() {
+        val field = fieldOf(VarintVal(1uL), VarintVal(2uL), VarintVal(3uL))
+        assertThat(ExtensionCodecs.int32.decodeRepeated(field)).containsExactly(1, 2, 3).inOrder()
+    }
+
+    @Test
+    fun `decode repeated fixed32`() {
+        val field = fieldOf(Fixed32Val(10u), Fixed32Val(20u))
+        assertThat(ExtensionCodecs.fixed32.decodeRepeated(field)).containsExactly(10u, 20u).inOrder()
+    }
+
+    @Test
+    fun `decode repeated strings`() {
+        val field =
+            fieldOf(
+                LengthDelimitedVal(Bytes("a".encodeToByteArray())),
+                LengthDelimitedVal(Bytes("b".encodeToByteArray()))
+            )
+        assertThat(ExtensionCodecs.string.decodeRepeated(field)).containsExactly("a", "b").inOrder()
+    }
+
+    @Test
+    fun `encode round-trip int32`() {
+        val encoded = ExtensionCodecs.int32.encode(1u, 42)
+        val decoded =
+            ExtensionCodecs.int32.decodeSingular(
+                buildField(encoded)
+            )
+        assertThat(decoded).isEqualTo(42)
+    }
+
+    @Test
+    fun `encode round-trip bool`() {
+        val encoded = ExtensionCodecs.bool.encode(1u, true)
+        val decoded =
+            ExtensionCodecs.bool.decodeSingular(
+                buildField(encoded)
+            )
+        assertThat(decoded).isTrue()
+    }
+
+    @Test
+    fun `encode round-trip string`() {
+        val encoded = ExtensionCodecs.string.encode(1u, "hello")
+        val decoded =
+            ExtensionCodecs.string.decodeSingular(
+                buildField(encoded)
+            )
+        assertThat(decoded).isEqualTo("hello")
+    }
+
+    @Test
+    fun `decode singular returns last value for multiple entries`() {
+        val field = fieldOf(VarintVal(1uL), VarintVal(2uL), VarintVal(3uL))
+        assertThat(ExtensionCodecs.int32.decodeSingular(field)).isEqualTo(3)
+    }
+
+    @Test
+    fun `decode singular returns null for empty field`() {
+        val field = emptyField()
+        assertThat(ExtensionCodecs.int32.decodeSingular(field)).isNull()
+        assertThat(ExtensionCodecs.string.decodeSingular(field)).isNull()
+        assertThat(ExtensionCodecs.fixed32.decodeSingular(field)).isNull()
+        assertThat(ExtensionCodecs.fixed64.decodeSingular(field)).isNull()
+    }
+
+    @Test
+    fun `operator get on message`() {
+        val ext = Extension<TestMsg, Int>(1u, ExtensionCodecs.int32)
+        val msg = TestMsg(VarintVal(42uL))
+        assertThat(msg[ext]).isEqualTo(42)
+    }
+
+    @Test
+    fun `operator get returns null for missing extension`() {
+        val ext = Extension<TestMsg, Int>(999u, ExtensionCodecs.int32)
+        val msg = TestMsg(VarintVal(42uL))
+        assertThat(msg[ext]).isNull()
+    }
+
+    @Test
+    fun `repeated operator get on message`() {
+        val ext = RepeatedExtension<TestMsg, Int>(1u, ExtensionCodecs.int32)
+        val msg =
+            TestMsg(
+                UnknownFieldSet.Builder().apply {
+                    add(UnknownField.varint(1u, 10))
+                    add(UnknownField.varint(1u, 20))
+                    add(UnknownField.varint(1u, 30))
+                }.build()
+            )
+        assertThat(msg[ext]).containsExactly(10, 20, 30).inOrder()
+    }
+
+    @Test
+    fun `repeated operator get returns empty list for missing extension`() {
+        val ext = RepeatedExtension<TestMsg, Int>(999u, ExtensionCodecs.int32)
+        val msg = TestMsg(VarintVal(42uL))
+        assertThat(msg[ext]).isEmpty()
+    }
+
+    private fun fieldOf(vararg values: UnknownValue): UnknownFieldSet.Field =
+        UnknownFieldSet.Field.Builder().apply { values.forEach { add(it) } }.build()
+
+    private fun emptyField(): UnknownFieldSet.Field =
+        UnknownFieldSet.Field.Builder().build()
+
+    private fun buildField(unknownField: UnknownField): UnknownFieldSet.Field =
+        UnknownFieldSet.Field.Builder().apply { add(unknownField.value) }.build()
+
+    @OptIn(OnlyForUseByGeneratedProtoCode::class)
+    private class TestMsg(
+        override val unknownFields: UnknownFieldSet
+    ) : AbstractMessage() {
+        constructor(value: UnknownValue) : this(
+            UnknownFieldSet.Builder().apply {
+                add(UnknownField.varint(1u, (value as VarintVal).value.toLong()))
+            }.build()
+        )
+
+        override fun serializedSize() =
+            unknownFields.size()
+        override fun serialize(writer: Writer) =
+            writer.writeUnknown(unknownFields)
+    }
+}

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
@@ -229,6 +229,7 @@ class ReaderValidationTest {
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object EmptyMessage : AbstractDeserializer<EmptyMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -247,6 +248,7 @@ private object EmptyMessage : AbstractDeserializer<EmptyMessage>(), Message {
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object Fixed32FieldMessage : AbstractDeserializer<Fixed32FieldMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -269,6 +271,7 @@ private object Fixed32FieldMessage : AbstractDeserializer<Fixed32FieldMessage>()
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object Fixed64FieldMessage : AbstractDeserializer<Fixed64FieldMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -291,6 +294,7 @@ private object Fixed64FieldMessage : AbstractDeserializer<Fixed64FieldMessage>()
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object VarintFieldMessage : AbstractDeserializer<VarintFieldMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -309,6 +313,7 @@ private object VarintFieldMessage : AbstractDeserializer<VarintFieldMessage>(), 
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object NestedLenDelimitedMessage : AbstractDeserializer<NestedLenDelimitedMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -331,6 +336,7 @@ private object NestedLenDelimitedMessage : AbstractDeserializer<NestedLenDelimit
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object RecursiveMessage : AbstractDeserializer<RecursiveMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}

--- a/protokt-runtime/src/nonJvmMain/kotlin/protokt/v1/Message.kt
+++ b/protokt-runtime/src/nonJvmMain/kotlin/protokt/v1/Message.kt
@@ -16,6 +16,8 @@
 package protokt.v1
 
 actual interface Message {
+    actual val unknownFields: UnknownFieldSet
+
     actual fun serializedSize(): Int
 
     actual fun serialize(writer: Writer)

--- a/testing/interop/src/test/kotlin/protokt/v1/testing/ExtensionInteropTest.kt
+++ b/testing/interop/src/test/kotlin/protokt/v1/testing/ExtensionInteropTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.DescriptorProtos
+import com.toasttab.protokt.v1.ProtoktProtos
+import org.junit.jupiter.api.Test
+import protokt.v1.Extension
+import protokt.v1.ExtensionCodecs
+import protokt.v1.RepeatedExtension
+import protokt.v1.get
+import protokt.v1.google.protobuf.FieldOptions
+
+class ExtensionInteropTest {
+    private val propertyExt =
+        Extension<FieldOptions, protokt.v1.FieldOptions>(
+            1253u,
+            ExtensionCodecs.message(protokt.v1.FieldOptions)
+        )
+
+    @Test
+    fun `read protokt field options from wire bytes`() {
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setExtension(
+                    ProtoktProtos.property,
+                    ProtoktProtos.FieldOptions.newBuilder()
+                        .setWrap("java.util.UUID")
+                        .build()
+                )
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        val opts = protoktFieldOptions[propertyExt]
+
+        assertThat(opts).isNotNull()
+        assertThat(opts!!.wrap).isEqualTo("java.util.UUID")
+    }
+
+    @Test
+    fun `read protokt field options with non-null accessor`() {
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setExtension(
+                    ProtoktProtos.property,
+                    ProtoktProtos.FieldOptions.newBuilder()
+                        .setGenerateNonNullAccessor(true)
+                        .setDeprecationMessage("old field")
+                        .build()
+                )
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        val opts = protoktFieldOptions[propertyExt]!!
+
+        assertThat(opts.generateNonNullAccessor).isTrue()
+        assertThat(opts.deprecationMessage).isEqualTo("old field")
+    }
+
+    @Test
+    fun `missing extension returns null`() {
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setDeprecated(true)
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        assertThat(protoktFieldOptions[propertyExt]).isNull()
+    }
+
+    @Test
+    fun `read descriptor field options from live proto`() {
+        val descriptor =
+            com.toasttab.protokt.v1.testing.WrappersDynamic.Wrappers.getDescriptor()
+
+        val uuidField = descriptor.findFieldByName("uuid")
+        val javaOpts = uuidField.options
+
+        val protoktOpts = FieldOptions.deserialize(javaOpts.toByteArray())
+        val opts = protoktOpts[propertyExt]
+
+        assertThat(opts).isNotNull()
+        assertThat(opts!!.wrap).isEqualTo("java.util.UUID")
+    }
+
+    @Test
+    fun `scalar extension round-trip`() {
+        val ext = Extension<FieldOptions, Boolean>(99999u, ExtensionCodecs.bool)
+
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setDeprecated(true)
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        assertThat(protoktFieldOptions[ext]).isNull()
+    }
+
+    @Test
+    fun `repeated extension`() {
+        val ext = RepeatedExtension<FieldOptions, String>(99999u, ExtensionCodecs.string)
+
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder().build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        assertThat(protoktFieldOptions[ext]).isEmpty()
+    }
+}

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/ToStringTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/ToStringTest.kt
@@ -40,7 +40,7 @@ class ToStringTest {
             }.toString()
         ).isEqualTo(
             "ToStringTestEmpty(" +
-                "unknownFields=UnknownFieldSet(unknownFields={5=Field(" +
+                "unknownFields=UnknownFieldSet(fields={5=Field(" +
                 "varint=[], " +
                 "fixed32=[Fixed32Val(value=10)], " +
                 "fixed64=[], " +
@@ -70,7 +70,7 @@ class ToStringTest {
             "ToStringTest2(" +
                 "`val`=[], " +
                 "extra=foo, " +
-                "unknownFields=UnknownFieldSet(unknownFields={5=Field(" +
+                "unknownFields=UnknownFieldSet(fields={5=Field(" +
                 "varint=[], " +
                 "fixed32=[Fixed32Val(value=10)], " +
                 "fixed64=[], " +

--- a/third-party/proto-google-common-protos-lite/api/proto-google-common-protos-lite.api
+++ b/third-party/proto-google-common-protos-lite/api/proto-google-common-protos-lite.api
@@ -5,7 +5,7 @@ public final class protokt/v1/google/api/Advice : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Advice;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Advice;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -45,7 +45,7 @@ public final class protokt/v1/google/api/AuthProvider : protokt/v1/AbstractMessa
 	public final fun getIssuer ()Ljava/lang/String;
 	public final fun getJwksUri ()Ljava/lang/String;
 	public final fun getJwtLocations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/AuthProvider;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -91,7 +91,7 @@ public final class protokt/v1/google/api/AuthRequirement : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAudiences ()Ljava/lang/String;
 	public final fun getProviderId ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/AuthRequirement;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -129,7 +129,7 @@ public final class protokt/v1/google/api/Authentication : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getProviders ()Ljava/util/List;
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Authentication;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -169,7 +169,7 @@ public final class protokt/v1/google/api/AuthenticationRule : protokt/v1/Abstrac
 	public final fun getOauth ()Lprotokt/v1/google/api/OAuthRequirements;
 	public final fun getRequirements ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/AuthenticationRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -210,7 +210,7 @@ public final class protokt/v1/google/api/Backend : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Backend;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Backend;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -253,7 +253,7 @@ public final class protokt/v1/google/api/BackendRule : protokt/v1/AbstractMessag
 	public final fun getPathTranslation ()Lprotokt/v1/google/api/BackendRule$PathTranslation;
 	public final fun getProtocol ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/BackendRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -357,7 +357,7 @@ public final class protokt/v1/google/api/Billing : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Billing;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumerDestinations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Billing;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -374,7 +374,7 @@ public final class protokt/v1/google/api/Billing$BillingDestination : protokt/v1
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetrics ()Ljava/util/List;
 	public final fun getMonitoredResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Billing$BillingDestination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -547,7 +547,7 @@ public final class protokt/v1/google/api/ClientLibrarySettings : protokt/v1/Abst
 	public final fun getPythonSettings ()Lprotokt/v1/google/api/PythonSettings;
 	public final fun getRestNumericEnums ()Z
 	public final fun getRubySettings ()Lprotokt/v1/google/api/RubySettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ClientLibrarySettings;
@@ -605,7 +605,7 @@ public final class protokt/v1/google/api/CommonLanguageSettings : protokt/v1/Abs
 	public final fun getDestinations ()Ljava/util/List;
 	public final fun getReferenceDocsUri ()Ljava/lang/String;
 	public final fun getSelectiveGapicGeneration ()Lprotokt/v1/google/api/SelectiveGapicGeneration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/CommonLanguageSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -648,7 +648,7 @@ public final class protokt/v1/google/api/ConfigChange : protokt/v1/AbstractMessa
 	public final fun getElement ()Ljava/lang/String;
 	public final fun getNewValue ()Ljava/lang/String;
 	public final fun getOldValue ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ConfigChange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -691,7 +691,7 @@ public final class protokt/v1/google/api/Context : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Context;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Context;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -730,7 +730,7 @@ public final class protokt/v1/google/api/ContextRule : protokt/v1/AbstractMessag
 	public final fun getProvided ()Ljava/util/List;
 	public final fun getRequested ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ContextRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -774,7 +774,7 @@ public final class protokt/v1/google/api/Control : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnvironment ()Ljava/lang/String;
 	public final fun getMethodPolicies ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Control;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -811,7 +811,7 @@ public final class protokt/v1/google/api/CppSettings : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/CppSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/CppSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -847,7 +847,7 @@ public final class protokt/v1/google/api/CustomHttpPattern : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKind ()Ljava/lang/String;
 	public final fun getPath ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/CustomHttpPattern;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -890,7 +890,7 @@ public final class protokt/v1/google/api/Distribution : protokt/v1/AbstractMessa
 	public final fun getMean ()D
 	public final fun getRange ()Lprotokt/v1/google/api/Distribution$Range;
 	public final fun getSumOfSquaredDeviation ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -906,7 +906,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions : protokt/v1
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Distribution$BucketOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOptions ()Lprotokt/v1/google/api/Distribution$BucketOptions$Options;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -941,7 +941,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions$Explicit : p
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Distribution$BucketOptions$Explicit;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions$Explicit;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -978,7 +978,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions$Exponential 
 	public final fun getGrowthFactor ()D
 	public final fun getNumFiniteBuckets ()I
 	public final fun getScale ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions$Exponential;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1018,7 +1018,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions$Linear : pro
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNumFiniteBuckets ()I
 	public final fun getOffset ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWidth ()D
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions$Linear;
@@ -1126,7 +1126,7 @@ public final class protokt/v1/google/api/Distribution$Exemplar : protokt/v1/Abst
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getTimestamp ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()D
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$Exemplar;
@@ -1167,7 +1167,7 @@ public final class protokt/v1/google/api/Distribution$Range : protokt/v1/Abstrac
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMax ()D
 	public final fun getMin ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$Range;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1209,7 +1209,7 @@ public final class protokt/v1/google/api/Documentation : protokt/v1/AbstractMess
 	public final fun getRules ()Ljava/util/List;
 	public final fun getServiceRootUrl ()Ljava/lang/String;
 	public final fun getSummary ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Documentation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1256,7 +1256,7 @@ public final class protokt/v1/google/api/DocumentationRule : protokt/v1/Abstract
 	public final fun getDeprecationDescription ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/DocumentationRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1300,7 +1300,7 @@ public final class protokt/v1/google/api/DotnetSettings : protokt/v1/AbstractMes
 	public final fun getIgnoredResources ()Ljava/util/List;
 	public final fun getRenamedResources ()Ljava/util/Map;
 	public final fun getRenamedServices ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/DotnetSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1348,7 +1348,7 @@ public final class protokt/v1/google/api/Endpoint : protokt/v1/AbstractMessage {
 	public final fun getAllowCors ()Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTarget ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Endpoint;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1590,7 +1590,7 @@ public final class protokt/v1/google/api/FieldInfo : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormat ()Lprotokt/v1/google/api/FieldInfo$Format;
 	public final fun getReferencedTypes ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/FieldInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1665,7 +1665,7 @@ public final class protokt/v1/google/api/FieldPolicy : protokt/v1/AbstractMessag
 	public final fun getResourcePermission ()Ljava/lang/String;
 	public final fun getResourceType ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/FieldPolicy;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1705,7 +1705,7 @@ public final class protokt/v1/google/api/GoSettings : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
 	public final fun getRenamedServices ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/GoSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1743,7 +1743,7 @@ public final class protokt/v1/google/api/Http : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFullyDecodeReservedExpansion ()Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Http;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1782,7 +1782,7 @@ public final class protokt/v1/google/api/HttpBody : protokt/v1/AbstractMessage {
 	public final fun getContentType ()Ljava/lang/String;
 	public final fun getData ()Lprotokt/v1/Bytes;
 	public final fun getExtensions ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/HttpBody;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1825,7 +1825,7 @@ public final class protokt/v1/google/api/HttpRule : protokt/v1/AbstractMessage {
 	public final fun getPattern ()Lprotokt/v1/google/api/HttpRule$Pattern;
 	public final fun getResponseBody ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/HttpRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1939,7 +1939,7 @@ public final class protokt/v1/google/api/JavaSettings : protokt/v1/AbstractMessa
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
 	public final fun getLibraryPackage ()Ljava/lang/String;
 	public final fun getServiceClassNames ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/JavaSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1978,7 +1978,7 @@ public final class protokt/v1/google/api/JwtLocation : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/JwtLocation;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIn ()Lprotokt/v1/google/api/JwtLocation$In;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValuePrefix ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/JwtLocation;
@@ -2053,7 +2053,7 @@ public final class protokt/v1/google/api/LabelDescriptor : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueType ()Lprotokt/v1/google/api/LabelDescriptor$ValueType;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/LabelDescriptor;
@@ -2172,7 +2172,7 @@ public final class protokt/v1/google/api/LogDescriptor : protokt/v1/AbstractMess
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getLabels ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/LogDescriptor;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2214,7 +2214,7 @@ public final class protokt/v1/google/api/Logging : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumerDestinations ()Ljava/util/List;
 	public final fun getProducerDestinations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Logging;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2252,7 +2252,7 @@ public final class protokt/v1/google/api/Logging$LoggingDestination : protokt/v1
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLogs ()Ljava/util/List;
 	public final fun getMonitoredResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Logging$LoggingDestination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2290,7 +2290,7 @@ public final class protokt/v1/google/api/MethodPolicy : protokt/v1/AbstractMessa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestPolicies ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MethodPolicy;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2329,7 +2329,7 @@ public final class protokt/v1/google/api/MethodSettings : protokt/v1/AbstractMes
 	public final fun getAutoPopulatedFields ()Ljava/util/List;
 	public final fun getLongRunning ()Lprotokt/v1/google/api/MethodSettings$LongRunning;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MethodSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2371,7 +2371,7 @@ public final class protokt/v1/google/api/MethodSettings$LongRunning : protokt/v1
 	public final fun getMaxPollDelay ()Lprotokt/v1/google/protobuf/Duration;
 	public final fun getPollDelayMultiplier ()F
 	public final fun getTotalPollTimeout ()Lprotokt/v1/google/protobuf/Duration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MethodSettings$LongRunning;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2413,7 +2413,7 @@ public final class protokt/v1/google/api/Metric : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLabels ()Ljava/util/Map;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Metric;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2459,7 +2459,7 @@ public final class protokt/v1/google/api/MetricDescriptor : protokt/v1/AbstractM
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getUnit ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueType ()Lprotokt/v1/google/api/MetricDescriptor$ValueType;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MetricDescriptor;
@@ -2518,7 +2518,7 @@ public final class protokt/v1/google/api/MetricDescriptor$MetricDescriptorMetada
 	public final fun getLaunchStage ()Lprotokt/v1/google/api/LaunchStage;
 	public final fun getSamplePeriod ()Lprotokt/v1/google/protobuf/Duration;
 	public final fun getTimeSeriesResourceHierarchyLevel ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MetricDescriptor$MetricDescriptorMetadata;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2668,7 +2668,7 @@ public final class protokt/v1/google/api/MetricRule : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetricCosts ()Ljava/util/Map;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MetricRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2706,7 +2706,7 @@ public final class protokt/v1/google/api/MonitoredResource : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLabels ()Ljava/util/Map;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MonitoredResource;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2748,7 +2748,7 @@ public final class protokt/v1/google/api/MonitoredResourceDescriptor : protokt/v
 	public final fun getLaunchStage ()Lprotokt/v1/google/api/LaunchStage;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MonitoredResourceDescriptor;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2793,7 +2793,7 @@ public final class protokt/v1/google/api/MonitoredResourceMetadata : protokt/v1/
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/MonitoredResourceMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSystemLabels ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUserLabels ()Ljava/util/Map;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MonitoredResourceMetadata;
@@ -2832,7 +2832,7 @@ public final class protokt/v1/google/api/Monitoring : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumerDestinations ()Ljava/util/List;
 	public final fun getProducerDestinations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Monitoring;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2870,7 +2870,7 @@ public final class protokt/v1/google/api/Monitoring$MonitoringDestination : prot
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetrics ()Ljava/util/List;
 	public final fun getMonitoredResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Monitoring$MonitoringDestination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2907,7 +2907,7 @@ public final class protokt/v1/google/api/NodeSettings : protokt/v1/AbstractMessa
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/NodeSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/NodeSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2942,7 +2942,7 @@ public final class protokt/v1/google/api/OAuthRequirements : protokt/v1/Abstract
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/OAuthRequirements;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanonicalScopes ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/OAuthRequirements;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2979,7 +2979,7 @@ public final class protokt/v1/google/api/Page : protokt/v1/AbstractMessage {
 	public final fun getContent ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSubpages ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Page;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3018,7 +3018,7 @@ public final class protokt/v1/google/api/PhpSettings : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/PhpSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/PhpSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3053,7 +3053,7 @@ public final class protokt/v1/google/api/ProjectProperties : protokt/v1/Abstract
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/ProjectProperties;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getProperties ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ProjectProperties;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3090,7 +3090,7 @@ public final class protokt/v1/google/api/Property : protokt/v1/AbstractMessage {
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Lprotokt/v1/google/api/Property$PropertyType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Property;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3175,7 +3175,7 @@ public final class protokt/v1/google/api/Publishing : protokt/v1/AbstractMessage
 	public final fun getOrganization ()Lprotokt/v1/google/api/ClientLibraryOrganization;
 	public final fun getProtoReferenceDocumentationUri ()Ljava/lang/String;
 	public final fun getRestReferenceDocumentationUri ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Publishing;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3231,7 +3231,7 @@ public final class protokt/v1/google/api/PythonSettings : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
 	public final fun getExperimentalFeatures ()Lprotokt/v1/google/api/PythonSettings$ExperimentalFeatures;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/PythonSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3269,7 +3269,7 @@ public final class protokt/v1/google/api/PythonSettings$ExperimentalFeatures : p
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getProtobufPythonicTypesEnabled ()Z
 	public final fun getRestAsyncIoEnabled ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUnversionedPackageDisabled ()Z
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/PythonSettings$ExperimentalFeatures;
@@ -3310,7 +3310,7 @@ public final class protokt/v1/google/api/Quota : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLimits ()Ljava/util/List;
 	public final fun getMetricRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Quota;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3355,7 +3355,7 @@ public final class protokt/v1/google/api/QuotaLimit : protokt/v1/AbstractMessage
 	public final fun getMetric ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getUnit ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValues ()Ljava/util/Map;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/QuotaLimit;
@@ -3415,7 +3415,7 @@ public final class protokt/v1/google/api/ResourceDescriptor : protokt/v1/Abstrac
 	public final fun getSingular ()Ljava/lang/String;
 	public final fun getStyle ()Ljava/util/List;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ResourceDescriptor;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3515,7 +3515,7 @@ public final class protokt/v1/google/api/ResourceReference : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChildType ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ResourceReference;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3553,7 +3553,7 @@ public final class protokt/v1/google/api/RoutingParameter : protokt/v1/AbstractM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getField ()Ljava/lang/String;
 	public final fun getPathTemplate ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/RoutingParameter;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3590,7 +3590,7 @@ public final class protokt/v1/google/api/RoutingRule : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/RoutingRule;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRoutingParameters ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/RoutingRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3625,7 +3625,7 @@ public final class protokt/v1/google/api/RubySettings : protokt/v1/AbstractMessa
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/RubySettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/RubySettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3661,7 +3661,7 @@ public final class protokt/v1/google/api/SelectiveGapicGeneration : protokt/v1/A
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGenerateOmittedAsInternal ()Z
 	public final fun getMethods ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SelectiveGapicGeneration;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3722,7 +3722,7 @@ public final class protokt/v1/google/api/Service : protokt/v1/AbstractMessage {
 	public final fun getSystemParameters ()Lprotokt/v1/google/api/SystemParameters;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getTypes ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUsage ()Lprotokt/v1/google/api/Usage;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Service;
@@ -3808,7 +3808,7 @@ public final class protokt/v1/google/api/SourceInfo : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/SourceInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSourceFiles ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SourceInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3844,7 +3844,7 @@ public final class protokt/v1/google/api/SystemParameter : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHttpHeader ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUrlQueryParameter ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SystemParameter;
@@ -3885,7 +3885,7 @@ public final class protokt/v1/google/api/SystemParameterRule : protokt/v1/Abstra
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getParameters ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SystemParameterRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3922,7 +3922,7 @@ public final class protokt/v1/google/api/SystemParameters : protokt/v1/AbstractM
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/SystemParameters;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SystemParameters;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3957,7 +3957,7 @@ public final class protokt/v1/google/api/TypeReference : protokt/v1/AbstractMess
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/TypeReference;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTypeName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/TypeReference;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3994,7 +3994,7 @@ public final class protokt/v1/google/api/Usage : protokt/v1/AbstractMessage {
 	public final fun getProducerNotificationChannel ()Ljava/lang/String;
 	public final fun getRequirements ()Ljava/util/List;
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Usage;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4035,7 +4035,7 @@ public final class protokt/v1/google/api/UsageRule : protokt/v1/AbstractMessage 
 	public final fun getAllowUnregisteredCalls ()Z
 	public final fun getSelector ()Ljava/lang/String;
 	public final fun getSkipServiceControl ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/UsageRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4074,7 +4074,7 @@ public final class protokt/v1/google/api/Visibility : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Visibility;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Visibility;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4110,7 +4110,7 @@ public final class protokt/v1/google/api/VisibilityRule : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRestriction ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/VisibilityRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4153,7 +4153,7 @@ public final class protokt/v1/google/apps/card/v1/Action : protokt/v1/AbstractMe
 	public final fun getParameters ()Ljava/util/List;
 	public final fun getPersistValues ()Z
 	public final fun getRequiredWidgets ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Action;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4169,7 +4169,7 @@ public final class protokt/v1/google/apps/card/v1/Action$ActionParameter : proto
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Action$ActionParameter;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKey ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Action$ActionParameter;
@@ -4288,7 +4288,7 @@ public final class protokt/v1/google/apps/card/v1/BorderStyle : protokt/v1/Abstr
 	public final fun getCornerRadius ()I
 	public final fun getStrokeColor ()Lprotokt/v1/google/type/Color;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/BorderStyle$BorderType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/BorderStyle;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4361,7 +4361,7 @@ public final class protokt/v1/google/apps/card/v1/Button : protokt/v1/AbstractMe
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
 	public final fun getText ()Ljava/lang/String;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/Button$Type;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Button;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4444,7 +4444,7 @@ public final class protokt/v1/google/apps/card/v1/ButtonList : protokt/v1/Abstra
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/ButtonList;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getButtons ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ButtonList;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4486,7 +4486,7 @@ public final class protokt/v1/google/apps/card/v1/Card : protokt/v1/AbstractMess
 	public final fun getPeekCardHeader ()Lprotokt/v1/google/apps/card/v1/Card$CardHeader;
 	public final fun getSectionDividerStyle ()Lprotokt/v1/google/apps/card/v1/Card$DividerStyle;
 	public final fun getSections ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4530,7 +4530,7 @@ public final class protokt/v1/google/apps/card/v1/Card$CardAction : protokt/v1/A
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActionLabel ()Ljava/lang/String;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$CardAction;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4568,7 +4568,7 @@ public final class protokt/v1/google/apps/card/v1/Card$CardFixedFooter : protokt
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPrimaryButton ()Lprotokt/v1/google/apps/card/v1/Button;
 	public final fun getSecondaryButton ()Lprotokt/v1/google/apps/card/v1/Button;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$CardFixedFooter;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4609,7 +4609,7 @@ public final class protokt/v1/google/apps/card/v1/Card$CardHeader : protokt/v1/A
 	public final fun getImageUrl ()Ljava/lang/String;
 	public final fun getSubtitle ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$CardHeader;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4714,7 +4714,7 @@ public final class protokt/v1/google/apps/card/v1/Card$NestedWidget : protokt/v1
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Card$NestedWidget;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/Card$NestedWidget$Data;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$NestedWidget;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4788,7 +4788,7 @@ public final class protokt/v1/google/apps/card/v1/Card$Section : protokt/v1/Abst
 	public final fun getCollapsible ()Z
 	public final fun getHeader ()Ljava/lang/String;
 	public final fun getUncollapsibleWidgetsCount ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWidgets ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$Section;
@@ -4832,7 +4832,7 @@ public final class protokt/v1/google/apps/card/v1/Carousel : protokt/v1/Abstract
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Carousel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCarouselCards ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Carousel;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4861,7 +4861,7 @@ public final class protokt/v1/google/apps/card/v1/Carousel$CarouselCard : protok
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Carousel$CarouselCard;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFooterWidgets ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWidgets ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Carousel$CarouselCard;
@@ -4910,7 +4910,7 @@ public final class protokt/v1/google/apps/card/v1/Chip : protokt/v1/AbstractMess
 	public final fun getIcon ()Lprotokt/v1/google/apps/card/v1/Icon;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Chip;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4956,7 +4956,7 @@ public final class protokt/v1/google/apps/card/v1/ChipList : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChips ()Ljava/util/List;
 	public final fun getLayout ()Lprotokt/v1/google/apps/card/v1/ChipList$Layout;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ChipList;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5023,7 +5023,7 @@ public final class protokt/v1/google/apps/card/v1/CollapseControl : protokt/v1/A
 	public final fun getCollapseButton ()Lprotokt/v1/google/apps/card/v1/Button;
 	public final fun getExpandButton ()Lprotokt/v1/google/apps/card/v1/Button;
 	public final fun getHorizontalAlignment ()Lprotokt/v1/google/apps/card/v1/Widget$HorizontalAlignment;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/CollapseControl;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5062,7 +5062,7 @@ public final class protokt/v1/google/apps/card/v1/Columns : protokt/v1/AbstractM
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Columns;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColumnItems ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Columns;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5092,7 +5092,7 @@ public final class protokt/v1/google/apps/card/v1/Columns$Column : protokt/v1/Ab
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHorizontalAlignment ()Lprotokt/v1/google/apps/card/v1/Widget$HorizontalAlignment;
 	public final fun getHorizontalSizeStyle ()Lprotokt/v1/google/apps/card/v1/Columns$Column$HorizontalSizeStyle;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVerticalAlignment ()Lprotokt/v1/google/apps/card/v1/Columns$Column$VerticalAlignment;
 	public final fun getWidgets ()Ljava/util/List;
 	public fun hashCode ()I
@@ -5195,7 +5195,7 @@ public final class protokt/v1/google/apps/card/v1/Columns$Column$Widgets : proto
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Columns$Column$Widgets;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/Columns$Column$Widgets$Data;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Columns$Column$Widgets;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5331,7 +5331,7 @@ public final class protokt/v1/google/apps/card/v1/DateTimePicker : protokt/v1/Ab
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getTimezoneOffsetDate ()I
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/DateTimePicker$DateTimePickerType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueMsEpoch ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/DateTimePicker;
@@ -5415,7 +5415,7 @@ public final class protokt/v1/google/apps/card/v1/DecoratedText : protokt/v1/Abs
 	public final fun getText ()Ljava/lang/String;
 	public final fun getTopLabel ()Ljava/lang/String;
 	public final fun getTopLabelText ()Lprotokt/v1/google/apps/card/v1/TextParagraph;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWrapText ()Z
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/DecoratedText;
@@ -5512,7 +5512,7 @@ public final class protokt/v1/google/apps/card/v1/DecoratedText$SwitchControl : 
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getSelected ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/DecoratedText$SwitchControl;
@@ -5583,7 +5583,7 @@ public final class protokt/v1/google/apps/card/v1/Divider : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Divider;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Divider;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Divider;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5620,7 +5620,7 @@ public final class protokt/v1/google/apps/card/v1/Grid : protokt/v1/AbstractMess
 	public final fun getItems ()Ljava/util/List;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Grid;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5667,7 +5667,7 @@ public final class protokt/v1/google/apps/card/v1/Grid$GridItem : protokt/v1/Abs
 	public final fun getLayout ()Lprotokt/v1/google/apps/card/v1/Grid$GridItem$GridItemLayout;
 	public final fun getSubtitle ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Grid$GridItem;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5740,7 +5740,7 @@ public final class protokt/v1/google/apps/card/v1/Icon : protokt/v1/AbstractMess
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getIcons ()Lprotokt/v1/google/apps/card/v1/Icon$Icons;
 	public final fun getImageType ()Lprotokt/v1/google/apps/card/v1/Widget$ImageType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Icon;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5817,7 +5817,7 @@ public final class protokt/v1/google/apps/card/v1/Image : protokt/v1/AbstractMes
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getImageUrl ()Ljava/lang/String;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Image;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5859,7 +5859,7 @@ public final class protokt/v1/google/apps/card/v1/ImageComponent : protokt/v1/Ab
 	public final fun getBorderStyle ()Lprotokt/v1/google/apps/card/v1/BorderStyle;
 	public final fun getCropStyle ()Lprotokt/v1/google/apps/card/v1/ImageCropStyle;
 	public final fun getImageUri ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ImageComponent;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5901,7 +5901,7 @@ public final class protokt/v1/google/apps/card/v1/ImageCropStyle : protokt/v1/Ab
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAspectRatio ()D
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/ImageCropStyle$ImageCropType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ImageCropStyle;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5976,7 +5976,7 @@ public final class protokt/v1/google/apps/card/v1/MaterialIcon : protokt/v1/Abst
 	public final fun getFill ()Z
 	public final fun getGrade ()I
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWeight ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/MaterialIcon;
@@ -6018,7 +6018,7 @@ public final class protokt/v1/google/apps/card/v1/OnClick : protokt/v1/AbstractM
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/OnClick;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/OnClick$Data;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OnClick;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6112,7 +6112,7 @@ public final class protokt/v1/google/apps/card/v1/OpenLink : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOnClose ()Lprotokt/v1/google/apps/card/v1/OpenLink$OnClose;
 	public final fun getOpenAs ()Lprotokt/v1/google/apps/card/v1/OpenLink$OpenAs;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OpenLink;
@@ -6200,7 +6200,7 @@ public final class protokt/v1/google/apps/card/v1/OverflowMenu : protokt/v1/Abst
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/OverflowMenu;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getItems ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OverflowMenu;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6238,7 +6238,7 @@ public final class protokt/v1/google/apps/card/v1/OverflowMenu$OverflowMenuItem 
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
 	public final fun getStartIcon ()Lprotokt/v1/google/apps/card/v1/Icon;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OverflowMenu$OverflowMenuItem;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6286,7 +6286,7 @@ public final class protokt/v1/google/apps/card/v1/SelectionInput : protokt/v1/Ab
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/SelectionInput$SelectionType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/SelectionInput;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6360,7 +6360,7 @@ public final class protokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSou
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSource;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataSource ()Lprotokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSource$DataSource;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSource;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6436,7 +6436,7 @@ public final class protokt/v1/google/apps/card/v1/SelectionInput$SelectionItem :
 	public final fun getSelected ()Z
 	public final fun getStartIcon ()Lprotokt/v1/google/apps/card/v1/SelectionInput$SelectionItem$StartIcon;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/SelectionInput$SelectionItem;
@@ -6530,7 +6530,7 @@ public final class protokt/v1/google/apps/card/v1/Suggestions : protokt/v1/Abstr
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Suggestions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getItems ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Suggestions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6565,7 +6565,7 @@ public final class protokt/v1/google/apps/card/v1/Suggestions$SuggestionItem : p
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Suggestions$SuggestionItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContent ()Lprotokt/v1/google/apps/card/v1/Suggestions$SuggestionItem$Content;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Suggestions$SuggestionItem;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6621,7 +6621,7 @@ public final class protokt/v1/google/apps/card/v1/TextInput : protokt/v1/Abstrac
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getPlaceholderText ()Ljava/lang/String;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/TextInput$Type;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValidation ()Lprotokt/v1/google/apps/card/v1/Validation;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -6702,7 +6702,7 @@ public final class protokt/v1/google/apps/card/v1/TextParagraph : protokt/v1/Abs
 	public final fun getMaxLines ()I
 	public final fun getText ()Ljava/lang/String;
 	public final fun getTextSyntax ()Lprotokt/v1/google/apps/card/v1/TextParagraph$TextSyntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/TextParagraph;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6770,7 +6770,7 @@ public final class protokt/v1/google/apps/card/v1/Validation : protokt/v1/Abstra
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCharacterLimit ()I
 	public final fun getInputType ()Lprotokt/v1/google/apps/card/v1/Validation$InputType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Validation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6848,7 +6848,7 @@ public final class protokt/v1/google/apps/card/v1/Widget : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/Widget$Data;
 	public final fun getHorizontalAlignment ()Lprotokt/v1/google/apps/card/v1/Widget$HorizontalAlignment;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Widget;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7158,7 +7158,7 @@ public final class protokt/v1/google/cloud/audit/AuditLog : protokt/v1/AbstractM
 	public final fun getServiceData ()Lprotokt/v1/google/protobuf/Any;
 	public final fun getServiceName ()Ljava/lang/String;
 	public final fun getStatus ()Lprotokt/v1/google/rpc/Status;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/AuditLog;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7226,7 +7226,7 @@ public final class protokt/v1/google/cloud/audit/AuthenticationInfo : protokt/v1
 	public final fun getServiceAccountDelegationInfo ()Ljava/util/List;
 	public final fun getServiceAccountKeyName ()Ljava/lang/String;
 	public final fun getThirdPartyPrincipal ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/AuthenticationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7275,7 +7275,7 @@ public final class protokt/v1/google/cloud/audit/AuthorizationInfo : protokt/v1/
 	public final fun getPermissionType ()Lprotokt/v1/google/cloud/audit/AuthorizationInfo$PermissionType;
 	public final fun getResource ()Ljava/lang/String;
 	public final fun getResourceAttributes ()Lprotokt/v1/google/rpc/context/AttributeContext$Resource;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/AuthorizationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7356,7 +7356,7 @@ public final class protokt/v1/google/cloud/audit/OrgPolicyViolationInfo : protok
 	public final fun getPayload ()Lprotokt/v1/google/protobuf/Struct;
 	public final fun getResourceTags ()Ljava/util/Map;
 	public final fun getResourceType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getViolationInfo ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/OrgPolicyViolationInfo;
@@ -7398,7 +7398,7 @@ public final class protokt/v1/google/cloud/audit/PolicyViolationInfo : protokt/v
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/cloud/audit/PolicyViolationInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOrgPolicyViolationInfo ()Lprotokt/v1/google/cloud/audit/OrgPolicyViolationInfo;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/PolicyViolationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7437,7 +7437,7 @@ public final class protokt/v1/google/cloud/audit/RequestMetadata : protokt/v1/Ab
 	public final fun getCallerSuppliedUserAgent ()Ljava/lang/String;
 	public final fun getDestinationAttributes ()Lprotokt/v1/google/rpc/context/AttributeContext$Peer;
 	public final fun getRequestAttributes ()Lprotokt/v1/google/rpc/context/AttributeContext$Request;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/RequestMetadata;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7481,7 +7481,7 @@ public final class protokt/v1/google/cloud/audit/ResourceLocation : protokt/v1/A
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentLocations ()Ljava/util/List;
 	public final fun getOriginalLocations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ResourceLocation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7519,7 +7519,7 @@ public final class protokt/v1/google/cloud/audit/ServiceAccountDelegationInfo : 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthority ()Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$Authority;
 	public final fun getPrincipalSubject ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7582,7 +7582,7 @@ public final class protokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$Fi
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPrincipalEmail ()Ljava/lang/String;
 	public final fun getServiceMetadata ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$FirstPartyPrincipal;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7619,7 +7619,7 @@ public final class protokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$Th
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$ThirdPartyPrincipal;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getThirdPartyClaims ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$ThirdPartyPrincipal;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7657,7 +7657,7 @@ public final class protokt/v1/google/cloud/audit/ViolationInfo : protokt/v1/Abst
 	public final fun getConstraint ()Ljava/lang/String;
 	public final fun getErrorMessage ()Ljava/lang/String;
 	public final fun getPolicyType ()Lprotokt/v1/google/cloud/audit/ViolationInfo$PolicyType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ViolationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7730,7 +7730,7 @@ public final class protokt/v1/google/cloud/location/GetLocationRequest : protokt
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/cloud/location/GetLocationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/GetLocationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7768,7 +7768,7 @@ public final class protokt/v1/google/cloud/location/ListLocationsRequest : proto
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPageSize ()I
 	public final fun getPageToken ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/ListLocationsRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7810,7 +7810,7 @@ public final class protokt/v1/google/cloud/location/ListLocationsResponse : prot
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLocations ()Ljava/util/List;
 	public final fun getNextPageToken ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/ListLocationsResponse;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7851,7 +7851,7 @@ public final class protokt/v1/google/cloud/location/Location : protokt/v1/Abstra
 	public final fun getLocationId ()Ljava/lang/String;
 	public final fun getMetadata ()Lprotokt/v1/google/protobuf/Any;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/Location;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7895,7 +7895,7 @@ public final class protokt/v1/google/geo/type/Viewport : protokt/v1/AbstractMess
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHigh ()Lprotokt/v1/google/type/LatLng;
 	public final fun getLow ()Lprotokt/v1/google/type/LatLng;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/geo/type/Viewport;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7945,7 +7945,7 @@ public final class protokt/v1/google/logging/type/HttpRequest : protokt/v1/Abstr
 	public final fun getResponseSize ()J
 	public final fun getServerIp ()Ljava/lang/String;
 	public final fun getStatus ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUserAgent ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/logging/type/HttpRequest;
@@ -8061,7 +8061,7 @@ public final class protokt/v1/google/longrunning/CancelOperationRequest : protok
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/longrunning/CancelOperationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/CancelOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8096,7 +8096,7 @@ public final class protokt/v1/google/longrunning/DeleteOperationRequest : protok
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/longrunning/DeleteOperationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/DeleteOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8131,7 +8131,7 @@ public final class protokt/v1/google/longrunning/GetOperationRequest : protokt/v
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/longrunning/GetOperationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/GetOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8170,7 +8170,7 @@ public final class protokt/v1/google/longrunning/ListOperationsRequest : protokt
 	public final fun getPageSize ()I
 	public final fun getPageToken ()Ljava/lang/String;
 	public final fun getReturnPartialSuccess ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/ListOperationsRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8214,7 +8214,7 @@ public final class protokt/v1/google/longrunning/ListOperationsResponse : protok
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNextPageToken ()Ljava/lang/String;
 	public final fun getOperations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUnreachable ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/ListOperationsResponse;
@@ -8257,7 +8257,7 @@ public final class protokt/v1/google/longrunning/Operation : protokt/v1/Abstract
 	public final fun getMetadata ()Lprotokt/v1/google/protobuf/Any;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getResult ()Lprotokt/v1/google/longrunning/Operation$Result;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/Operation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8324,7 +8324,7 @@ public final class protokt/v1/google/longrunning/OperationInfo : protokt/v1/Abst
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetadataType ()Ljava/lang/String;
 	public final fun getResponseType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/OperationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8362,7 +8362,7 @@ public final class protokt/v1/google/longrunning/WaitOperationRequest : protokt/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTimeout ()Lprotokt/v1/google/protobuf/Duration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/WaitOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8399,7 +8399,7 @@ public final class protokt/v1/google/rpc/BadRequest : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/BadRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFieldViolations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/BadRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8437,7 +8437,7 @@ public final class protokt/v1/google/rpc/BadRequest$FieldViolation : protokt/v1/
 	public final fun getField ()Ljava/lang/String;
 	public final fun getLocalizedMessage ()Lprotokt/v1/google/rpc/LocalizedMessage;
 	public final fun getReason ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/BadRequest$FieldViolation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8563,7 +8563,7 @@ public final class protokt/v1/google/rpc/DebugInfo : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDetail ()Ljava/lang/String;
 	public final fun getStackEntries ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/DebugInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8602,7 +8602,7 @@ public final class protokt/v1/google/rpc/ErrorInfo : protokt/v1/AbstractMessage 
 	public final fun getDomain ()Ljava/lang/String;
 	public final fun getMetadata ()Ljava/util/Map;
 	public final fun getReason ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/ErrorInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8641,7 +8641,7 @@ public final class protokt/v1/google/rpc/Help : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/Help;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLinks ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/Help;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8676,7 +8676,7 @@ public final class protokt/v1/google/rpc/Help$Link : protokt/v1/AbstractMessage 
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/Help$Link;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/Help$Link;
@@ -8715,7 +8715,7 @@ public final class protokt/v1/google/rpc/LocalizedMessage : protokt/v1/AbstractM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLocale ()Ljava/lang/String;
 	public final fun getMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/LocalizedMessage;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8751,7 +8751,7 @@ public final class protokt/v1/google/rpc/PreconditionFailure : protokt/v1/Abstra
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/PreconditionFailure;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/PreconditionFailure;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getViolations ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/PreconditionFailure;
@@ -8789,7 +8789,7 @@ public final class protokt/v1/google/rpc/PreconditionFailure$Violation : protokt
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getSubject ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/PreconditionFailure$Violation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8827,7 +8827,7 @@ public final class protokt/v1/google/rpc/QuotaFailure : protokt/v1/AbstractMessa
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/QuotaFailure;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/QuotaFailure;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getViolations ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/QuotaFailure;
@@ -8870,7 +8870,7 @@ public final class protokt/v1/google/rpc/QuotaFailure$Violation : protokt/v1/Abs
 	public final fun getQuotaMetric ()Ljava/lang/String;
 	public final fun getQuotaValue ()J
 	public final fun getSubject ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/QuotaFailure$Violation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8920,7 +8920,7 @@ public final class protokt/v1/google/rpc/RequestInfo : protokt/v1/AbstractMessag
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestId ()Ljava/lang/String;
 	public final fun getServingData ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/RequestInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8960,7 +8960,7 @@ public final class protokt/v1/google/rpc/ResourceInfo : protokt/v1/AbstractMessa
 	public final fun getOwner ()Ljava/lang/String;
 	public final fun getResourceName ()Ljava/lang/String;
 	public final fun getResourceType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/ResourceInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9001,7 +9001,7 @@ public final class protokt/v1/google/rpc/RetryInfo : protokt/v1/AbstractMessage 
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/RetryInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRetryDelay ()Lprotokt/v1/google/protobuf/Duration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/RetryInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9038,7 +9038,7 @@ public final class protokt/v1/google/rpc/Status : protokt/v1/AbstractMessage {
 	public final fun getCode ()I
 	public final fun getDetails ()Ljava/util/List;
 	public final fun getMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/Status;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9084,7 +9084,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext : protokt/v1/A
 	public final fun getResource ()Lprotokt/v1/google/rpc/context/AttributeContext$Resource;
 	public final fun getResponse ()Lprotokt/v1/google/rpc/context/AttributeContext$Response;
 	public final fun getSource ()Lprotokt/v1/google/rpc/context/AttributeContext$Peer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9102,7 +9102,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Api : protokt/
 	public final fun getOperation ()Ljava/lang/String;
 	public final fun getProtocol ()Ljava/lang/String;
 	public final fun getService ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Api;
@@ -9148,7 +9148,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Auth : protokt
 	public final fun getClaims ()Lprotokt/v1/google/protobuf/Struct;
 	public final fun getPresenter ()Ljava/lang/String;
 	public final fun getPrincipal ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Auth;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9228,7 +9228,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Peer : protokt
 	public final fun getPort ()J
 	public final fun getPrincipal ()Ljava/lang/String;
 	public final fun getRegionCode ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Peer;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9282,7 +9282,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Request : prot
 	public final fun getScheme ()Ljava/lang/String;
 	public final fun getSize ()J
 	public final fun getTime ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Request;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9349,7 +9349,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Resource : pro
 	public final fun getService ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getUid ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUpdateTime ()Lprotokt/v1/google/protobuf/Timestamp;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Resource;
@@ -9411,7 +9411,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Response : pro
 	public final fun getHeaders ()Ljava/util/Map;
 	public final fun getSize ()J
 	public final fun getTime ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Response;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9458,7 +9458,7 @@ public final class protokt/v1/google/rpc/context/AuditContext : protokt/v1/Abstr
 	public final fun getScrubbedResponse ()Lprotokt/v1/google/protobuf/Struct;
 	public final fun getScrubbedResponseItemCount ()I
 	public final fun getTargetResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AuditContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9500,7 +9500,7 @@ public final class protokt/v1/google/shopping/type/Channel : protokt/v1/Abstract
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Channel;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/shopping/type/Channel;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Channel;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9562,7 +9562,7 @@ public final class protokt/v1/google/shopping/type/CustomAttribute : protokt/v1/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGroupValues ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/CustomAttribute;
@@ -9601,7 +9601,7 @@ public final class protokt/v1/google/shopping/type/Destination : protokt/v1/Abst
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Destination;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/shopping/type/Destination;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Destination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9703,7 +9703,7 @@ public final class protokt/v1/google/shopping/type/Price : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmountMicros ()Ljava/lang/Long;
 	public final fun getCurrencyCode ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Price;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9739,7 +9739,7 @@ public final class protokt/v1/google/shopping/type/ReportingContext : protokt/v1
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/ReportingContext;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/shopping/type/ReportingContext;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/ReportingContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9869,7 +9869,7 @@ public final class protokt/v1/google/shopping/type/Weight : protokt/v1/AbstractM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmountMicros ()Ljava/lang/Long;
 	public final fun getUnit ()Lprotokt/v1/google/shopping/type/Weight$WeightUnit;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Weight;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9985,7 +9985,7 @@ public final class protokt/v1/google/type/Color : protokt/v1/AbstractMessage {
 	public final fun getBlue ()F
 	public final fun getGreen ()F
 	public final fun getRed ()F
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Color;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10027,7 +10027,7 @@ public final class protokt/v1/google/type/Date : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDay ()I
 	public final fun getMonth ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getYear ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Date;
@@ -10073,7 +10073,7 @@ public final class protokt/v1/google/type/DateTime : protokt/v1/AbstractMessage 
 	public final fun getNanos ()I
 	public final fun getSeconds ()I
 	public final fun getTimeOffset ()Lprotokt/v1/google/type/DateTime$TimeOffset;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getYear ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/DateTime;
@@ -10195,7 +10195,7 @@ public final class protokt/v1/google/type/Decimal : protokt/v1/AbstractMessage {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Decimal;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/type/Decimal;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Decimal;
@@ -10234,7 +10234,7 @@ public final class protokt/v1/google/type/Expr : protokt/v1/AbstractMessage {
 	public final fun getExpression ()Ljava/lang/String;
 	public final fun getLocation ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Expr;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10276,7 +10276,7 @@ public final class protokt/v1/google/type/Fraction : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDenominator ()J
 	public final fun getNumerator ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Fraction;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10314,7 +10314,7 @@ public final class protokt/v1/google/type/Interval : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEndTime ()Lprotokt/v1/google/protobuf/Timestamp;
 	public final fun getStartTime ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Interval;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10352,7 +10352,7 @@ public final class protokt/v1/google/type/LatLng : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLatitude ()D
 	public final fun getLongitude ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/LatLng;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10390,7 +10390,7 @@ public final class protokt/v1/google/type/LocalizedText : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLanguageCode ()Ljava/lang/String;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/LocalizedText;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10429,7 +10429,7 @@ public final class protokt/v1/google/type/Money : protokt/v1/AbstractMessage {
 	public final fun getCurrencyCode ()Ljava/lang/String;
 	public final fun getNanos ()I
 	public final fun getUnits ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Money;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10537,7 +10537,7 @@ public final class protokt/v1/google/type/PhoneNumber : protokt/v1/AbstractMessa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExtension ()Ljava/lang/String;
 	public final fun getKind ()Lprotokt/v1/google/type/PhoneNumber$Kind;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/PhoneNumber;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10600,7 +10600,7 @@ public final class protokt/v1/google/type/PhoneNumber$ShortCode : protokt/v1/Abs
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNumber ()Ljava/lang/String;
 	public final fun getRegionCode ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/PhoneNumber$ShortCode;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10647,7 +10647,7 @@ public final class protokt/v1/google/type/PostalAddress : protokt/v1/AbstractMes
 	public final fun getRevision ()I
 	public final fun getSortingCode ()Ljava/lang/String;
 	public final fun getSublocality ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/PostalAddress;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10701,7 +10701,7 @@ public final class protokt/v1/google/type/Quaternion : protokt/v1/AbstractMessag
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Quaternion;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/type/Quaternion;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getW ()D
 	public final fun getX ()D
 	public final fun getY ()D
@@ -10749,7 +10749,7 @@ public final class protokt/v1/google/type/TimeOfDay : protokt/v1/AbstractMessage
 	public final fun getMinutes ()I
 	public final fun getNanos ()I
 	public final fun getSeconds ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/TimeOfDay;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10790,7 +10790,7 @@ public final class protokt/v1/google/type/TimeZone : protokt/v1/AbstractMessage 
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/type/TimeZone;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/TimeZone;


### PR DESCRIPTION
## Summary

- Promote `unknownFields` to the `Message` interface; privatize the `UnknownFieldSet` internal map behind `operator get`, `operator contains`, `isEmpty`, and `forEach`
- Add `Extension<E, T>` and `RepeatedExtension<E, T>` with `operator fun get` on `Message` for type-safe proto2 extension access
- `ExtensionCodec` sealed interface with `ExtensionCodecs` factory covers all scalar, enum, message, string, and bytes wire types
- Simplify `protokt-reflect`: delete `getUnknownFields()` kotlin-reflect hack, replace with direct `message.unknownFields` access

## Behavioral changes

- `UnknownFieldSet.toString()` format changes from `unknownFields=` to `fields=`
- `Message` interface now requires `val unknownFields: UnknownFieldSet`; all generated classes already had this property, now with `override`
- Map entry classes gain an `override val unknownFields = UnknownFieldSet.empty()`

## Test plan

- [x] `ExtensionTest`: 20+ tests covering all 17 wire type codecs, singular/repeated decode, encode round-trips, operator get, null/empty edge cases
- [x] `ExtensionInteropTest`: reads protokt's own custom options from protobuf-java-serialized bytes and from live proto descriptors
- [x] Full existing test suite passes