### PR TITLE
Self-host codegen pipeline with generated extension declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up js
       run: npm install protobufjs@7.2.6 long@5.2.3
     - name: Build, test, and publish integration repo
-      run: ./gradlew clean check publishToIntegrationRepository -x :testing:protovalidate-conformance:conformance -x :testing:protovalidate-conformance:test --stacktrace --no-daemon
+      run: ./gradlew clean check :protokt-codegen:verifyBootstrap publishToIntegrationRepository -x :testing:protovalidate-conformance:conformance -x :testing:protovalidate-conformance:test --stacktrace --no-daemon
       env:
         GRADLE_OPTS: "-Xmx4g"
     - name: Run protovalidate conformance

--- a/buildSrc/src/main/kotlin/protokt.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/protokt.spotless-conventions.gradle.kts
@@ -35,6 +35,7 @@ allprojects {
             targetExclude(
                 "buildSrc/build/generated-sources/**",
                 "**/generated/**",
+                "**/protokt-bootstrap/**",
                 "protokt-core-lite/src/jvmMain/kotlin/com/toasttab/protokt/**/*.kt",
                 "extensions/protokt-jvm-extensions-lite/src/main/kotlin/com/toasttab/protokt/ext/**.kt",
                 "extensions/protokt-extensions-lite/src/jvmMain/kotlin/com/toasttab/protokt/ext/**.kt",
@@ -65,7 +66,8 @@ allprojects {
                 "**/build/generated/source/**",
                 "**/protokt/v1/animals/**",
                 "**/protokt/v1/helloworld/**",
-                "**/protokt/v1/io/grpc/examples/**"
+                "**/protokt/v1/io/grpc/examples/**",
+                "**/protokt/v1/bootstrap/**"
             )
         }
 

--- a/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
+++ b/extensions/protokt-extensions-lite/api/protokt-extensions-lite.api
@@ -13,7 +13,7 @@ public final class protokt/v1/EnumOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -48,7 +48,7 @@ public final class protokt/v1/EnumValueOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumValueOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumValueOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -86,7 +86,7 @@ public final class protokt/v1/FieldOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getKeyWrap ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueWrap ()Ljava/lang/String;
 	public final fun getWrap ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -133,7 +133,7 @@ public final class protokt/v1/FileOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/FileOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/FileOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -185,7 +185,7 @@ public final class protokt/v1/InetSocketAddress : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lprotokt/v1/Bytes;
 	public final fun getPort ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/InetSocketAddress;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -255,7 +255,7 @@ public final class protokt/v1/MessageOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MessageOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -293,7 +293,7 @@ public final class protokt/v1/MethodOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestMarshaller ()Ljava/lang/String;
 	public final fun getResponseMarshaller ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MethodOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -332,7 +332,7 @@ public final class protokt/v1/OneofOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/OneofOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -370,7 +370,7 @@ public final class protokt/v1/ServiceOptions : protokt/v1/AbstractMessage {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/ServiceOptions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V

--- a/protokt-bootstrap/build.gradle.kts
+++ b/protokt-bootstrap/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Toast, Inc.
+ * Copyright (c) 2026 Toast, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,25 @@
  * limitations under the License.
  */
 
-package protokt.v1.codegen.util
+plugins {
+    id("protokt.jvm-conventions")
+}
 
-import protokt.v1.google.protobuf.FileDescriptorProto
-import protokt.v1.reflect.DOT_GOOGLE_PROTOBUF
-import protokt.v1.reflect.PROTOKT_V1
-import protokt.v1.reflect.resolvePackage
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-opt-in=protokt.v1.OnlyForUseByGeneratedProtoCode")
+    }
+}
 
-val PROTOKT_V1_GOOGLE_PROTO = PROTOKT_V1 + DOT_GOOGLE_PROTOBUF
+dependencies {
+    implementation(project(":protokt-runtime"))
+}
 
-fun packagesByFileName(protoFileList: List<FileDescriptorProto>) =
-    protoFileList.associate { it.name to resolvePackage(it.`package`.orEmpty()) }
+spotless {
+    kotlin {
+        targetExclude("**/*.kt")
+    }
+    format("kotlinLicense") {
+        targetExclude("**/*.kt")
+    }
+}

--- a/protokt-bootstrap/src/main/kotlin/protokt/v1/Protokt.kt
+++ b/protokt-bootstrap/src/main/kotlin/protokt/v1/Protokt.kt
@@ -1,0 +1,1288 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("DEPRECATION")
+@file:OptIn(protokt.v1.OnlyForUseByGeneratedProtoCode::class)
+
+package protokt.v1
+
+import protokt.v1.Sizes.sizeOf
+import protokt.v1.`get`
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.OptIn
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmStatic
+
+@GeneratedMessage("protokt.v1.FileOptions")
+public class FileOptions private constructor(
+  private val _fileDescriptorObjectName: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_fileDescriptorObjectName.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Specify the name of the Kotlin object that contains the reference to this file's FileDescriptor object.
+   */
+  @GeneratedProperty(1)
+  public val fileDescriptorObjectName: String
+    get() = _fileDescriptorObjectName.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
+      writer.writeTag(10u).write(_fileDescriptorObjectName.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FileOptions &&
+      other.fileDescriptorObjectName == this.fileDescriptorObjectName &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + fileDescriptorObjectName.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FileOptions(" +
+      "fileDescriptorObjectName=$fileDescriptorObjectName" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FileOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _fileDescriptorObjectNameRef: LazyReference<Bytes, String>? = null
+
+    public var fileDescriptorObjectName: String
+      get() = _fileDescriptorObjectNameRef?.value() ?: ""
+      set(newValue) {
+        _fileDescriptorObjectNameRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FileOptions =
+      FileOptions(
+        _fileDescriptorObjectNameRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FileOptions): Builder =
+        Builder().also {
+          it._fileDescriptorObjectNameRef = msg._fileDescriptorObjectName
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FileOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FileOptions {
+      var fileDescriptorObjectName: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FileOptions(
+              LazyReference(fileDescriptorObjectName ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            fileDescriptorObjectName = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FileOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.MessageOptions")
+public class MessageOptions private constructor(
+  private val _implements: LazyReference<Bytes, String>,
+  private val _deprecationMessage: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_implements.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_implements.wireValue())
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Declares that the message class implements an interface. Scoping rules are the same as those for declaring wrapper types.
+   */
+  @GeneratedProperty(1)
+  public val implements: String
+    get() = _implements.value()
+
+  /**
+   * Provides a message for deprecation
+   */
+  @GeneratedProperty(2)
+  public val deprecationMessage: String
+    get() = _deprecationMessage.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_implements.wireValue().isNotEmpty()) {
+      writer.writeTag(10u).write(_implements.wireValue())
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      writer.writeTag(18u).write(_deprecationMessage.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is MessageOptions &&
+      other.implements == this.implements &&
+      other.deprecationMessage == this.deprecationMessage &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + implements.hashCode()
+    result = 31 * result + deprecationMessage.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "MessageOptions(" +
+      "implements=$implements, " +
+      "deprecationMessage=$deprecationMessage" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): MessageOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _implementsRef: LazyReference<Bytes, String>? = null
+
+    public var implements: String
+      get() = _implementsRef?.value() ?: ""
+      set(newValue) {
+        _implementsRef = LazyReference(newValue, StringConverter)
+      }
+
+    private var _deprecationMessageRef: LazyReference<Bytes, String>? = null
+
+    public var deprecationMessage: String
+      get() = _deprecationMessageRef?.value() ?: ""
+      set(newValue) {
+        _deprecationMessageRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): MessageOptions =
+      MessageOptions(
+        _implementsRef ?: LazyReference(Bytes.empty(), StringConverter),
+        _deprecationMessageRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: MessageOptions): Builder =
+        Builder().also {
+          it._implementsRef = msg._implements
+          it._deprecationMessageRef = msg._deprecationMessage
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<MessageOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): MessageOptions {
+      var implements: Bytes? = null
+      var deprecationMessage: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return MessageOptions(
+              LazyReference(implements ?: Bytes.empty(), StringConverter),
+              LazyReference(deprecationMessage ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            implements = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            deprecationMessage = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): MessageOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.FieldOptions")
+public class FieldOptions private constructor(
+  /**
+   * Generates a non-nullable accessor.
+   *
+   *  For example:
+   *
+   *  message Foo {   Bar id = 1 [(protokt.v1.property).generate_non_null_accessor = true]; }
+   *
+   *  will generate an accessor called [requireId] that has the non-nullable type [Bar] (as opposed to [Bar?]).
+   */
+  @GeneratedProperty(1)
+  public val generateNonNullAccessor: Boolean,
+  private val _wrap: LazyReference<Bytes, String>,
+  /**
+   * Maps a bytes field to BytesSlice. If deserialized from a byte array, BytesSlice will point to the source array without copying the subarray.
+   */
+  @GeneratedProperty(3)
+  public val bytesSlice: Boolean,
+  private val _deprecationMessage: LazyReference<Bytes, String>,
+  private val _keyWrap: LazyReference<Bytes, String>,
+  private val _valueWrap: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (generateNonNullAccessor) {
+      result += sizeOf(8u) + 1
+    }
+    if (_wrap.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_wrap.wireValue())
+    }
+    if (bytesSlice) {
+      result += sizeOf(24u) + 1
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(34u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    if (_keyWrap.wireValue().isNotEmpty()) {
+      result += sizeOf(42u) + sizeOf(_keyWrap.wireValue())
+    }
+    if (_valueWrap.wireValue().isNotEmpty()) {
+      result += sizeOf(50u) + sizeOf(_valueWrap.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Expose a wrapper class instead of a raw protobuf type.
+   *
+   *  For example:
+   *
+   *  message Foo {   string id = 1 [(protokt.v1.property).wrap = "com.foo.FooId"]; }
+   *
+   *  data class FooId(val value: String)
+   *
+   *  will yield: class Foo(val id: FooId) ...
+   *
+   *  If the Kotlin package (or Java package, if the Kotlin package is unspecified) of this file is the same as the package of the wrapper type, full qualification is optional.
+   *
+   *  This option can be applied to repeated fields.
+   */
+  @GeneratedProperty(2)
+  public val wrap: String
+    get() = _wrap.value()
+
+  /**
+   * Provides a message for deprecation
+   */
+  @GeneratedProperty(4)
+  public val deprecationMessage: String
+    get() = _deprecationMessage.value()
+
+  /**
+   * Expose a wrapper class instead of a raw protobuf type for the key type of a map.
+   *
+   *  For example:
+   *
+   *  message Foo {   map<string, int32> map = 1 [(protokt.v1.property).key_wrap = "com.foo.FooId"]; }
+   *
+   *  data class FooId(val value: String)
+   *
+   *  will yield: class Foo(val map: Map<FooId, String>) ...
+   *
+   *  Scoping rules  are the same as those for declaring regular field wrapper types.
+   */
+  @GeneratedProperty(5)
+  public val keyWrap: String
+    get() = _keyWrap.value()
+
+  /**
+   * Expose a wrapper class instead of a raw protobuf type for the value type of a map.
+   *
+   *  For example:
+   *
+   *  message Foo {   map<int32, string> map = 1 [(protokt.v1.property).value_wrap = "com.foo.FooId"]; }
+   *
+   *  data class FooId(val value: String)
+   *
+   *  will yield: class Foo(val map: Map<Int, FooId>) ...
+   *
+   *  Scoping rules  are the same as those for declaring regular field wrapper types.
+   */
+  @GeneratedProperty(6)
+  public val valueWrap: String
+    get() = _valueWrap.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (generateNonNullAccessor) {
+      writer.writeTag(8u).write(generateNonNullAccessor)
+    }
+    if (_wrap.wireValue().isNotEmpty()) {
+      writer.writeTag(18u).write(_wrap.wireValue())
+    }
+    if (bytesSlice) {
+      writer.writeTag(24u).write(bytesSlice)
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      writer.writeTag(34u).write(_deprecationMessage.wireValue())
+    }
+    if (_keyWrap.wireValue().isNotEmpty()) {
+      writer.writeTag(42u).write(_keyWrap.wireValue())
+    }
+    if (_valueWrap.wireValue().isNotEmpty()) {
+      writer.writeTag(50u).write(_valueWrap.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FieldOptions &&
+      other.generateNonNullAccessor == this.generateNonNullAccessor &&
+      other.wrap == this.wrap &&
+      other.bytesSlice == this.bytesSlice &&
+      other.deprecationMessage == this.deprecationMessage &&
+      other.keyWrap == this.keyWrap &&
+      other.valueWrap == this.valueWrap &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + generateNonNullAccessor.hashCode()
+    result = 31 * result + wrap.hashCode()
+    result = 31 * result + bytesSlice.hashCode()
+    result = 31 * result + deprecationMessage.hashCode()
+    result = 31 * result + keyWrap.hashCode()
+    result = 31 * result + valueWrap.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FieldOptions(" +
+      "generateNonNullAccessor=$generateNonNullAccessor, " +
+      "wrap=$wrap, " +
+      "bytesSlice=$bytesSlice, " +
+      "deprecationMessage=$deprecationMessage, " +
+      "keyWrap=$keyWrap, " +
+      "valueWrap=$valueWrap" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FieldOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var generateNonNullAccessor: Boolean = false
+
+    private var _wrapRef: LazyReference<Bytes, String>? = null
+
+    public var wrap: String
+      get() = _wrapRef?.value() ?: ""
+      set(newValue) {
+        _wrapRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var bytesSlice: Boolean = false
+
+    private var _deprecationMessageRef: LazyReference<Bytes, String>? = null
+
+    public var deprecationMessage: String
+      get() = _deprecationMessageRef?.value() ?: ""
+      set(newValue) {
+        _deprecationMessageRef = LazyReference(newValue, StringConverter)
+      }
+
+    private var _keyWrapRef: LazyReference<Bytes, String>? = null
+
+    public var keyWrap: String
+      get() = _keyWrapRef?.value() ?: ""
+      set(newValue) {
+        _keyWrapRef = LazyReference(newValue, StringConverter)
+      }
+
+    private var _valueWrapRef: LazyReference<Bytes, String>? = null
+
+    public var valueWrap: String
+      get() = _valueWrapRef?.value() ?: ""
+      set(newValue) {
+        _valueWrapRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FieldOptions =
+      FieldOptions(
+        generateNonNullAccessor,
+        _wrapRef ?: LazyReference(Bytes.empty(), StringConverter),
+        bytesSlice,
+        _deprecationMessageRef ?: LazyReference(Bytes.empty(), StringConverter),
+        _keyWrapRef ?: LazyReference(Bytes.empty(), StringConverter),
+        _valueWrapRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FieldOptions): Builder =
+        Builder().also {
+          it.generateNonNullAccessor = msg.generateNonNullAccessor
+          it._wrapRef = msg._wrap
+          it.bytesSlice = msg.bytesSlice
+          it._deprecationMessageRef = msg._deprecationMessage
+          it._keyWrapRef = msg._keyWrap
+          it._valueWrapRef = msg._valueWrap
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FieldOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FieldOptions {
+      var generateNonNullAccessor = false
+      var wrap: Bytes? = null
+      var bytesSlice = false
+      var deprecationMessage: Bytes? = null
+      var keyWrap: Bytes? = null
+      var valueWrap: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FieldOptions(
+              generateNonNullAccessor,
+              LazyReference(wrap ?: Bytes.empty(), StringConverter),
+              bytesSlice,
+              LazyReference(deprecationMessage ?: Bytes.empty(), StringConverter),
+              LazyReference(keyWrap ?: Bytes.empty(), StringConverter),
+              LazyReference(valueWrap ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            generateNonNullAccessor = reader.readBool()
+          }
+
+          18u -> {
+            wrap = StringConverter.readValidatedBytes(reader)
+          }
+
+          24u -> {
+            bytesSlice = reader.readBool()
+          }
+
+          34u -> {
+            deprecationMessage = StringConverter.readValidatedBytes(reader)
+          }
+
+          42u -> {
+            keyWrap = StringConverter.readValidatedBytes(reader)
+          }
+
+          50u -> {
+            valueWrap = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FieldOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.OneofOptions")
+public class OneofOptions private constructor(
+  /**
+   * Generates a non-nullable accessor for a oneof field.
+   *
+   *  For example:
+   *
+   *  message Message {   oneof some_field_name {     option (protokt.v1.oneof).generate_non_null_accessor = true;
+   *
+   *      string id = 1;   } }
+   */
+  @GeneratedProperty(1)
+  public val generateNonNullAccessor: Boolean,
+  private val _implements: LazyReference<Bytes, String>,
+  private val _deprecationMessage: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (generateNonNullAccessor) {
+      result += sizeOf(8u) + 1
+    }
+    if (_implements.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_implements.wireValue())
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(26u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Make the sealed class implement an interface, enforcing the presence of a property in each possible variant. Scoping rules  are the same as those for declaring wrapper types.
+   */
+  @GeneratedProperty(2)
+  public val implements: String
+    get() = _implements.value()
+
+  /**
+   * Provides a message for deprecation
+   */
+  @GeneratedProperty(3)
+  public val deprecationMessage: String
+    get() = _deprecationMessage.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (generateNonNullAccessor) {
+      writer.writeTag(8u).write(generateNonNullAccessor)
+    }
+    if (_implements.wireValue().isNotEmpty()) {
+      writer.writeTag(18u).write(_implements.wireValue())
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      writer.writeTag(26u).write(_deprecationMessage.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is OneofOptions &&
+      other.generateNonNullAccessor == this.generateNonNullAccessor &&
+      other.implements == this.implements &&
+      other.deprecationMessage == this.deprecationMessage &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + generateNonNullAccessor.hashCode()
+    result = 31 * result + implements.hashCode()
+    result = 31 * result + deprecationMessage.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "OneofOptions(" +
+      "generateNonNullAccessor=$generateNonNullAccessor, " +
+      "implements=$implements, " +
+      "deprecationMessage=$deprecationMessage" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): OneofOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var generateNonNullAccessor: Boolean = false
+
+    private var _implementsRef: LazyReference<Bytes, String>? = null
+
+    public var implements: String
+      get() = _implementsRef?.value() ?: ""
+      set(newValue) {
+        _implementsRef = LazyReference(newValue, StringConverter)
+      }
+
+    private var _deprecationMessageRef: LazyReference<Bytes, String>? = null
+
+    public var deprecationMessage: String
+      get() = _deprecationMessageRef?.value() ?: ""
+      set(newValue) {
+        _deprecationMessageRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): OneofOptions =
+      OneofOptions(
+        generateNonNullAccessor,
+        _implementsRef ?: LazyReference(Bytes.empty(), StringConverter),
+        _deprecationMessageRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: OneofOptions): Builder =
+        Builder().also {
+          it.generateNonNullAccessor = msg.generateNonNullAccessor
+          it._implementsRef = msg._implements
+          it._deprecationMessageRef = msg._deprecationMessage
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<OneofOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): OneofOptions {
+      var generateNonNullAccessor = false
+      var implements: Bytes? = null
+      var deprecationMessage: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return OneofOptions(
+              generateNonNullAccessor,
+              LazyReference(implements ?: Bytes.empty(), StringConverter),
+              LazyReference(deprecationMessage ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            generateNonNullAccessor = reader.readBool()
+          }
+
+          18u -> {
+            implements = StringConverter.readValidatedBytes(reader)
+          }
+
+          26u -> {
+            deprecationMessage = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): OneofOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.EnumOptions")
+public class EnumOptions private constructor(
+  private val _deprecationMessage: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Provides a message for deprecation
+   */
+  @GeneratedProperty(1)
+  public val deprecationMessage: String
+    get() = _deprecationMessage.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      writer.writeTag(10u).write(_deprecationMessage.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is EnumOptions &&
+      other.deprecationMessage == this.deprecationMessage &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + deprecationMessage.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "EnumOptions(" +
+      "deprecationMessage=$deprecationMessage" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): EnumOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _deprecationMessageRef: LazyReference<Bytes, String>? = null
+
+    public var deprecationMessage: String
+      get() = _deprecationMessageRef?.value() ?: ""
+      set(newValue) {
+        _deprecationMessageRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): EnumOptions =
+      EnumOptions(
+        _deprecationMessageRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: EnumOptions): Builder =
+        Builder().also {
+          it._deprecationMessageRef = msg._deprecationMessage
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<EnumOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): EnumOptions {
+      var deprecationMessage: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return EnumOptions(
+              LazyReference(deprecationMessage ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            deprecationMessage = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): EnumOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.EnumValueOptions")
+public class EnumValueOptions private constructor(
+  private val _deprecationMessage: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Provides a message for deprecation
+   */
+  @GeneratedProperty(1)
+  public val deprecationMessage: String
+    get() = _deprecationMessage.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      writer.writeTag(10u).write(_deprecationMessage.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is EnumValueOptions &&
+      other.deprecationMessage == this.deprecationMessage &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + deprecationMessage.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "EnumValueOptions(" +
+      "deprecationMessage=$deprecationMessage" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): EnumValueOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _deprecationMessageRef: LazyReference<Bytes, String>? = null
+
+    public var deprecationMessage: String
+      get() = _deprecationMessageRef?.value() ?: ""
+      set(newValue) {
+        _deprecationMessageRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): EnumValueOptions =
+      EnumValueOptions(
+        _deprecationMessageRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: EnumValueOptions): Builder =
+        Builder().also {
+          it._deprecationMessageRef = msg._deprecationMessage
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<EnumValueOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): EnumValueOptions {
+      var deprecationMessage: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return EnumValueOptions(
+              LazyReference(deprecationMessage ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            deprecationMessage = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): EnumValueOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.ServiceOptions")
+public class ServiceOptions private constructor(
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    unknownFields.size()
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is ServiceOptions && other.unknownFields == unknownFields
+
+  override fun hashCode(): Int =
+    unknownFields.hashCode()
+
+  override fun toString(): String =
+    "ServiceOptions(${if (unknownFields.isEmpty()) ")" else "unknownFields=$unknownFields)"}"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): ServiceOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): ServiceOptions =
+      ServiceOptions(unknownFields)
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: ServiceOptions): Builder =
+        Builder().also {
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<ServiceOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): ServiceOptions {
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return ServiceOptions(
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): ServiceOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("protokt.v1.MethodOptions")
+public class MethodOptions private constructor(
+  private val _requestMarshaller: LazyReference<Bytes, String>,
+  private val _responseMarshaller: LazyReference<Bytes, String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_requestMarshaller.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_requestMarshaller.wireValue())
+    }
+    if (_responseMarshaller.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_responseMarshaller.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Provides a custom request marshaller for the generated method descriptor. Substitutes the provided expression directly for `com.toasttab.protokt.grpc.KtMarshaller(<request_type>)`
+   */
+  @GeneratedProperty(1)
+  public val requestMarshaller: String
+    get() = _requestMarshaller.value()
+
+  /**
+   * Provides a custom response marshaller for the generated method descriptor. Substitutes the provided expression directly for `com.toasttab.protokt.grpc.KtMarshaller(<response_type>)`
+   */
+  @GeneratedProperty(2)
+  public val responseMarshaller: String
+    get() = _responseMarshaller.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_requestMarshaller.wireValue().isNotEmpty()) {
+      writer.writeTag(10u).write(_requestMarshaller.wireValue())
+    }
+    if (_responseMarshaller.wireValue().isNotEmpty()) {
+      writer.writeTag(18u).write(_responseMarshaller.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is MethodOptions &&
+      other.requestMarshaller == this.requestMarshaller &&
+      other.responseMarshaller == this.responseMarshaller &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + requestMarshaller.hashCode()
+    result = 31 * result + responseMarshaller.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "MethodOptions(" +
+      "requestMarshaller=$requestMarshaller, " +
+      "responseMarshaller=$responseMarshaller" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): MethodOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _requestMarshallerRef: LazyReference<Bytes, String>? = null
+
+    public var requestMarshaller: String
+      get() = _requestMarshallerRef?.value() ?: ""
+      set(newValue) {
+        _requestMarshallerRef = LazyReference(newValue, StringConverter)
+      }
+
+    private var _responseMarshallerRef: LazyReference<Bytes, String>? = null
+
+    public var responseMarshaller: String
+      get() = _responseMarshallerRef?.value() ?: ""
+      set(newValue) {
+        _responseMarshallerRef = LazyReference(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): MethodOptions =
+      MethodOptions(
+        _requestMarshallerRef ?: LazyReference(Bytes.empty(), StringConverter),
+        _responseMarshallerRef ?: LazyReference(Bytes.empty(), StringConverter),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: MethodOptions): Builder =
+        Builder().also {
+          it._requestMarshallerRef = msg._requestMarshaller
+          it._responseMarshallerRef = msg._responseMarshaller
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<MethodOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): MethodOptions {
+      var requestMarshaller: Bytes? = null
+      var responseMarshaller: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return MethodOptions(
+              LazyReference(requestMarshaller ?: Bytes.empty(), StringConverter),
+              LazyReference(responseMarshaller ?: Bytes.empty(), StringConverter),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            requestMarshaller = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            responseMarshaller = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): MethodOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+private val fileExtension: Extension<protokt.v1.google.protobuf.FileOptions, FileOptions> =
+  Extension(1_253u, ExtensionCodecs.message(FileOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.FileOptions.`file`: FileOptions?
+  get() = this[fileExtension]
+
+private val classExtension: Extension<protokt.v1.google.protobuf.MessageOptions, MessageOptions> =
+  Extension(1_253u, ExtensionCodecs.message(MessageOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.MessageOptions.`class`: MessageOptions?
+  get() = this[classExtension]
+
+private val propertyExtension: Extension<protokt.v1.google.protobuf.FieldOptions, FieldOptions> =
+  Extension(1_253u, ExtensionCodecs.message(FieldOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.FieldOptions.`property`: FieldOptions?
+  get() = this[propertyExtension]
+
+private val oneofExtension: Extension<protokt.v1.google.protobuf.OneofOptions, OneofOptions> =
+  Extension(1_253u, ExtensionCodecs.message(OneofOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.OneofOptions.oneof: OneofOptions?
+  get() = this[oneofExtension]
+
+private val enumExtension: Extension<protokt.v1.google.protobuf.EnumOptions, EnumOptions> =
+  Extension(1_253u, ExtensionCodecs.message(EnumOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.EnumOptions.`enum`: EnumOptions?
+  get() = this[enumExtension]
+
+private val enumValueExtension:
+  Extension<protokt.v1.google.protobuf.EnumValueOptions, EnumValueOptions> =
+  Extension(1_253u, ExtensionCodecs.message(EnumValueOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.EnumValueOptions.enumValue: EnumValueOptions?
+  get() = this[enumValueExtension]
+
+private val serviceExtension: Extension<protokt.v1.google.protobuf.ServiceOptions, ServiceOptions> =
+  Extension(1_253u, ExtensionCodecs.message(ServiceOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.ServiceOptions.service: ServiceOptions?
+  get() = this[serviceExtension]
+
+private val methodExtension: Extension<protokt.v1.google.protobuf.MethodOptions, MethodOptions> =
+  Extension(1_253u, ExtensionCodecs.message(MethodOptions))
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val protokt.v1.google.protobuf.MethodOptions.method: MethodOptions?
+  get() = this[methodExtension]

--- a/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/Descriptor.kt
+++ b/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/Descriptor.kt
@@ -1,0 +1,8106 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("DEPRECATION")
+@file:OptIn(protokt.v1.OnlyForUseByGeneratedProtoCode::class)
+
+package protokt.v1.google.protobuf
+
+import protokt.v1.AbstractDeserializer
+import protokt.v1.AbstractMessage
+import protokt.v1.BuilderDsl
+import protokt.v1.BuilderScope
+import protokt.v1.Bytes
+import protokt.v1.Collections.freezeList
+import protokt.v1.Collections.listBuilder
+import protokt.v1.Enum
+import protokt.v1.EnumDeserializer
+import protokt.v1.GeneratedMessage
+import protokt.v1.GeneratedProperty
+import protokt.v1.LazyConvertingList
+import protokt.v1.LazyReference
+import protokt.v1.ListBuilder
+import protokt.v1.OnlyForUseByGeneratedProtoCode
+import protokt.v1.Reader
+import protokt.v1.Sizes.sizeOf
+import protokt.v1.StringConverter
+import protokt.v1.UnknownFieldSet
+import protokt.v1.Writer
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Double
+import kotlin.Int
+import kotlin.Long
+import kotlin.OptIn
+import kotlin.String
+import kotlin.Suppress
+import kotlin.ULong
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmStatic
+
+/**
+ * The protocol compiler can output a FileDescriptorSet containing the .proto files it parses.
+ */
+public sealed class Edition(
+  override val `value`: Int,
+  override val name: String
+) : Enum() {
+  public object EDITION_UNKNOWN : Edition(0, "EDITION_UNKNOWN")
+
+  public object EDITION_LEGACY : Edition(900, "EDITION_LEGACY")
+
+  public object EDITION_PROTO2 : Edition(998, "EDITION_PROTO2")
+
+  public object EDITION_PROTO3 : Edition(999, "EDITION_PROTO3")
+
+  public object EDITION_2023 : Edition(1000, "EDITION_2023")
+
+  public object EDITION_2024 : Edition(1001, "EDITION_2024")
+
+  public object EDITION_1_TEST_ONLY : Edition(1, "EDITION_1_TEST_ONLY")
+
+  public object EDITION_2_TEST_ONLY : Edition(2, "EDITION_2_TEST_ONLY")
+
+  public object EDITION_99997_TEST_ONLY : Edition(99997, "EDITION_99997_TEST_ONLY")
+
+  public object EDITION_99998_TEST_ONLY : Edition(99998, "EDITION_99998_TEST_ONLY")
+
+  public object EDITION_99999_TEST_ONLY : Edition(99999, "EDITION_99999_TEST_ONLY")
+
+  public object EDITION_MAX : Edition(2147483647, "EDITION_MAX")
+
+  public class UNRECOGNIZED(
+    `value`: Int
+  ) : Edition(value, "UNRECOGNIZED")
+
+  public companion object Deserializer : EnumDeserializer<Edition> {
+    override fun deserialize(`value`: Int): Edition =
+      when (value) {
+        0 -> EDITION_UNKNOWN
+        900 -> EDITION_LEGACY
+        998 -> EDITION_PROTO2
+        999 -> EDITION_PROTO3
+        1_000 -> EDITION_2023
+        1_001 -> EDITION_2024
+        1 -> EDITION_1_TEST_ONLY
+        2 -> EDITION_2_TEST_ONLY
+        99_997 -> EDITION_99997_TEST_ONLY
+        99_998 -> EDITION_99998_TEST_ONLY
+        99_999 -> EDITION_99999_TEST_ONLY
+        2_147_483_647 -> EDITION_MAX
+        else -> UNRECOGNIZED(value)
+      }
+  }
+}
+
+/**
+ * The protocol compiler can output a FileDescriptorSet containing the .proto files it parses.
+ */
+@GeneratedMessage("google.protobuf.FileDescriptorSet")
+public class FileDescriptorSet private constructor(
+  @GeneratedProperty(1)
+  public val `file`: List<FileDescriptorProto>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (`file`.isNotEmpty()) {
+      result += (sizeOf(10u) * `file`.size) + `file`.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    `file`.forEach { writer.writeTag(10u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FileDescriptorSet &&
+      other.`file` == this.`file` &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + `file`.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FileDescriptorSet(" +
+      "`file`=$`file`" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FileDescriptorSet =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var `file`: List<FileDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FileDescriptorSet =
+      FileDescriptorSet(
+        freezeList(`file`),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FileDescriptorSet): Builder =
+        Builder().also {
+          it.`file` = msg.`file`
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FileDescriptorSet>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FileDescriptorSet {
+      var `file`: ListBuilder<FileDescriptorProto>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FileDescriptorSet(
+              `file`?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            `file` =
+              (`file` ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FileDescriptorProto))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FileDescriptorSet =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * Describes a complete .proto file.
+ */
+@GeneratedMessage("google.protobuf.FileDescriptorProto")
+public class FileDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  private val _package: LazyReference<Bytes, String>?,
+  /**
+   * Names of files imported by this file.
+   */
+  @GeneratedProperty(3)
+  public val dependency: List<String>,
+  /**
+   * All top-level definitions in this file.
+   */
+  @GeneratedProperty(4)
+  public val messageType: List<DescriptorProto>,
+  @GeneratedProperty(5)
+  public val enumType: List<EnumDescriptorProto>,
+  @GeneratedProperty(6)
+  public val service: List<ServiceDescriptorProto>,
+  @GeneratedProperty(7)
+  public val extension: List<FieldDescriptorProto>,
+  @GeneratedProperty(8)
+  public val options: FileOptions?,
+  /**
+   * This field contains optional information about the original source code. You may safely remove this entire field without harming runtime functionality of the descriptors -- the information is needed only by development tools.
+   */
+  @GeneratedProperty(9)
+  public val sourceCodeInfo: SourceCodeInfo?,
+  /**
+   * Indexes of the public imported files in the dependency list above.
+   */
+  @GeneratedProperty(10)
+  public val publicDependency: List<Int>,
+  /**
+   * Indexes of the weak imported files in the dependency list. For Google-internal migration only. Do not use.
+   */
+  @GeneratedProperty(11)
+  public val weakDependency: List<Int>,
+  private val _syntax: LazyReference<Bytes, String>?,
+  /**
+   * The edition of the proto file. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(14)
+  public val edition: Edition?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (_package != null) {
+      result += sizeOf(18u) + sizeOf(_package.wireValue())
+    }
+    if (dependency.isNotEmpty()) {
+      result +=
+        @Suppress("UNCHECKED_CAST")
+        (dependency as LazyConvertingList<Bytes, Any>).let { list ->
+          (sizeOf(26u) * list.size) +
+            run {
+              var sum = 0
+              for (i in list.indices) sum += sizeOf(list.wireGet(i))
+              sum
+            }
+        }
+    }
+    if (messageType.isNotEmpty()) {
+      result += (sizeOf(34u) * messageType.size) + messageType.sumOf { sizeOf(it) }
+    }
+    if (enumType.isNotEmpty()) {
+      result += (sizeOf(42u) * enumType.size) + enumType.sumOf { sizeOf(it) }
+    }
+    if (service.isNotEmpty()) {
+      result += (sizeOf(50u) * service.size) + service.sumOf { sizeOf(it) }
+    }
+    if (extension.isNotEmpty()) {
+      result += (sizeOf(58u) * extension.size) + extension.sumOf { sizeOf(it) }
+    }
+    if (options != null) {
+      result += sizeOf(66u) + sizeOf(options)
+    }
+    if (sourceCodeInfo != null) {
+      result += sizeOf(74u) + sizeOf(sourceCodeInfo)
+    }
+    if (publicDependency.isNotEmpty()) {
+      result += (sizeOf(80u) * publicDependency.size) + publicDependency.sumOf { sizeOf(it) }
+    }
+    if (weakDependency.isNotEmpty()) {
+      result += (sizeOf(88u) * weakDependency.size) + weakDependency.sumOf { sizeOf(it) }
+    }
+    if (_syntax != null) {
+      result += sizeOf(98u) + sizeOf(_syntax.wireValue())
+    }
+    if (edition != null) {
+      result += sizeOf(112u) + sizeOf(edition)
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  @GeneratedProperty(2)
+  public val `package`: String?
+    get() = _package?.value()
+
+  /**
+   * The syntax of the proto file. The supported values are "proto2", "proto3", and "editions".
+   *
+   *  If `edition` is present, this value must be "editions". WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(12)
+  public val syntax: String?
+    get() = _syntax?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    if (_package != null) {
+      writer.writeTag(18u).write(_package.wireValue())
+    }
+    if (dependency.isNotEmpty()) {
+      @Suppress("UNCHECKED_CAST")
+      (dependency as LazyConvertingList<Bytes, Any>).wireForEach { writer.writeTag(26u).write(it) }
+    }
+    messageType.forEach { writer.writeTag(34u).write(it) }
+    enumType.forEach { writer.writeTag(42u).write(it) }
+    service.forEach { writer.writeTag(50u).write(it) }
+    extension.forEach { writer.writeTag(58u).write(it) }
+    if (options != null) {
+      writer.writeTag(66u).write(options)
+    }
+    if (sourceCodeInfo != null) {
+      writer.writeTag(74u).write(sourceCodeInfo)
+    }
+    publicDependency.forEach { writer.writeTag(80u).write(it) }
+    weakDependency.forEach { writer.writeTag(88u).write(it) }
+    if (_syntax != null) {
+      writer.writeTag(98u).write(_syntax.wireValue())
+    }
+    if (edition != null) {
+      writer.writeTag(112u).write(edition)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FileDescriptorProto &&
+      other.name == this.name &&
+      other.`package` == this.`package` &&
+      other.dependency == this.dependency &&
+      other.messageType == this.messageType &&
+      other.enumType == this.enumType &&
+      other.service == this.service &&
+      other.extension == this.extension &&
+      other.options == this.options &&
+      other.sourceCodeInfo == this.sourceCodeInfo &&
+      other.publicDependency == this.publicDependency &&
+      other.weakDependency == this.weakDependency &&
+      other.syntax == this.syntax &&
+      other.edition == this.edition &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + `package`.hashCode()
+    result = 31 * result + dependency.hashCode()
+    result = 31 * result + messageType.hashCode()
+    result = 31 * result + enumType.hashCode()
+    result = 31 * result + service.hashCode()
+    result = 31 * result + extension.hashCode()
+    result = 31 * result + options.hashCode()
+    result = 31 * result + sourceCodeInfo.hashCode()
+    result = 31 * result + publicDependency.hashCode()
+    result = 31 * result + weakDependency.hashCode()
+    result = 31 * result + syntax.hashCode()
+    result = 31 * result + edition.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FileDescriptorProto(" +
+      "name=$name, " +
+      "`package`=$`package`, " +
+      "dependency=$dependency, " +
+      "messageType=$messageType, " +
+      "enumType=$enumType, " +
+      "service=$service, " +
+      "extension=$extension, " +
+      "options=$options, " +
+      "sourceCodeInfo=$sourceCodeInfo, " +
+      "publicDependency=$publicDependency, " +
+      "weakDependency=$weakDependency, " +
+      "syntax=$syntax, " +
+      "edition=$edition" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FileDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _packageRef: LazyReference<Bytes, String>? = null
+
+    public var `package`: String?
+      get() = _packageRef?.value()
+      set(newValue) {
+        _packageRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var dependency: List<String> = emptyList()
+      set(newValue) {
+        field = if (newValue is LazyConvertingList<*, *>) newValue else LazyConvertingList.fromKotlin(newValue, StringConverter)
+      }
+
+    public var messageType: List<DescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var enumType: List<EnumDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var service: List<ServiceDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var extension: List<FieldDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var options: FileOptions? = null
+
+    public var sourceCodeInfo: SourceCodeInfo? = null
+
+    public var publicDependency: List<Int> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var weakDependency: List<Int> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    private var _syntaxRef: LazyReference<Bytes, String>? = null
+
+    public var syntax: String?
+      get() = _syntaxRef?.value()
+      set(newValue) {
+        _syntaxRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var edition: Edition? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FileDescriptorProto =
+      FileDescriptorProto(
+        _nameRef,
+        _packageRef,
+        dependency,
+        freezeList(messageType),
+        freezeList(enumType),
+        freezeList(service),
+        freezeList(extension),
+        options,
+        sourceCodeInfo,
+        freezeList(publicDependency),
+        freezeList(weakDependency),
+        _syntaxRef,
+        edition,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FileDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it._packageRef = msg._package
+          it.dependency = msg.dependency
+          it.messageType = msg.messageType
+          it.enumType = msg.enumType
+          it.service = msg.service
+          it.extension = msg.extension
+          it.options = msg.options
+          it.sourceCodeInfo = msg.sourceCodeInfo
+          it.publicDependency = msg.publicDependency
+          it.weakDependency = msg.weakDependency
+          it._syntaxRef = msg._syntax
+          it.edition = msg.edition
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FileDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FileDescriptorProto {
+      var name: Bytes? = null
+      var `package`: Bytes? = null
+      var dependency: ListBuilder<Any?>? = null
+      var messageType: ListBuilder<DescriptorProto>? = null
+      var enumType: ListBuilder<EnumDescriptorProto>? = null
+      var service: ListBuilder<ServiceDescriptorProto>? = null
+      var extension: ListBuilder<FieldDescriptorProto>? = null
+      var options: FileOptions? = null
+      var sourceCodeInfo: SourceCodeInfo? = null
+      var publicDependency: ListBuilder<Int>? = null
+      var weakDependency: ListBuilder<Int>? = null
+      var syntax: Bytes? = null
+      var edition: Edition? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FileDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              `package`?.let { LazyReference(it, StringConverter) },
+              dependency?.build()?.let { LazyConvertingList<Bytes, String>(it, StringConverter) } ?: emptyList(),
+              messageType?.build() ?: emptyList(),
+              enumType?.build() ?: emptyList(),
+              service?.build() ?: emptyList(),
+              extension?.build() ?: emptyList(),
+              options,
+              sourceCodeInfo,
+              publicDependency?.build() ?: emptyList(),
+              weakDependency?.build() ?: emptyList(),
+              syntax?.let { LazyReference(it, StringConverter) },
+              edition,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            `package` = StringConverter.readValidatedBytes(reader)
+          }
+
+          26u -> {
+            dependency =
+              (dependency ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(LazyReference(StringConverter.readValidatedBytes(reader), StringConverter))
+                }
+              }
+          }
+
+          34u -> {
+            messageType =
+              (messageType ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(DescriptorProto))
+                }
+              }
+          }
+
+          42u -> {
+            enumType =
+              (enumType ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(EnumDescriptorProto))
+                }
+              }
+          }
+
+          50u -> {
+            service =
+              (service ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(ServiceDescriptorProto))
+                }
+              }
+          }
+
+          58u -> {
+            extension =
+              (extension ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FieldDescriptorProto))
+                }
+              }
+          }
+
+          66u -> {
+            options = reader.readMessage(FileOptions)
+          }
+
+          74u -> {
+            sourceCodeInfo = reader.readMessage(SourceCodeInfo)
+          }
+
+          80u -> {
+            publicDependency =
+              (publicDependency ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readInt32())
+                }
+              }
+          }
+
+          82u -> {
+            publicDependency =
+              (publicDependency ?: listBuilder()).apply {
+                reader.readRepeated(true) {
+                  add(reader.readInt32())
+                }
+              }
+          }
+
+          88u -> {
+            weakDependency =
+              (weakDependency ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readInt32())
+                }
+              }
+          }
+
+          90u -> {
+            weakDependency =
+              (weakDependency ?: listBuilder()).apply {
+                reader.readRepeated(true) {
+                  add(reader.readInt32())
+                }
+              }
+          }
+
+          98u -> {
+            syntax = StringConverter.readValidatedBytes(reader)
+          }
+
+          112u -> {
+            edition = reader.readEnum(Edition)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FileDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * Describes a message type.
+ */
+@GeneratedMessage("google.protobuf.DescriptorProto")
+public class DescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  @GeneratedProperty(2)
+  public val `field`: List<FieldDescriptorProto>,
+  @GeneratedProperty(3)
+  public val nestedType: List<DescriptorProto>,
+  @GeneratedProperty(4)
+  public val enumType: List<EnumDescriptorProto>,
+  @GeneratedProperty(5)
+  public val extensionRange: List<ExtensionRange>,
+  @GeneratedProperty(6)
+  public val extension: List<FieldDescriptorProto>,
+  @GeneratedProperty(7)
+  public val options: MessageOptions?,
+  @GeneratedProperty(8)
+  public val oneofDecl: List<OneofDescriptorProto>,
+  @GeneratedProperty(9)
+  public val reservedRange: List<ReservedRange>,
+  /**
+   * Reserved field names, which may not be used by fields in the same message. A given name may only be reserved once.
+   */
+  @GeneratedProperty(10)
+  public val reservedName: List<String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (`field`.isNotEmpty()) {
+      result += (sizeOf(18u) * `field`.size) + `field`.sumOf { sizeOf(it) }
+    }
+    if (nestedType.isNotEmpty()) {
+      result += (sizeOf(26u) * nestedType.size) + nestedType.sumOf { sizeOf(it) }
+    }
+    if (enumType.isNotEmpty()) {
+      result += (sizeOf(34u) * enumType.size) + enumType.sumOf { sizeOf(it) }
+    }
+    if (extensionRange.isNotEmpty()) {
+      result += (sizeOf(42u) * extensionRange.size) + extensionRange.sumOf { sizeOf(it) }
+    }
+    if (extension.isNotEmpty()) {
+      result += (sizeOf(50u) * extension.size) + extension.sumOf { sizeOf(it) }
+    }
+    if (options != null) {
+      result += sizeOf(58u) + sizeOf(options)
+    }
+    if (oneofDecl.isNotEmpty()) {
+      result += (sizeOf(66u) * oneofDecl.size) + oneofDecl.sumOf { sizeOf(it) }
+    }
+    if (reservedRange.isNotEmpty()) {
+      result += (sizeOf(74u) * reservedRange.size) + reservedRange.sumOf { sizeOf(it) }
+    }
+    if (reservedName.isNotEmpty()) {
+      result +=
+        @Suppress("UNCHECKED_CAST")
+        (reservedName as LazyConvertingList<Bytes, Any>).let { list ->
+          (sizeOf(82u) * list.size) +
+            run {
+              var sum = 0
+              for (i in list.indices) sum += sizeOf(list.wireGet(i))
+              sum
+            }
+        }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    `field`.forEach { writer.writeTag(18u).write(it) }
+    nestedType.forEach { writer.writeTag(26u).write(it) }
+    enumType.forEach { writer.writeTag(34u).write(it) }
+    extensionRange.forEach { writer.writeTag(42u).write(it) }
+    extension.forEach { writer.writeTag(50u).write(it) }
+    if (options != null) {
+      writer.writeTag(58u).write(options)
+    }
+    oneofDecl.forEach { writer.writeTag(66u).write(it) }
+    reservedRange.forEach { writer.writeTag(74u).write(it) }
+    if (reservedName.isNotEmpty()) {
+      @Suppress("UNCHECKED_CAST")
+      (reservedName as LazyConvertingList<Bytes, Any>).wireForEach { writer.writeTag(82u).write(it) }
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is DescriptorProto &&
+      other.name == this.name &&
+      other.`field` == this.`field` &&
+      other.nestedType == this.nestedType &&
+      other.enumType == this.enumType &&
+      other.extensionRange == this.extensionRange &&
+      other.extension == this.extension &&
+      other.options == this.options &&
+      other.oneofDecl == this.oneofDecl &&
+      other.reservedRange == this.reservedRange &&
+      other.reservedName == this.reservedName &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + `field`.hashCode()
+    result = 31 * result + nestedType.hashCode()
+    result = 31 * result + enumType.hashCode()
+    result = 31 * result + extensionRange.hashCode()
+    result = 31 * result + extension.hashCode()
+    result = 31 * result + options.hashCode()
+    result = 31 * result + oneofDecl.hashCode()
+    result = 31 * result + reservedRange.hashCode()
+    result = 31 * result + reservedName.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "DescriptorProto(" +
+      "name=$name, " +
+      "`field`=$`field`, " +
+      "nestedType=$nestedType, " +
+      "enumType=$enumType, " +
+      "extensionRange=$extensionRange, " +
+      "extension=$extension, " +
+      "options=$options, " +
+      "oneofDecl=$oneofDecl, " +
+      "reservedRange=$reservedRange, " +
+      "reservedName=$reservedName" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): DescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var `field`: List<FieldDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var nestedType: List<DescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var enumType: List<EnumDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var extensionRange: List<ExtensionRange> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var extension: List<FieldDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var options: MessageOptions? = null
+
+    public var oneofDecl: List<OneofDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var reservedRange: List<ReservedRange> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var reservedName: List<String> = emptyList()
+      set(newValue) {
+        field = if (newValue is LazyConvertingList<*, *>) newValue else LazyConvertingList.fromKotlin(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): DescriptorProto =
+      DescriptorProto(
+        _nameRef,
+        freezeList(`field`),
+        freezeList(nestedType),
+        freezeList(enumType),
+        freezeList(extensionRange),
+        freezeList(extension),
+        options,
+        freezeList(oneofDecl),
+        freezeList(reservedRange),
+        reservedName,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: DescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it.`field` = msg.`field`
+          it.nestedType = msg.nestedType
+          it.enumType = msg.enumType
+          it.extensionRange = msg.extensionRange
+          it.extension = msg.extension
+          it.options = msg.options
+          it.oneofDecl = msg.oneofDecl
+          it.reservedRange = msg.reservedRange
+          it.reservedName = msg.reservedName
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<DescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): DescriptorProto {
+      var name: Bytes? = null
+      var `field`: ListBuilder<FieldDescriptorProto>? = null
+      var nestedType: ListBuilder<DescriptorProto>? = null
+      var enumType: ListBuilder<EnumDescriptorProto>? = null
+      var extensionRange: ListBuilder<ExtensionRange>? = null
+      var extension: ListBuilder<FieldDescriptorProto>? = null
+      var options: MessageOptions? = null
+      var oneofDecl: ListBuilder<OneofDescriptorProto>? = null
+      var reservedRange: ListBuilder<ReservedRange>? = null
+      var reservedName: ListBuilder<Any?>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return DescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              `field`?.build() ?: emptyList(),
+              nestedType?.build() ?: emptyList(),
+              enumType?.build() ?: emptyList(),
+              extensionRange?.build() ?: emptyList(),
+              extension?.build() ?: emptyList(),
+              options,
+              oneofDecl?.build() ?: emptyList(),
+              reservedRange?.build() ?: emptyList(),
+              reservedName?.build()?.let { LazyConvertingList<Bytes, String>(it, StringConverter) } ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            `field` =
+              (`field` ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FieldDescriptorProto))
+                }
+              }
+          }
+
+          26u -> {
+            nestedType =
+              (nestedType ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(DescriptorProto))
+                }
+              }
+          }
+
+          34u -> {
+            enumType =
+              (enumType ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(EnumDescriptorProto))
+                }
+              }
+          }
+
+          42u -> {
+            extensionRange =
+              (extensionRange ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(ExtensionRange))
+                }
+              }
+          }
+
+          50u -> {
+            extension =
+              (extension ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FieldDescriptorProto))
+                }
+              }
+          }
+
+          58u -> {
+            options = reader.readMessage(MessageOptions)
+          }
+
+          66u -> {
+            oneofDecl =
+              (oneofDecl ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(OneofDescriptorProto))
+                }
+              }
+          }
+
+          74u -> {
+            reservedRange =
+              (reservedRange ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(ReservedRange))
+                }
+              }
+          }
+
+          82u -> {
+            reservedName =
+              (reservedName ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(LazyReference(StringConverter.readValidatedBytes(reader), StringConverter))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): DescriptorProto =
+      Builder().apply(dsl).build()
+  }
+
+  @GeneratedMessage("google.protobuf.DescriptorProto.ExtensionRange")
+  public class ExtensionRange private constructor(
+    @GeneratedProperty(1)
+    public val start: Int?,
+    @GeneratedProperty(2)
+    public val end: Int?,
+    @GeneratedProperty(3)
+    public val options: ExtensionRangeOptions?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (start != null) {
+        result += sizeOf(8u) + sizeOf(start)
+      }
+      if (end != null) {
+        result += sizeOf(16u) + sizeOf(end)
+      }
+      if (options != null) {
+        result += sizeOf(26u) + sizeOf(options)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (start != null) {
+        writer.writeTag(8u).write(start)
+      }
+      if (end != null) {
+        writer.writeTag(16u).write(end)
+      }
+      if (options != null) {
+        writer.writeTag(26u).write(options)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is ExtensionRange &&
+        other.start == this.start &&
+        other.end == this.end &&
+        other.options == this.options &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + start.hashCode()
+      result = 31 * result + end.hashCode()
+      result = 31 * result + options.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "ExtensionRange(" +
+        "start=$start, " +
+        "end=$end, " +
+        "options=$options" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): ExtensionRange =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var start: Int? = null
+
+      public var end: Int? = null
+
+      public var options: ExtensionRangeOptions? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): ExtensionRange =
+        ExtensionRange(
+          start,
+          end,
+          options,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: ExtensionRange): Builder =
+          Builder().also {
+            it.start = msg.start
+            it.end = msg.end
+            it.options = msg.options
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<ExtensionRange>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): ExtensionRange {
+        var start: Int? = null
+        var end: Int? = null
+        var options: ExtensionRangeOptions? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return ExtensionRange(
+                start,
+                end,
+                options,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              start = reader.readInt32()
+            }
+
+            16u -> {
+              end = reader.readInt32()
+            }
+
+            26u -> {
+              options = reader.readMessage(ExtensionRangeOptions)
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): ExtensionRange =
+        Builder().apply(dsl).build()
+    }
+  }
+
+  /**
+   * Range of reserved tag numbers. Reserved tag numbers may not be used by fields or extension ranges in the same message. Reserved ranges may not overlap.
+   */
+  @GeneratedMessage("google.protobuf.DescriptorProto.ReservedRange")
+  public class ReservedRange private constructor(
+    @GeneratedProperty(1)
+    public val start: Int?,
+    @GeneratedProperty(2)
+    public val end: Int?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (start != null) {
+        result += sizeOf(8u) + sizeOf(start)
+      }
+      if (end != null) {
+        result += sizeOf(16u) + sizeOf(end)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (start != null) {
+        writer.writeTag(8u).write(start)
+      }
+      if (end != null) {
+        writer.writeTag(16u).write(end)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is ReservedRange &&
+        other.start == this.start &&
+        other.end == this.end &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + start.hashCode()
+      result = 31 * result + end.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "ReservedRange(" +
+        "start=$start, " +
+        "end=$end" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): ReservedRange =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var start: Int? = null
+
+      public var end: Int? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): ReservedRange =
+        ReservedRange(
+          start,
+          end,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: ReservedRange): Builder =
+          Builder().also {
+            it.start = msg.start
+            it.end = msg.end
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<ReservedRange>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): ReservedRange {
+        var start: Int? = null
+        var end: Int? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return ReservedRange(
+                start,
+                end,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              start = reader.readInt32()
+            }
+
+            16u -> {
+              end = reader.readInt32()
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): ReservedRange =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+@GeneratedMessage("google.protobuf.ExtensionRangeOptions")
+public class ExtensionRangeOptions private constructor(
+  /**
+   * For external users: DO NOT USE. We are in the process of open sourcing extension declaration and executing internal cleanups before it can be used externally.
+   */
+  @GeneratedProperty(2)
+  public val declaration: List<Declaration>,
+  /**
+   * The verification state of the range. TODO: flip the default to DECLARATION once all empty ranges are marked as UNVERIFIED.
+   */
+  @GeneratedProperty(3)
+  public val verification: VerificationState?,
+  /**
+   * Any features defined in the specific edition.
+   */
+  @GeneratedProperty(50)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (declaration.isNotEmpty()) {
+      result += (sizeOf(18u) * declaration.size) + declaration.sumOf { sizeOf(it) }
+    }
+    if (verification != null) {
+      result += sizeOf(24u) + sizeOf(verification)
+    }
+    if (features != null) {
+      result += sizeOf(402u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    declaration.forEach { writer.writeTag(18u).write(it) }
+    if (verification != null) {
+      writer.writeTag(24u).write(verification)
+    }
+    if (features != null) {
+      writer.writeTag(402u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is ExtensionRangeOptions &&
+      other.declaration == this.declaration &&
+      other.verification == this.verification &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + declaration.hashCode()
+    result = 31 * result + verification.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "ExtensionRangeOptions(" +
+      "declaration=$declaration, " +
+      "verification=$verification, " +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): ExtensionRangeOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var declaration: List<Declaration> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var verification: VerificationState? = null
+
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): ExtensionRangeOptions =
+      ExtensionRangeOptions(
+        freezeList(declaration),
+        verification,
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: ExtensionRangeOptions): Builder =
+        Builder().also {
+          it.declaration = msg.declaration
+          it.verification = msg.verification
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<ExtensionRangeOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): ExtensionRangeOptions {
+      var declaration: ListBuilder<Declaration>? = null
+      var verification: VerificationState? = null
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return ExtensionRangeOptions(
+              declaration?.build() ?: emptyList(),
+              verification,
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          18u -> {
+            declaration =
+              (declaration ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(Declaration))
+                }
+              }
+          }
+
+          24u -> {
+            verification = reader.readEnum(VerificationState)
+          }
+
+          402u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): ExtensionRangeOptions =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * The verification state of the extension range.
+   */
+  public sealed class VerificationState(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    /**
+     * All the extensions of the range must be declared.
+     */
+    public object DECLARATION : VerificationState(0, "DECLARATION")
+
+    public object UNVERIFIED : VerificationState(1, "UNVERIFIED")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : VerificationState(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<VerificationState> {
+      override fun deserialize(`value`: Int): VerificationState =
+        when (value) {
+          0 -> DECLARATION
+          1 -> UNVERIFIED
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  @GeneratedMessage("google.protobuf.ExtensionRangeOptions.Declaration")
+  public class Declaration private constructor(
+    /**
+     * The extension number declared within the extension range.
+     */
+    @GeneratedProperty(1)
+    public val number: Int?,
+    private val _fullName: LazyReference<Bytes, String>?,
+    private val _type: LazyReference<Bytes, String>?,
+    /**
+     * If true, indicates that the number is reserved in the extension range, and any extension field with the number will fail to compile. Set this when a declared extension field is deleted.
+     */
+    @GeneratedProperty(5)
+    public val reserved: Boolean?,
+    /**
+     * If true, indicates that the extension must be defined as repeated. Otherwise the extension must be defined as optional.
+     */
+    @GeneratedProperty(6)
+    public val repeated: Boolean?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (number != null) {
+        result += sizeOf(8u) + sizeOf(number)
+      }
+      if (_fullName != null) {
+        result += sizeOf(18u) + sizeOf(_fullName.wireValue())
+      }
+      if (_type != null) {
+        result += sizeOf(26u) + sizeOf(_type.wireValue())
+      }
+      if (reserved != null) {
+        result += sizeOf(40u) + 1
+      }
+      if (repeated != null) {
+        result += sizeOf(48u) + 1
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    /**
+     * The fully-qualified name of the extension field. There must be a leading dot in front of the full name.
+     */
+    @GeneratedProperty(2)
+    public val fullName: String?
+      get() = _fullName?.value()
+
+    /**
+     * The fully-qualified type name of the extension field. Unlike Metadata.type, Declaration.type must have a leading dot for messages and enums.
+     */
+    @GeneratedProperty(3)
+    public val type: String?
+      get() = _type?.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (number != null) {
+        writer.writeTag(8u).write(number)
+      }
+      if (_fullName != null) {
+        writer.writeTag(18u).write(_fullName.wireValue())
+      }
+      if (_type != null) {
+        writer.writeTag(26u).write(_type.wireValue())
+      }
+      if (reserved != null) {
+        writer.writeTag(40u).write(reserved)
+      }
+      if (repeated != null) {
+        writer.writeTag(48u).write(repeated)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is Declaration &&
+        other.number == this.number &&
+        other.fullName == this.fullName &&
+        other.type == this.type &&
+        other.reserved == this.reserved &&
+        other.repeated == this.repeated &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + number.hashCode()
+      result = 31 * result + fullName.hashCode()
+      result = 31 * result + type.hashCode()
+      result = 31 * result + reserved.hashCode()
+      result = 31 * result + repeated.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "Declaration(" +
+        "number=$number, " +
+        "fullName=$fullName, " +
+        "type=$type, " +
+        "reserved=$reserved, " +
+        "repeated=$repeated" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): Declaration =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var number: Int? = null
+
+      private var _fullNameRef: LazyReference<Bytes, String>? = null
+
+      public var fullName: String?
+        get() = _fullNameRef?.value()
+        set(newValue) {
+          _fullNameRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      private var _typeRef: LazyReference<Bytes, String>? = null
+
+      public var type: String?
+        get() = _typeRef?.value()
+        set(newValue) {
+          _typeRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      public var reserved: Boolean? = null
+
+      public var repeated: Boolean? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): Declaration =
+        Declaration(
+          number,
+          _fullNameRef,
+          _typeRef,
+          reserved,
+          repeated,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: Declaration): Builder =
+          Builder().also {
+            it.number = msg.number
+            it._fullNameRef = msg._fullName
+            it._typeRef = msg._type
+            it.reserved = msg.reserved
+            it.repeated = msg.repeated
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<Declaration>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): Declaration {
+        var number: Int? = null
+        var fullName: Bytes? = null
+        var type: Bytes? = null
+        var reserved: Boolean? = null
+        var repeated: Boolean? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return Declaration(
+                number,
+                fullName?.let { LazyReference(it, StringConverter) },
+                type?.let { LazyReference(it, StringConverter) },
+                reserved,
+                repeated,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              number = reader.readInt32()
+            }
+
+            18u -> {
+              fullName = StringConverter.readValidatedBytes(reader)
+            }
+
+            26u -> {
+              type = StringConverter.readValidatedBytes(reader)
+            }
+
+            40u -> {
+              reserved = reader.readBool()
+            }
+
+            48u -> {
+              repeated = reader.readBool()
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): Declaration =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+/**
+ * Describes a field within a message.
+ */
+@GeneratedMessage("google.protobuf.FieldDescriptorProto")
+public class FieldDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  private val _extendee: LazyReference<Bytes, String>?,
+  @GeneratedProperty(3)
+  public val number: Int?,
+  @GeneratedProperty(4)
+  public val label: Label?,
+  /**
+   * If type_name is set, this need not be set.  If both this and type_name are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+   */
+  @GeneratedProperty(5)
+  public val type: Type?,
+  private val _typeName: LazyReference<Bytes, String>?,
+  private val _defaultValue: LazyReference<Bytes, String>?,
+  @GeneratedProperty(8)
+  public val options: FieldOptions?,
+  /**
+   * If set, gives the index of a oneof in the containing type's oneof_decl list.  This field is a member of that oneof.
+   */
+  @GeneratedProperty(9)
+  public val oneofIndex: Int?,
+  private val _jsonName: LazyReference<Bytes, String>?,
+  /**
+   * If true, this is a proto3 "optional". When a proto3 field is optional, it tracks presence regardless of field type.
+   *
+   *  When proto3_optional is true, this field must belong to a oneof to signal to old proto3 clients that presence is tracked for this field. This oneof is known as a "synthetic" oneof, and this field must be its sole member (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs exist in the descriptor only, and do not generate any API. Synthetic oneofs must be ordered after all "real" oneofs.
+   *
+   *  For message fields, proto3_optional doesn't create any semantic change, since non-repeated message fields always track presence. However it still indicates the semantic detail of whether the user wrote "optional" or not. This can be useful for round-tripping the .proto file. For consistency we give message fields a synthetic oneof also, even though it is not required to track presence. This is especially important because the parser can't tell if a field is a message or an enum, so it must always create a synthetic oneof.
+   *
+   *  Proto2 optional fields do not set this flag, because they already indicate optional with `LABEL_OPTIONAL`.
+   */
+  @GeneratedProperty(17)
+  public val proto3Optional: Boolean?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (_extendee != null) {
+      result += sizeOf(18u) + sizeOf(_extendee.wireValue())
+    }
+    if (number != null) {
+      result += sizeOf(24u) + sizeOf(number)
+    }
+    if (label != null) {
+      result += sizeOf(32u) + sizeOf(label)
+    }
+    if (type != null) {
+      result += sizeOf(40u) + sizeOf(type)
+    }
+    if (_typeName != null) {
+      result += sizeOf(50u) + sizeOf(_typeName.wireValue())
+    }
+    if (_defaultValue != null) {
+      result += sizeOf(58u) + sizeOf(_defaultValue.wireValue())
+    }
+    if (options != null) {
+      result += sizeOf(66u) + sizeOf(options)
+    }
+    if (oneofIndex != null) {
+      result += sizeOf(72u) + sizeOf(oneofIndex)
+    }
+    if (_jsonName != null) {
+      result += sizeOf(82u) + sizeOf(_jsonName.wireValue())
+    }
+    if (proto3Optional != null) {
+      result += sizeOf(136u) + 1
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  /**
+   * For extensions, this is the name of the type being extended.  It is resolved in the same manner as type_name.
+   */
+  @GeneratedProperty(2)
+  public val extendee: String?
+    get() = _extendee?.value()
+
+  /**
+   * For message and enum types, this is the name of the type.  If the name starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping rules are used to find the type (i.e. first the nested types within this message are searched, then within the parent, on up to the root namespace).
+   */
+  @GeneratedProperty(6)
+  public val typeName: String?
+    get() = _typeName?.value()
+
+  /**
+   * For numeric types, contains the original text representation of the value. For booleans, "true" or "false". For strings, contains the default text contents (not escaped in any way). For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+   */
+  @GeneratedProperty(7)
+  public val defaultValue: String?
+    get() = _defaultValue?.value()
+
+  /**
+   * JSON name of this field. The value is set by protocol compiler. If the user has set a "json_name" option on this field, that option's value will be used. Otherwise, it's deduced from the field's name by converting it to camelCase.
+   */
+  @GeneratedProperty(10)
+  public val jsonName: String?
+    get() = _jsonName?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    if (_extendee != null) {
+      writer.writeTag(18u).write(_extendee.wireValue())
+    }
+    if (number != null) {
+      writer.writeTag(24u).write(number)
+    }
+    if (label != null) {
+      writer.writeTag(32u).write(label)
+    }
+    if (type != null) {
+      writer.writeTag(40u).write(type)
+    }
+    if (_typeName != null) {
+      writer.writeTag(50u).write(_typeName.wireValue())
+    }
+    if (_defaultValue != null) {
+      writer.writeTag(58u).write(_defaultValue.wireValue())
+    }
+    if (options != null) {
+      writer.writeTag(66u).write(options)
+    }
+    if (oneofIndex != null) {
+      writer.writeTag(72u).write(oneofIndex)
+    }
+    if (_jsonName != null) {
+      writer.writeTag(82u).write(_jsonName.wireValue())
+    }
+    if (proto3Optional != null) {
+      writer.writeTag(136u).write(proto3Optional)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FieldDescriptorProto &&
+      other.name == this.name &&
+      other.extendee == this.extendee &&
+      other.number == this.number &&
+      other.label == this.label &&
+      other.type == this.type &&
+      other.typeName == this.typeName &&
+      other.defaultValue == this.defaultValue &&
+      other.options == this.options &&
+      other.oneofIndex == this.oneofIndex &&
+      other.jsonName == this.jsonName &&
+      other.proto3Optional == this.proto3Optional &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + extendee.hashCode()
+    result = 31 * result + number.hashCode()
+    result = 31 * result + label.hashCode()
+    result = 31 * result + type.hashCode()
+    result = 31 * result + typeName.hashCode()
+    result = 31 * result + defaultValue.hashCode()
+    result = 31 * result + options.hashCode()
+    result = 31 * result + oneofIndex.hashCode()
+    result = 31 * result + jsonName.hashCode()
+    result = 31 * result + proto3Optional.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FieldDescriptorProto(" +
+      "name=$name, " +
+      "extendee=$extendee, " +
+      "number=$number, " +
+      "label=$label, " +
+      "type=$type, " +
+      "typeName=$typeName, " +
+      "defaultValue=$defaultValue, " +
+      "options=$options, " +
+      "oneofIndex=$oneofIndex, " +
+      "jsonName=$jsonName, " +
+      "proto3Optional=$proto3Optional" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FieldDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _extendeeRef: LazyReference<Bytes, String>? = null
+
+    public var extendee: String?
+      get() = _extendeeRef?.value()
+      set(newValue) {
+        _extendeeRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var number: Int? = null
+
+    public var label: Label? = null
+
+    public var type: Type? = null
+
+    private var _typeNameRef: LazyReference<Bytes, String>? = null
+
+    public var typeName: String?
+      get() = _typeNameRef?.value()
+      set(newValue) {
+        _typeNameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _defaultValueRef: LazyReference<Bytes, String>? = null
+
+    public var defaultValue: String?
+      get() = _defaultValueRef?.value()
+      set(newValue) {
+        _defaultValueRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var options: FieldOptions? = null
+
+    public var oneofIndex: Int? = null
+
+    private var _jsonNameRef: LazyReference<Bytes, String>? = null
+
+    public var jsonName: String?
+      get() = _jsonNameRef?.value()
+      set(newValue) {
+        _jsonNameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var proto3Optional: Boolean? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FieldDescriptorProto =
+      FieldDescriptorProto(
+        _nameRef,
+        _extendeeRef,
+        number,
+        label,
+        type,
+        _typeNameRef,
+        _defaultValueRef,
+        options,
+        oneofIndex,
+        _jsonNameRef,
+        proto3Optional,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FieldDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it._extendeeRef = msg._extendee
+          it.number = msg.number
+          it.label = msg.label
+          it.type = msg.type
+          it._typeNameRef = msg._typeName
+          it._defaultValueRef = msg._defaultValue
+          it.options = msg.options
+          it.oneofIndex = msg.oneofIndex
+          it._jsonNameRef = msg._jsonName
+          it.proto3Optional = msg.proto3Optional
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FieldDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FieldDescriptorProto {
+      var name: Bytes? = null
+      var extendee: Bytes? = null
+      var number: Int? = null
+      var label: Label? = null
+      var type: Type? = null
+      var typeName: Bytes? = null
+      var defaultValue: Bytes? = null
+      var options: FieldOptions? = null
+      var oneofIndex: Int? = null
+      var jsonName: Bytes? = null
+      var proto3Optional: Boolean? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FieldDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              extendee?.let { LazyReference(it, StringConverter) },
+              number,
+              label,
+              type,
+              typeName?.let { LazyReference(it, StringConverter) },
+              defaultValue?.let { LazyReference(it, StringConverter) },
+              options,
+              oneofIndex,
+              jsonName?.let { LazyReference(it, StringConverter) },
+              proto3Optional,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            extendee = StringConverter.readValidatedBytes(reader)
+          }
+
+          24u -> {
+            number = reader.readInt32()
+          }
+
+          32u -> {
+            label = reader.readEnum(Label)
+          }
+
+          40u -> {
+            type = reader.readEnum(Type)
+          }
+
+          50u -> {
+            typeName = StringConverter.readValidatedBytes(reader)
+          }
+
+          58u -> {
+            defaultValue = StringConverter.readValidatedBytes(reader)
+          }
+
+          66u -> {
+            options = reader.readMessage(FieldOptions)
+          }
+
+          72u -> {
+            oneofIndex = reader.readInt32()
+          }
+
+          82u -> {
+            jsonName = StringConverter.readValidatedBytes(reader)
+          }
+
+          136u -> {
+            proto3Optional = reader.readBool()
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FieldDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+
+  public sealed class Type(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    /**
+     * 0 is reserved for errors. Order is weird for historical reasons.
+     */
+    public object DOUBLE : Type(1, "DOUBLE")
+
+    public object FLOAT : Type(2, "FLOAT")
+
+    /**
+     * Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if negative values are likely.
+     */
+    public object INT64 : Type(3, "INT64")
+
+    public object UINT64 : Type(4, "UINT64")
+
+    /**
+     * Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if negative values are likely.
+     */
+    public object INT32 : Type(5, "INT32")
+
+    public object FIXED64 : Type(6, "FIXED64")
+
+    public object FIXED32 : Type(7, "FIXED32")
+
+    public object BOOL : Type(8, "BOOL")
+
+    public object STRING : Type(9, "STRING")
+
+    /**
+     * Tag-delimited aggregate. Group type is deprecated and not supported after google.protobuf. However, Proto3 implementations should still be able to parse the group wire format and treat group fields as unknown fields.  In Editions, the group wire format can be enabled via the `message_encoding` feature.
+     */
+    public object GROUP : Type(10, "GROUP")
+
+    public object MESSAGE : Type(11, "MESSAGE")
+
+    /**
+     * New in version 2.
+     */
+    public object BYTES : Type(12, "BYTES")
+
+    public object UINT32 : Type(13, "UINT32")
+
+    public object ENUM : Type(14, "ENUM")
+
+    public object SFIXED32 : Type(15, "SFIXED32")
+
+    public object SFIXED64 : Type(16, "SFIXED64")
+
+    public object SINT32 : Type(17, "SINT32")
+
+    public object SINT64 : Type(18, "SINT64")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : Type(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<Type> {
+      override fun deserialize(`value`: Int): Type =
+        when (value) {
+          1 -> DOUBLE
+          2 -> FLOAT
+          3 -> INT64
+          4 -> UINT64
+          5 -> INT32
+          6 -> FIXED64
+          7 -> FIXED32
+          8 -> BOOL
+          9 -> STRING
+          10 -> GROUP
+          11 -> MESSAGE
+          12 -> BYTES
+          13 -> UINT32
+          14 -> ENUM
+          15 -> SFIXED32
+          16 -> SFIXED64
+          17 -> SINT32
+          18 -> SINT64
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class Label(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    /**
+     * 0 is reserved for errors
+     */
+    public object OPTIONAL : Label(1, "OPTIONAL")
+
+    public object REPEATED : Label(3, "REPEATED")
+
+    /**
+     * The required label is only allowed in google.protobuf.  In proto3 and Editions it's explicitly prohibited.  In Editions, the `field_presence` feature can be used to get this behavior.
+     */
+    public object REQUIRED : Label(2, "REQUIRED")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : Label(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<Label> {
+      override fun deserialize(`value`: Int): Label =
+        when (value) {
+          1 -> OPTIONAL
+          3 -> REPEATED
+          2 -> REQUIRED
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+}
+
+/**
+ * Describes a oneof.
+ */
+@GeneratedMessage("google.protobuf.OneofDescriptorProto")
+public class OneofDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  @GeneratedProperty(2)
+  public val options: OneofOptions?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (options != null) {
+      result += sizeOf(18u) + sizeOf(options)
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    if (options != null) {
+      writer.writeTag(18u).write(options)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is OneofDescriptorProto &&
+      other.name == this.name &&
+      other.options == this.options &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + options.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "OneofDescriptorProto(" +
+      "name=$name, " +
+      "options=$options" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): OneofDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var options: OneofOptions? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): OneofDescriptorProto =
+      OneofDescriptorProto(
+        _nameRef,
+        options,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: OneofDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it.options = msg.options
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<OneofDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): OneofDescriptorProto {
+      var name: Bytes? = null
+      var options: OneofOptions? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return OneofDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              options,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            options = reader.readMessage(OneofOptions)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): OneofDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * Describes an enum type.
+ */
+@GeneratedMessage("google.protobuf.EnumDescriptorProto")
+public class EnumDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  @GeneratedProperty(2)
+  public val `value`: List<EnumValueDescriptorProto>,
+  @GeneratedProperty(3)
+  public val options: EnumOptions?,
+  /**
+   * Range of reserved numeric values. Reserved numeric values may not be used by enum values in the same enum declaration. Reserved ranges may not overlap.
+   */
+  @GeneratedProperty(4)
+  public val reservedRange: List<EnumReservedRange>,
+  /**
+   * Reserved enum value names, which may not be reused. A given name may only be reserved once.
+   */
+  @GeneratedProperty(5)
+  public val reservedName: List<String>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (`value`.isNotEmpty()) {
+      result += (sizeOf(18u) * `value`.size) + `value`.sumOf { sizeOf(it) }
+    }
+    if (options != null) {
+      result += sizeOf(26u) + sizeOf(options)
+    }
+    if (reservedRange.isNotEmpty()) {
+      result += (sizeOf(34u) * reservedRange.size) + reservedRange.sumOf { sizeOf(it) }
+    }
+    if (reservedName.isNotEmpty()) {
+      result +=
+        @Suppress("UNCHECKED_CAST")
+        (reservedName as LazyConvertingList<Bytes, Any>).let { list ->
+          (sizeOf(42u) * list.size) +
+            run {
+              var sum = 0
+              for (i in list.indices) sum += sizeOf(list.wireGet(i))
+              sum
+            }
+        }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    `value`.forEach { writer.writeTag(18u).write(it) }
+    if (options != null) {
+      writer.writeTag(26u).write(options)
+    }
+    reservedRange.forEach { writer.writeTag(34u).write(it) }
+    if (reservedName.isNotEmpty()) {
+      @Suppress("UNCHECKED_CAST")
+      (reservedName as LazyConvertingList<Bytes, Any>).wireForEach { writer.writeTag(42u).write(it) }
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is EnumDescriptorProto &&
+      other.name == this.name &&
+      other.`value` == this.`value` &&
+      other.options == this.options &&
+      other.reservedRange == this.reservedRange &&
+      other.reservedName == this.reservedName &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + `value`.hashCode()
+    result = 31 * result + options.hashCode()
+    result = 31 * result + reservedRange.hashCode()
+    result = 31 * result + reservedName.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "EnumDescriptorProto(" +
+      "name=$name, " +
+      "`value`=$`value`, " +
+      "options=$options, " +
+      "reservedRange=$reservedRange, " +
+      "reservedName=$reservedName" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): EnumDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var `value`: List<EnumValueDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var options: EnumOptions? = null
+
+    public var reservedRange: List<EnumReservedRange> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var reservedName: List<String> = emptyList()
+      set(newValue) {
+        field = if (newValue is LazyConvertingList<*, *>) newValue else LazyConvertingList.fromKotlin(newValue, StringConverter)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): EnumDescriptorProto =
+      EnumDescriptorProto(
+        _nameRef,
+        freezeList(`value`),
+        options,
+        freezeList(reservedRange),
+        reservedName,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: EnumDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it.`value` = msg.`value`
+          it.options = msg.options
+          it.reservedRange = msg.reservedRange
+          it.reservedName = msg.reservedName
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<EnumDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): EnumDescriptorProto {
+      var name: Bytes? = null
+      var `value`: ListBuilder<EnumValueDescriptorProto>? = null
+      var options: EnumOptions? = null
+      var reservedRange: ListBuilder<EnumReservedRange>? = null
+      var reservedName: ListBuilder<Any?>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return EnumDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              `value`?.build() ?: emptyList(),
+              options,
+              reservedRange?.build() ?: emptyList(),
+              reservedName?.build()?.let { LazyConvertingList<Bytes, String>(it, StringConverter) } ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            `value` =
+              (`value` ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(EnumValueDescriptorProto))
+                }
+              }
+          }
+
+          26u -> {
+            options = reader.readMessage(EnumOptions)
+          }
+
+          34u -> {
+            reservedRange =
+              (reservedRange ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(EnumReservedRange))
+                }
+              }
+          }
+
+          42u -> {
+            reservedName =
+              (reservedName ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(LazyReference(StringConverter.readValidatedBytes(reader), StringConverter))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): EnumDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * Range of reserved numeric values. Reserved values may not be used by entries in the same enum. Reserved ranges may not overlap.
+   *
+   *  Note that this is distinct from DescriptorProto.ReservedRange in that it is inclusive such that it can appropriately represent the entire int32 domain.
+   */
+  @GeneratedMessage("google.protobuf.EnumDescriptorProto.EnumReservedRange")
+  public class EnumReservedRange private constructor(
+    @GeneratedProperty(1)
+    public val start: Int?,
+    @GeneratedProperty(2)
+    public val end: Int?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (start != null) {
+        result += sizeOf(8u) + sizeOf(start)
+      }
+      if (end != null) {
+        result += sizeOf(16u) + sizeOf(end)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (start != null) {
+        writer.writeTag(8u).write(start)
+      }
+      if (end != null) {
+        writer.writeTag(16u).write(end)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is EnumReservedRange &&
+        other.start == this.start &&
+        other.end == this.end &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + start.hashCode()
+      result = 31 * result + end.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "EnumReservedRange(" +
+        "start=$start, " +
+        "end=$end" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): EnumReservedRange =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var start: Int? = null
+
+      public var end: Int? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): EnumReservedRange =
+        EnumReservedRange(
+          start,
+          end,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: EnumReservedRange): Builder =
+          Builder().also {
+            it.start = msg.start
+            it.end = msg.end
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<EnumReservedRange>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): EnumReservedRange {
+        var start: Int? = null
+        var end: Int? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return EnumReservedRange(
+                start,
+                end,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              start = reader.readInt32()
+            }
+
+            16u -> {
+              end = reader.readInt32()
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): EnumReservedRange =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+/**
+ * Describes a value within an enum.
+ */
+@GeneratedMessage("google.protobuf.EnumValueDescriptorProto")
+public class EnumValueDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  @GeneratedProperty(2)
+  public val number: Int?,
+  @GeneratedProperty(3)
+  public val options: EnumValueOptions?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (number != null) {
+      result += sizeOf(16u) + sizeOf(number)
+    }
+    if (options != null) {
+      result += sizeOf(26u) + sizeOf(options)
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    if (number != null) {
+      writer.writeTag(16u).write(number)
+    }
+    if (options != null) {
+      writer.writeTag(26u).write(options)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is EnumValueDescriptorProto &&
+      other.name == this.name &&
+      other.number == this.number &&
+      other.options == this.options &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + number.hashCode()
+    result = 31 * result + options.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "EnumValueDescriptorProto(" +
+      "name=$name, " +
+      "number=$number, " +
+      "options=$options" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): EnumValueDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var number: Int? = null
+
+    public var options: EnumValueOptions? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): EnumValueDescriptorProto =
+      EnumValueDescriptorProto(
+        _nameRef,
+        number,
+        options,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: EnumValueDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it.number = msg.number
+          it.options = msg.options
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<EnumValueDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): EnumValueDescriptorProto {
+      var name: Bytes? = null
+      var number: Int? = null
+      var options: EnumValueOptions? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return EnumValueDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              number,
+              options,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          16u -> {
+            number = reader.readInt32()
+          }
+
+          26u -> {
+            options = reader.readMessage(EnumValueOptions)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): EnumValueDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * Describes a service.
+ */
+@GeneratedMessage("google.protobuf.ServiceDescriptorProto")
+public class ServiceDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  @GeneratedProperty(2)
+  public val method: List<MethodDescriptorProto>,
+  @GeneratedProperty(3)
+  public val options: ServiceOptions?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (method.isNotEmpty()) {
+      result += (sizeOf(18u) * method.size) + method.sumOf { sizeOf(it) }
+    }
+    if (options != null) {
+      result += sizeOf(26u) + sizeOf(options)
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    method.forEach { writer.writeTag(18u).write(it) }
+    if (options != null) {
+      writer.writeTag(26u).write(options)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is ServiceDescriptorProto &&
+      other.name == this.name &&
+      other.method == this.method &&
+      other.options == this.options &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + method.hashCode()
+    result = 31 * result + options.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "ServiceDescriptorProto(" +
+      "name=$name, " +
+      "method=$method, " +
+      "options=$options" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): ServiceDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var method: List<MethodDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var options: ServiceOptions? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): ServiceDescriptorProto =
+      ServiceDescriptorProto(
+        _nameRef,
+        freezeList(method),
+        options,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: ServiceDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it.method = msg.method
+          it.options = msg.options
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<ServiceDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): ServiceDescriptorProto {
+      var name: Bytes? = null
+      var method: ListBuilder<MethodDescriptorProto>? = null
+      var options: ServiceOptions? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return ServiceDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              method?.build() ?: emptyList(),
+              options,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            method =
+              (method ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(MethodDescriptorProto))
+                }
+              }
+          }
+
+          26u -> {
+            options = reader.readMessage(ServiceOptions)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): ServiceDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * Describes a method of a service.
+ */
+@GeneratedMessage("google.protobuf.MethodDescriptorProto")
+public class MethodDescriptorProto private constructor(
+  private val _name: LazyReference<Bytes, String>?,
+  private val _inputType: LazyReference<Bytes, String>?,
+  private val _outputType: LazyReference<Bytes, String>?,
+  @GeneratedProperty(4)
+  public val options: MethodOptions?,
+  /**
+   * Identifies if client streams multiple client messages
+   */
+  @GeneratedProperty(5)
+  public val clientStreaming: Boolean?,
+  /**
+   * Identifies if server streams multiple server messages
+   */
+  @GeneratedProperty(6)
+  public val serverStreaming: Boolean?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_name != null) {
+      result += sizeOf(10u) + sizeOf(_name.wireValue())
+    }
+    if (_inputType != null) {
+      result += sizeOf(18u) + sizeOf(_inputType.wireValue())
+    }
+    if (_outputType != null) {
+      result += sizeOf(26u) + sizeOf(_outputType.wireValue())
+    }
+    if (options != null) {
+      result += sizeOf(34u) + sizeOf(options)
+    }
+    if (clientStreaming != null) {
+      result += sizeOf(40u) + 1
+    }
+    if (serverStreaming != null) {
+      result += sizeOf(48u) + 1
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  /**
+   * Input and output type names.  These are resolved in the same way as FieldDescriptorProto.type_name, but must refer to a message type.
+   */
+  @GeneratedProperty(2)
+  public val inputType: String?
+    get() = _inputType?.value()
+
+  @GeneratedProperty(3)
+  public val outputType: String?
+    get() = _outputType?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_name != null) {
+      writer.writeTag(10u).write(_name.wireValue())
+    }
+    if (_inputType != null) {
+      writer.writeTag(18u).write(_inputType.wireValue())
+    }
+    if (_outputType != null) {
+      writer.writeTag(26u).write(_outputType.wireValue())
+    }
+    if (options != null) {
+      writer.writeTag(34u).write(options)
+    }
+    if (clientStreaming != null) {
+      writer.writeTag(40u).write(clientStreaming)
+    }
+    if (serverStreaming != null) {
+      writer.writeTag(48u).write(serverStreaming)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is MethodDescriptorProto &&
+      other.name == this.name &&
+      other.inputType == this.inputType &&
+      other.outputType == this.outputType &&
+      other.options == this.options &&
+      other.clientStreaming == this.clientStreaming &&
+      other.serverStreaming == this.serverStreaming &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + inputType.hashCode()
+    result = 31 * result + outputType.hashCode()
+    result = 31 * result + options.hashCode()
+    result = 31 * result + clientStreaming.hashCode()
+    result = 31 * result + serverStreaming.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "MethodDescriptorProto(" +
+      "name=$name, " +
+      "inputType=$inputType, " +
+      "outputType=$outputType, " +
+      "options=$options, " +
+      "clientStreaming=$clientStreaming, " +
+      "serverStreaming=$serverStreaming" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): MethodDescriptorProto =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _nameRef: LazyReference<Bytes, String>? = null
+
+    public var name: String?
+      get() = _nameRef?.value()
+      set(newValue) {
+        _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _inputTypeRef: LazyReference<Bytes, String>? = null
+
+    public var inputType: String?
+      get() = _inputTypeRef?.value()
+      set(newValue) {
+        _inputTypeRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _outputTypeRef: LazyReference<Bytes, String>? = null
+
+    public var outputType: String?
+      get() = _outputTypeRef?.value()
+      set(newValue) {
+        _outputTypeRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var options: MethodOptions? = null
+
+    public var clientStreaming: Boolean? = null
+
+    public var serverStreaming: Boolean? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): MethodDescriptorProto =
+      MethodDescriptorProto(
+        _nameRef,
+        _inputTypeRef,
+        _outputTypeRef,
+        options,
+        clientStreaming,
+        serverStreaming,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: MethodDescriptorProto): Builder =
+        Builder().also {
+          it._nameRef = msg._name
+          it._inputTypeRef = msg._inputType
+          it._outputTypeRef = msg._outputType
+          it.options = msg.options
+          it.clientStreaming = msg.clientStreaming
+          it.serverStreaming = msg.serverStreaming
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<MethodDescriptorProto>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): MethodDescriptorProto {
+      var name: Bytes? = null
+      var inputType: Bytes? = null
+      var outputType: Bytes? = null
+      var options: MethodOptions? = null
+      var clientStreaming: Boolean? = null
+      var serverStreaming: Boolean? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return MethodDescriptorProto(
+              name?.let { LazyReference(it, StringConverter) },
+              inputType?.let { LazyReference(it, StringConverter) },
+              outputType?.let { LazyReference(it, StringConverter) },
+              options,
+              clientStreaming,
+              serverStreaming,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            name = StringConverter.readValidatedBytes(reader)
+          }
+
+          18u -> {
+            inputType = StringConverter.readValidatedBytes(reader)
+          }
+
+          26u -> {
+            outputType = StringConverter.readValidatedBytes(reader)
+          }
+
+          34u -> {
+            options = reader.readMessage(MethodOptions)
+          }
+
+          40u -> {
+            clientStreaming = reader.readBool()
+          }
+
+          48u -> {
+            serverStreaming = reader.readBool()
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): MethodDescriptorProto =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("google.protobuf.FileOptions")
+public class FileOptions private constructor(
+  private val _javaPackage: LazyReference<Bytes, String>?,
+  private val _javaOuterClassname: LazyReference<Bytes, String>?,
+  @GeneratedProperty(9)
+  public val optimizeFor: OptimizeMode?,
+  /**
+   * If enabled, then the Java code generator will generate a separate .java file for each top-level message, enum, and service defined in the .proto file.  Thus, these types will *not* be nested inside the wrapper class named by java_outer_classname.  However, the wrapper class will still be generated to contain the file's getDescriptor() method as well as any top-level extensions defined in the file.
+   */
+  @GeneratedProperty(10)
+  public val javaMultipleFiles: Boolean?,
+  private val _goPackage: LazyReference<Bytes, String>?,
+  /**
+   * Should generic services be generated in each language?  "Generic" services are not specific to any particular RPC system.  They are generated by the main code generators in each language (without additional plugins). Generic services were the only kind of service generation supported by early versions of google.protobuf.
+   *
+   *  Generic services are now considered deprecated in favor of using plugins that generate code specific to your particular RPC system.  Therefore, these default to false.  Old code which depends on generic services should explicitly set them to true.
+   */
+  @GeneratedProperty(16)
+  public val ccGenericServices: Boolean?,
+  @GeneratedProperty(17)
+  public val javaGenericServices: Boolean?,
+  @GeneratedProperty(18)
+  public val pyGenericServices: Boolean?,
+  /**
+   * This option does nothing.
+   */
+  @GeneratedProperty(20)
+  @Deprecated("deprecated in proto")
+  public val javaGenerateEqualsAndHash: Boolean?,
+  /**
+   * Is this file deprecated? Depending on the target platform, this can emit Deprecated annotations for everything in the file, or it will be completely ignored; in the very least, this is a formalization for deprecating files.
+   */
+  @GeneratedProperty(23)
+  public val deprecated: Boolean?,
+  /**
+   * A proto2 file can set this to true to opt in to UTF-8 checking for Java, which will throw an exception if invalid UTF-8 is parsed from the wire or assigned to a string field.
+   *
+   *  TODO: clarify exactly what kinds of field types this option applies to, and update these docs accordingly.
+   *
+   *  Proto3 files already perform these checks. Setting the option explicitly to false has no effect: it cannot be used to opt proto3 files out of UTF-8 checks.
+   */
+  @GeneratedProperty(27)
+  public val javaStringCheckUtf8: Boolean?,
+  /**
+   * Enables the use of arenas for the proto messages in this file. This applies only to generated classes for C++.
+   */
+  @GeneratedProperty(31)
+  public val ccEnableArenas: Boolean?,
+  private val _objcClassPrefix: LazyReference<Bytes, String>?,
+  private val _csharpNamespace: LazyReference<Bytes, String>?,
+  private val _swiftPrefix: LazyReference<Bytes, String>?,
+  private val _phpClassPrefix: LazyReference<Bytes, String>?,
+  private val _phpNamespace: LazyReference<Bytes, String>?,
+  private val _phpMetadataNamespace: LazyReference<Bytes, String>?,
+  private val _rubyPackage: LazyReference<Bytes, String>?,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(50)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See the documentation for the "Options" section above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_javaPackage != null) {
+      result += sizeOf(10u) + sizeOf(_javaPackage.wireValue())
+    }
+    if (_javaOuterClassname != null) {
+      result += sizeOf(66u) + sizeOf(_javaOuterClassname.wireValue())
+    }
+    if (optimizeFor != null) {
+      result += sizeOf(72u) + sizeOf(optimizeFor)
+    }
+    if (javaMultipleFiles != null) {
+      result += sizeOf(80u) + 1
+    }
+    if (_goPackage != null) {
+      result += sizeOf(90u) + sizeOf(_goPackage.wireValue())
+    }
+    if (ccGenericServices != null) {
+      result += sizeOf(128u) + 1
+    }
+    if (javaGenericServices != null) {
+      result += sizeOf(136u) + 1
+    }
+    if (pyGenericServices != null) {
+      result += sizeOf(144u) + 1
+    }
+    if (javaGenerateEqualsAndHash != null) {
+      result += sizeOf(160u) + 1
+    }
+    if (deprecated != null) {
+      result += sizeOf(184u) + 1
+    }
+    if (javaStringCheckUtf8 != null) {
+      result += sizeOf(216u) + 1
+    }
+    if (ccEnableArenas != null) {
+      result += sizeOf(248u) + 1
+    }
+    if (_objcClassPrefix != null) {
+      result += sizeOf(290u) + sizeOf(_objcClassPrefix.wireValue())
+    }
+    if (_csharpNamespace != null) {
+      result += sizeOf(298u) + sizeOf(_csharpNamespace.wireValue())
+    }
+    if (_swiftPrefix != null) {
+      result += sizeOf(314u) + sizeOf(_swiftPrefix.wireValue())
+    }
+    if (_phpClassPrefix != null) {
+      result += sizeOf(322u) + sizeOf(_phpClassPrefix.wireValue())
+    }
+    if (_phpNamespace != null) {
+      result += sizeOf(330u) + sizeOf(_phpNamespace.wireValue())
+    }
+    if (_phpMetadataNamespace != null) {
+      result += sizeOf(354u) + sizeOf(_phpMetadataNamespace.wireValue())
+    }
+    if (_rubyPackage != null) {
+      result += sizeOf(362u) + sizeOf(_rubyPackage.wireValue())
+    }
+    if (features != null) {
+      result += sizeOf(402u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Sets the Java package where classes generated from this .proto will be placed.  By default, the proto package is used, but this is often inappropriate because proto packages do not normally start with backwards domain names.
+   */
+  @GeneratedProperty(1)
+  public val javaPackage: String?
+    get() = _javaPackage?.value()
+
+  /**
+   * Controls the name of the wrapper Java class generated for the .proto file. That class will always contain the .proto file's getDescriptor() method as well as any top-level extensions defined in the .proto file. If java_multiple_files is disabled, then all the other classes from the .proto file will be nested inside the single wrapper outer class.
+   */
+  @GeneratedProperty(8)
+  public val javaOuterClassname: String?
+    get() = _javaOuterClassname?.value()
+
+  /**
+   * Sets the Go package where structs generated from this .proto will be placed. If omitted, the Go package will be derived from the following:   - The basename of the package import path, if provided.   - Otherwise, the package statement in the .proto file, if present.   - Otherwise, the basename of the .proto file, without extension.
+   */
+  @GeneratedProperty(11)
+  public val goPackage: String?
+    get() = _goPackage?.value()
+
+  /**
+   * Sets the objective c class prefix which is prepended to all objective c generated classes from this .proto. There is no default.
+   */
+  @GeneratedProperty(36)
+  public val objcClassPrefix: String?
+    get() = _objcClassPrefix?.value()
+
+  /**
+   * Namespace for generated classes; defaults to the package.
+   */
+  @GeneratedProperty(37)
+  public val csharpNamespace: String?
+    get() = _csharpNamespace?.value()
+
+  /**
+   * By default Swift generators will take the proto package and CamelCase it replacing '.' with underscore and use that to prefix the types/symbols defined. When this options is provided, they will use this value instead to prefix the types/symbols defined.
+   */
+  @GeneratedProperty(39)
+  public val swiftPrefix: String?
+    get() = _swiftPrefix?.value()
+
+  /**
+   * Sets the php class prefix which is prepended to all php generated classes from this .proto. Default is empty.
+   */
+  @GeneratedProperty(40)
+  public val phpClassPrefix: String?
+    get() = _phpClassPrefix?.value()
+
+  /**
+   * Use this option to change the namespace of php generated classes. Default is empty. When this option is empty, the package name will be used for determining the namespace.
+   */
+  @GeneratedProperty(41)
+  public val phpNamespace: String?
+    get() = _phpNamespace?.value()
+
+  /**
+   * Use this option to change the namespace of php generated metadata classes. Default is empty. When this option is empty, the proto file name will be used for determining the namespace.
+   */
+  @GeneratedProperty(44)
+  public val phpMetadataNamespace: String?
+    get() = _phpMetadataNamespace?.value()
+
+  /**
+   * Use this option to change the package of ruby generated classes. Default is empty. When this option is not set, the package name will be used for determining the ruby package.
+   */
+  @GeneratedProperty(45)
+  public val rubyPackage: String?
+    get() = _rubyPackage?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_javaPackage != null) {
+      writer.writeTag(10u).write(_javaPackage.wireValue())
+    }
+    if (_javaOuterClassname != null) {
+      writer.writeTag(66u).write(_javaOuterClassname.wireValue())
+    }
+    if (optimizeFor != null) {
+      writer.writeTag(72u).write(optimizeFor)
+    }
+    if (javaMultipleFiles != null) {
+      writer.writeTag(80u).write(javaMultipleFiles)
+    }
+    if (_goPackage != null) {
+      writer.writeTag(90u).write(_goPackage.wireValue())
+    }
+    if (ccGenericServices != null) {
+      writer.writeTag(128u).write(ccGenericServices)
+    }
+    if (javaGenericServices != null) {
+      writer.writeTag(136u).write(javaGenericServices)
+    }
+    if (pyGenericServices != null) {
+      writer.writeTag(144u).write(pyGenericServices)
+    }
+    if (javaGenerateEqualsAndHash != null) {
+      writer.writeTag(160u).write(javaGenerateEqualsAndHash)
+    }
+    if (deprecated != null) {
+      writer.writeTag(184u).write(deprecated)
+    }
+    if (javaStringCheckUtf8 != null) {
+      writer.writeTag(216u).write(javaStringCheckUtf8)
+    }
+    if (ccEnableArenas != null) {
+      writer.writeTag(248u).write(ccEnableArenas)
+    }
+    if (_objcClassPrefix != null) {
+      writer.writeTag(290u).write(_objcClassPrefix.wireValue())
+    }
+    if (_csharpNamespace != null) {
+      writer.writeTag(298u).write(_csharpNamespace.wireValue())
+    }
+    if (_swiftPrefix != null) {
+      writer.writeTag(314u).write(_swiftPrefix.wireValue())
+    }
+    if (_phpClassPrefix != null) {
+      writer.writeTag(322u).write(_phpClassPrefix.wireValue())
+    }
+    if (_phpNamespace != null) {
+      writer.writeTag(330u).write(_phpNamespace.wireValue())
+    }
+    if (_phpMetadataNamespace != null) {
+      writer.writeTag(354u).write(_phpMetadataNamespace.wireValue())
+    }
+    if (_rubyPackage != null) {
+      writer.writeTag(362u).write(_rubyPackage.wireValue())
+    }
+    if (features != null) {
+      writer.writeTag(402u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FileOptions &&
+      other.javaPackage == this.javaPackage &&
+      other.javaOuterClassname == this.javaOuterClassname &&
+      other.optimizeFor == this.optimizeFor &&
+      other.javaMultipleFiles == this.javaMultipleFiles &&
+      other.goPackage == this.goPackage &&
+      other.ccGenericServices == this.ccGenericServices &&
+      other.javaGenericServices == this.javaGenericServices &&
+      other.pyGenericServices == this.pyGenericServices &&
+      other.javaGenerateEqualsAndHash == this.javaGenerateEqualsAndHash &&
+      other.deprecated == this.deprecated &&
+      other.javaStringCheckUtf8 == this.javaStringCheckUtf8 &&
+      other.ccEnableArenas == this.ccEnableArenas &&
+      other.objcClassPrefix == this.objcClassPrefix &&
+      other.csharpNamespace == this.csharpNamespace &&
+      other.swiftPrefix == this.swiftPrefix &&
+      other.phpClassPrefix == this.phpClassPrefix &&
+      other.phpNamespace == this.phpNamespace &&
+      other.phpMetadataNamespace == this.phpMetadataNamespace &&
+      other.rubyPackage == this.rubyPackage &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + javaPackage.hashCode()
+    result = 31 * result + javaOuterClassname.hashCode()
+    result = 31 * result + optimizeFor.hashCode()
+    result = 31 * result + javaMultipleFiles.hashCode()
+    result = 31 * result + goPackage.hashCode()
+    result = 31 * result + ccGenericServices.hashCode()
+    result = 31 * result + javaGenericServices.hashCode()
+    result = 31 * result + pyGenericServices.hashCode()
+    result = 31 * result + javaGenerateEqualsAndHash.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + javaStringCheckUtf8.hashCode()
+    result = 31 * result + ccEnableArenas.hashCode()
+    result = 31 * result + objcClassPrefix.hashCode()
+    result = 31 * result + csharpNamespace.hashCode()
+    result = 31 * result + swiftPrefix.hashCode()
+    result = 31 * result + phpClassPrefix.hashCode()
+    result = 31 * result + phpNamespace.hashCode()
+    result = 31 * result + phpMetadataNamespace.hashCode()
+    result = 31 * result + rubyPackage.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FileOptions(" +
+      "javaPackage=$javaPackage, " +
+      "javaOuterClassname=$javaOuterClassname, " +
+      "optimizeFor=$optimizeFor, " +
+      "javaMultipleFiles=$javaMultipleFiles, " +
+      "goPackage=$goPackage, " +
+      "ccGenericServices=$ccGenericServices, " +
+      "javaGenericServices=$javaGenericServices, " +
+      "pyGenericServices=$pyGenericServices, " +
+      "javaGenerateEqualsAndHash=$javaGenerateEqualsAndHash, " +
+      "deprecated=$deprecated, " +
+      "javaStringCheckUtf8=$javaStringCheckUtf8, " +
+      "ccEnableArenas=$ccEnableArenas, " +
+      "objcClassPrefix=$objcClassPrefix, " +
+      "csharpNamespace=$csharpNamespace, " +
+      "swiftPrefix=$swiftPrefix, " +
+      "phpClassPrefix=$phpClassPrefix, " +
+      "phpNamespace=$phpNamespace, " +
+      "phpMetadataNamespace=$phpMetadataNamespace, " +
+      "rubyPackage=$rubyPackage, " +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FileOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _javaPackageRef: LazyReference<Bytes, String>? = null
+
+    public var javaPackage: String?
+      get() = _javaPackageRef?.value()
+      set(newValue) {
+        _javaPackageRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _javaOuterClassnameRef: LazyReference<Bytes, String>? = null
+
+    public var javaOuterClassname: String?
+      get() = _javaOuterClassnameRef?.value()
+      set(newValue) {
+        _javaOuterClassnameRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var optimizeFor: OptimizeMode? = null
+
+    public var javaMultipleFiles: Boolean? = null
+
+    private var _goPackageRef: LazyReference<Bytes, String>? = null
+
+    public var goPackage: String?
+      get() = _goPackageRef?.value()
+      set(newValue) {
+        _goPackageRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var ccGenericServices: Boolean? = null
+
+    public var javaGenericServices: Boolean? = null
+
+    public var pyGenericServices: Boolean? = null
+
+    @Deprecated("deprecated in proto")
+    public var javaGenerateEqualsAndHash: Boolean? = null
+
+    public var deprecated: Boolean? = null
+
+    public var javaStringCheckUtf8: Boolean? = null
+
+    public var ccEnableArenas: Boolean? = null
+
+    private var _objcClassPrefixRef: LazyReference<Bytes, String>? = null
+
+    public var objcClassPrefix: String?
+      get() = _objcClassPrefixRef?.value()
+      set(newValue) {
+        _objcClassPrefixRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _csharpNamespaceRef: LazyReference<Bytes, String>? = null
+
+    public var csharpNamespace: String?
+      get() = _csharpNamespaceRef?.value()
+      set(newValue) {
+        _csharpNamespaceRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _swiftPrefixRef: LazyReference<Bytes, String>? = null
+
+    public var swiftPrefix: String?
+      get() = _swiftPrefixRef?.value()
+      set(newValue) {
+        _swiftPrefixRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _phpClassPrefixRef: LazyReference<Bytes, String>? = null
+
+    public var phpClassPrefix: String?
+      get() = _phpClassPrefixRef?.value()
+      set(newValue) {
+        _phpClassPrefixRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _phpNamespaceRef: LazyReference<Bytes, String>? = null
+
+    public var phpNamespace: String?
+      get() = _phpNamespaceRef?.value()
+      set(newValue) {
+        _phpNamespaceRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _phpMetadataNamespaceRef: LazyReference<Bytes, String>? = null
+
+    public var phpMetadataNamespace: String?
+      get() = _phpMetadataNamespaceRef?.value()
+      set(newValue) {
+        _phpMetadataNamespaceRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    private var _rubyPackageRef: LazyReference<Bytes, String>? = null
+
+    public var rubyPackage: String?
+      get() = _rubyPackageRef?.value()
+      set(newValue) {
+        _rubyPackageRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FileOptions =
+      FileOptions(
+        _javaPackageRef,
+        _javaOuterClassnameRef,
+        optimizeFor,
+        javaMultipleFiles,
+        _goPackageRef,
+        ccGenericServices,
+        javaGenericServices,
+        pyGenericServices,
+        javaGenerateEqualsAndHash,
+        deprecated,
+        javaStringCheckUtf8,
+        ccEnableArenas,
+        _objcClassPrefixRef,
+        _csharpNamespaceRef,
+        _swiftPrefixRef,
+        _phpClassPrefixRef,
+        _phpNamespaceRef,
+        _phpMetadataNamespaceRef,
+        _rubyPackageRef,
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FileOptions): Builder =
+        Builder().also {
+          it._javaPackageRef = msg._javaPackage
+          it._javaOuterClassnameRef = msg._javaOuterClassname
+          it.optimizeFor = msg.optimizeFor
+          it.javaMultipleFiles = msg.javaMultipleFiles
+          it._goPackageRef = msg._goPackage
+          it.ccGenericServices = msg.ccGenericServices
+          it.javaGenericServices = msg.javaGenericServices
+          it.pyGenericServices = msg.pyGenericServices
+          it.javaGenerateEqualsAndHash = msg.javaGenerateEqualsAndHash
+          it.deprecated = msg.deprecated
+          it.javaStringCheckUtf8 = msg.javaStringCheckUtf8
+          it.ccEnableArenas = msg.ccEnableArenas
+          it._objcClassPrefixRef = msg._objcClassPrefix
+          it._csharpNamespaceRef = msg._csharpNamespace
+          it._swiftPrefixRef = msg._swiftPrefix
+          it._phpClassPrefixRef = msg._phpClassPrefix
+          it._phpNamespaceRef = msg._phpNamespace
+          it._phpMetadataNamespaceRef = msg._phpMetadataNamespace
+          it._rubyPackageRef = msg._rubyPackage
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FileOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FileOptions {
+      var javaPackage: Bytes? = null
+      var javaOuterClassname: Bytes? = null
+      var optimizeFor: OptimizeMode? = null
+      var javaMultipleFiles: Boolean? = null
+      var goPackage: Bytes? = null
+      var ccGenericServices: Boolean? = null
+      var javaGenericServices: Boolean? = null
+      var pyGenericServices: Boolean? = null
+      var javaGenerateEqualsAndHash: Boolean? = null
+      var deprecated: Boolean? = null
+      var javaStringCheckUtf8: Boolean? = null
+      var ccEnableArenas: Boolean? = null
+      var objcClassPrefix: Bytes? = null
+      var csharpNamespace: Bytes? = null
+      var swiftPrefix: Bytes? = null
+      var phpClassPrefix: Bytes? = null
+      var phpNamespace: Bytes? = null
+      var phpMetadataNamespace: Bytes? = null
+      var rubyPackage: Bytes? = null
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FileOptions(
+              javaPackage?.let { LazyReference(it, StringConverter) },
+              javaOuterClassname?.let { LazyReference(it, StringConverter) },
+              optimizeFor,
+              javaMultipleFiles,
+              goPackage?.let { LazyReference(it, StringConverter) },
+              ccGenericServices,
+              javaGenericServices,
+              pyGenericServices,
+              javaGenerateEqualsAndHash,
+              deprecated,
+              javaStringCheckUtf8,
+              ccEnableArenas,
+              objcClassPrefix?.let { LazyReference(it, StringConverter) },
+              csharpNamespace?.let { LazyReference(it, StringConverter) },
+              swiftPrefix?.let { LazyReference(it, StringConverter) },
+              phpClassPrefix?.let { LazyReference(it, StringConverter) },
+              phpNamespace?.let { LazyReference(it, StringConverter) },
+              phpMetadataNamespace?.let { LazyReference(it, StringConverter) },
+              rubyPackage?.let { LazyReference(it, StringConverter) },
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            javaPackage = StringConverter.readValidatedBytes(reader)
+          }
+
+          66u -> {
+            javaOuterClassname = StringConverter.readValidatedBytes(reader)
+          }
+
+          72u -> {
+            optimizeFor = reader.readEnum(OptimizeMode)
+          }
+
+          80u -> {
+            javaMultipleFiles = reader.readBool()
+          }
+
+          90u -> {
+            goPackage = StringConverter.readValidatedBytes(reader)
+          }
+
+          128u -> {
+            ccGenericServices = reader.readBool()
+          }
+
+          136u -> {
+            javaGenericServices = reader.readBool()
+          }
+
+          144u -> {
+            pyGenericServices = reader.readBool()
+          }
+
+          160u -> {
+            javaGenerateEqualsAndHash = reader.readBool()
+          }
+
+          184u -> {
+            deprecated = reader.readBool()
+          }
+
+          216u -> {
+            javaStringCheckUtf8 = reader.readBool()
+          }
+
+          248u -> {
+            ccEnableArenas = reader.readBool()
+          }
+
+          290u -> {
+            objcClassPrefix = StringConverter.readValidatedBytes(reader)
+          }
+
+          298u -> {
+            csharpNamespace = StringConverter.readValidatedBytes(reader)
+          }
+
+          314u -> {
+            swiftPrefix = StringConverter.readValidatedBytes(reader)
+          }
+
+          322u -> {
+            phpClassPrefix = StringConverter.readValidatedBytes(reader)
+          }
+
+          330u -> {
+            phpNamespace = StringConverter.readValidatedBytes(reader)
+          }
+
+          354u -> {
+            phpMetadataNamespace = StringConverter.readValidatedBytes(reader)
+          }
+
+          362u -> {
+            rubyPackage = StringConverter.readValidatedBytes(reader)
+          }
+
+          402u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FileOptions =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * Generated classes can be optimized for speed or code size.
+   */
+  public sealed class OptimizeMode(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object SPEED : OptimizeMode(1, "SPEED")
+
+    /**
+     * etc.
+     */
+    public object CODE_SIZE : OptimizeMode(2, "CODE_SIZE")
+
+    public object LITE_RUNTIME : OptimizeMode(3, "LITE_RUNTIME")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : OptimizeMode(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<OptimizeMode> {
+      override fun deserialize(`value`: Int): OptimizeMode =
+        when (value) {
+          1 -> SPEED
+          2 -> CODE_SIZE
+          3 -> LITE_RUNTIME
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+}
+
+@GeneratedMessage("google.protobuf.MessageOptions")
+public class MessageOptions private constructor(
+  /**
+   * Set true to use the old proto1 MessageSet wire format for extensions. This is provided for backwards-compatibility with the MessageSet wire format.  You should not use this for any other reason:  It's less efficient, has fewer features, and is more complicated.
+   *
+   *  The message must be defined exactly as follows:   message Foo {     option message_set_wire_format = true;     extensions 4 to max;   } Note that the message cannot have any defined fields; MessageSets only have extensions.
+   *
+   *  All extensions of your type must be singular messages; e.g. they cannot be int32s, enums, or repeated messages.
+   *
+   *  Because this is an option, the above two restrictions are not enforced by the protocol compiler.
+   */
+  @GeneratedProperty(1)
+  public val messageSetWireFormat: Boolean?,
+  /**
+   * Disables the generation of the standard "descriptor()" accessor, which can conflict with a field of the same name.  This is meant to make migration from proto1 easier; new code should avoid fields named "descriptor".
+   */
+  @GeneratedProperty(2)
+  public val noStandardDescriptorAccessor: Boolean?,
+  /**
+   * Is this message deprecated? Depending on the target platform, this can emit Deprecated annotations for the message, or it will be completely ignored; in the very least, this is a formalization for deprecating messages.
+   */
+  @GeneratedProperty(3)
+  public val deprecated: Boolean?,
+  /**
+   * Whether the message is an automatically generated map entry type for the maps field.
+   *
+   *  For maps fields:     map<KeyType, ValueType> map_field = 1; The parsed descriptor looks like:     message MapFieldEntry {         option map_entry = true;         optional KeyType key = 1;         optional ValueType value = 2;     }     repeated MapFieldEntry map_field = 1;
+   *
+   *  Implementations may choose not to generate the map_entry=true message, but use a native map in the target language to hold the keys and values. The reflection APIs in such implementations still need to work as if the field is a repeated message field.
+   *
+   *  NOTE: Do not set the option in .proto files. Always use the maps syntax instead. The option should only be implicitly set by the proto compiler parser.
+   */
+  @GeneratedProperty(7)
+  public val mapEntry: Boolean?,
+  /**
+   * Enable the legacy handling of JSON field name conflicts.  This lowercases and strips underscored from the fields before comparison in proto3 only. The new behavior takes `json_name` into account and applies to proto2 as well.
+   *
+   *  This should only be used as a temporary measure against broken builds due to the change in behavior for JSON field name conflicts.
+   *
+   *  TODO This is legacy behavior we plan to remove once downstream teams have had time to migrate.
+   */
+  @GeneratedProperty(11)
+  @Deprecated("deprecated in proto")
+  public val deprecatedLegacyJsonFieldConflicts: Boolean?,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(12)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (messageSetWireFormat != null) {
+      result += sizeOf(8u) + 1
+    }
+    if (noStandardDescriptorAccessor != null) {
+      result += sizeOf(16u) + 1
+    }
+    if (deprecated != null) {
+      result += sizeOf(24u) + 1
+    }
+    if (mapEntry != null) {
+      result += sizeOf(56u) + 1
+    }
+    if (deprecatedLegacyJsonFieldConflicts != null) {
+      result += sizeOf(88u) + 1
+    }
+    if (features != null) {
+      result += sizeOf(98u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (messageSetWireFormat != null) {
+      writer.writeTag(8u).write(messageSetWireFormat)
+    }
+    if (noStandardDescriptorAccessor != null) {
+      writer.writeTag(16u).write(noStandardDescriptorAccessor)
+    }
+    if (deprecated != null) {
+      writer.writeTag(24u).write(deprecated)
+    }
+    if (mapEntry != null) {
+      writer.writeTag(56u).write(mapEntry)
+    }
+    if (deprecatedLegacyJsonFieldConflicts != null) {
+      writer.writeTag(88u).write(deprecatedLegacyJsonFieldConflicts)
+    }
+    if (features != null) {
+      writer.writeTag(98u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is MessageOptions &&
+      other.messageSetWireFormat == this.messageSetWireFormat &&
+      other.noStandardDescriptorAccessor == this.noStandardDescriptorAccessor &&
+      other.deprecated == this.deprecated &&
+      other.mapEntry == this.mapEntry &&
+      other.deprecatedLegacyJsonFieldConflicts == this.deprecatedLegacyJsonFieldConflicts &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + messageSetWireFormat.hashCode()
+    result = 31 * result + noStandardDescriptorAccessor.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + mapEntry.hashCode()
+    result = 31 * result + deprecatedLegacyJsonFieldConflicts.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "MessageOptions(" +
+      "messageSetWireFormat=$messageSetWireFormat, " +
+      "noStandardDescriptorAccessor=$noStandardDescriptorAccessor, " +
+      "deprecated=$deprecated, " +
+      "mapEntry=$mapEntry, " +
+      "deprecatedLegacyJsonFieldConflicts=$deprecatedLegacyJsonFieldConflicts, " +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): MessageOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var messageSetWireFormat: Boolean? = null
+
+    public var noStandardDescriptorAccessor: Boolean? = null
+
+    public var deprecated: Boolean? = null
+
+    public var mapEntry: Boolean? = null
+
+    @Deprecated("deprecated in proto")
+    public var deprecatedLegacyJsonFieldConflicts: Boolean? = null
+
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): MessageOptions =
+      MessageOptions(
+        messageSetWireFormat,
+        noStandardDescriptorAccessor,
+        deprecated,
+        mapEntry,
+        deprecatedLegacyJsonFieldConflicts,
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: MessageOptions): Builder =
+        Builder().also {
+          it.messageSetWireFormat = msg.messageSetWireFormat
+          it.noStandardDescriptorAccessor = msg.noStandardDescriptorAccessor
+          it.deprecated = msg.deprecated
+          it.mapEntry = msg.mapEntry
+          it.deprecatedLegacyJsonFieldConflicts = msg.deprecatedLegacyJsonFieldConflicts
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<MessageOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): MessageOptions {
+      var messageSetWireFormat: Boolean? = null
+      var noStandardDescriptorAccessor: Boolean? = null
+      var deprecated: Boolean? = null
+      var mapEntry: Boolean? = null
+      var deprecatedLegacyJsonFieldConflicts: Boolean? = null
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return MessageOptions(
+              messageSetWireFormat,
+              noStandardDescriptorAccessor,
+              deprecated,
+              mapEntry,
+              deprecatedLegacyJsonFieldConflicts,
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            messageSetWireFormat = reader.readBool()
+          }
+
+          16u -> {
+            noStandardDescriptorAccessor = reader.readBool()
+          }
+
+          24u -> {
+            deprecated = reader.readBool()
+          }
+
+          56u -> {
+            mapEntry = reader.readBool()
+          }
+
+          88u -> {
+            deprecatedLegacyJsonFieldConflicts = reader.readBool()
+          }
+
+          98u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): MessageOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("google.protobuf.FieldOptions")
+public class FieldOptions private constructor(
+  /**
+   * NOTE: ctype is deprecated. Use `features.(pb.cpp).string_type` instead. The ctype option instructs the C++ code generator to use a different representation of the field than it normally would.  See the specific options below.  This option is only implemented to support use of [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of type "bytes" in the open source release. TODO: make ctype actually deprecated.
+   */
+  @GeneratedProperty(1)
+  public val ctype: CType?,
+  /**
+   * The packed option can be enabled for repeated primitive fields to enable a more efficient representation on the wire. Rather than repeatedly writing the tag and type for each element, the entire array is encoded as a single length-delimited blob. In proto3, only explicit setting it to false will avoid using packed encoding.  This option is prohibited in Editions, but the `repeated_field_encoding` feature can be used to control the behavior.
+   */
+  @GeneratedProperty(2)
+  public val packed: Boolean?,
+  /**
+   * Is this field deprecated? Depending on the target platform, this can emit Deprecated annotations for accessors, or it will be completely ignored; in the very least, this is a formalization for deprecating fields.
+   */
+  @GeneratedProperty(3)
+  public val deprecated: Boolean?,
+  /**
+   * Should this field be parsed lazily?  Lazy applies only to message-type fields.  It means that when the outer message is initially parsed, the inner message's contents will not be parsed but instead stored in encoded form.  The inner message will actually be parsed when it is first accessed.
+   *
+   *  This is only a hint.  Implementations are free to choose whether to use eager or lazy parsing regardless of the value of this option.  However, setting this option true suggests that the protocol author believes that using lazy parsing on this field is worth the additional bookkeeping overhead typically needed to implement it.
+   *
+   *  This option does not affect the public interface of any generated code; all method signatures remain the same.  Furthermore, thread-safety of the interface is not affected by this option; const methods remain safe to call from multiple threads concurrently, while non-const methods continue to require exclusive access.
+   *
+   *  Note that lazy message fields are still eagerly verified to check ill-formed wireformat or missing required fields. Calling IsInitialized() on the outer message would fail if the inner message has missing required fields. Failed verification would result in parsing failure (except when uninitialized messages are acceptable).
+   */
+  @GeneratedProperty(5)
+  public val lazy: Boolean?,
+  /**
+   * The jstype option determines the JavaScript type used for values of the field.  The option is permitted only for 64 bit integral and fixed types (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING is represented as JavaScript string, which avoids loss of precision that can happen when a large value is converted to a floating point JavaScript. Specifying JS_NUMBER for the jstype causes the generated JavaScript code to use the JavaScript "number" type.  The behavior of the default option JS_NORMAL is implementation dependent.
+   *
+   *  This option is an enum to permit additional types to be added, e.g. goog.math.Integer.
+   */
+  @GeneratedProperty(6)
+  public val jstype: JSType?,
+  /**
+   * For Google-internal migration only. Do not use.
+   */
+  @GeneratedProperty(10)
+  public val weak: Boolean?,
+  /**
+   * unverified_lazy does no correctness checks on the byte stream. This should only be used where lazy with verification is prohibitive for performance reasons.
+   */
+  @GeneratedProperty(15)
+  public val unverifiedLazy: Boolean?,
+  /**
+   * Indicate that the field value should not be printed out when using debug formats, e.g. when the field contains sensitive credentials.
+   */
+  @GeneratedProperty(16)
+  public val debugRedact: Boolean?,
+  @GeneratedProperty(17)
+  public val retention: OptionRetention?,
+  @GeneratedProperty(19)
+  public val targets: List<OptionTargetType>,
+  @GeneratedProperty(20)
+  public val editionDefaults: List<EditionDefault>,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(21)
+  public val features: FeatureSet?,
+  @GeneratedProperty(22)
+  public val featureSupport: FeatureSupport?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (ctype != null) {
+      result += sizeOf(8u) + sizeOf(ctype)
+    }
+    if (packed != null) {
+      result += sizeOf(16u) + 1
+    }
+    if (deprecated != null) {
+      result += sizeOf(24u) + 1
+    }
+    if (lazy != null) {
+      result += sizeOf(40u) + 1
+    }
+    if (jstype != null) {
+      result += sizeOf(48u) + sizeOf(jstype)
+    }
+    if (weak != null) {
+      result += sizeOf(80u) + 1
+    }
+    if (unverifiedLazy != null) {
+      result += sizeOf(120u) + 1
+    }
+    if (debugRedact != null) {
+      result += sizeOf(128u) + 1
+    }
+    if (retention != null) {
+      result += sizeOf(136u) + sizeOf(retention)
+    }
+    if (targets.isNotEmpty()) {
+      result += (sizeOf(152u) * targets.size) + targets.sumOf { sizeOf(it) }
+    }
+    if (editionDefaults.isNotEmpty()) {
+      result += (sizeOf(162u) * editionDefaults.size) + editionDefaults.sumOf { sizeOf(it) }
+    }
+    if (features != null) {
+      result += sizeOf(170u) + sizeOf(features)
+    }
+    if (featureSupport != null) {
+      result += sizeOf(178u) + sizeOf(featureSupport)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (ctype != null) {
+      writer.writeTag(8u).write(ctype)
+    }
+    if (packed != null) {
+      writer.writeTag(16u).write(packed)
+    }
+    if (deprecated != null) {
+      writer.writeTag(24u).write(deprecated)
+    }
+    if (lazy != null) {
+      writer.writeTag(40u).write(lazy)
+    }
+    if (jstype != null) {
+      writer.writeTag(48u).write(jstype)
+    }
+    if (weak != null) {
+      writer.writeTag(80u).write(weak)
+    }
+    if (unverifiedLazy != null) {
+      writer.writeTag(120u).write(unverifiedLazy)
+    }
+    if (debugRedact != null) {
+      writer.writeTag(128u).write(debugRedact)
+    }
+    if (retention != null) {
+      writer.writeTag(136u).write(retention)
+    }
+    targets.forEach { writer.writeTag(152u).write(it) }
+    editionDefaults.forEach { writer.writeTag(162u).write(it) }
+    if (features != null) {
+      writer.writeTag(170u).write(features)
+    }
+    if (featureSupport != null) {
+      writer.writeTag(178u).write(featureSupport)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FieldOptions &&
+      other.ctype == this.ctype &&
+      other.packed == this.packed &&
+      other.deprecated == this.deprecated &&
+      other.lazy == this.lazy &&
+      other.jstype == this.jstype &&
+      other.weak == this.weak &&
+      other.unverifiedLazy == this.unverifiedLazy &&
+      other.debugRedact == this.debugRedact &&
+      other.retention == this.retention &&
+      other.targets == this.targets &&
+      other.editionDefaults == this.editionDefaults &&
+      other.features == this.features &&
+      other.featureSupport == this.featureSupport &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + ctype.hashCode()
+    result = 31 * result + packed.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + lazy.hashCode()
+    result = 31 * result + jstype.hashCode()
+    result = 31 * result + weak.hashCode()
+    result = 31 * result + unverifiedLazy.hashCode()
+    result = 31 * result + debugRedact.hashCode()
+    result = 31 * result + retention.hashCode()
+    result = 31 * result + targets.hashCode()
+    result = 31 * result + editionDefaults.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + featureSupport.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FieldOptions(" +
+      "ctype=$ctype, " +
+      "packed=$packed, " +
+      "deprecated=$deprecated, " +
+      "lazy=$lazy, " +
+      "jstype=$jstype, " +
+      "weak=$weak, " +
+      "unverifiedLazy=$unverifiedLazy, " +
+      "debugRedact=$debugRedact, " +
+      "retention=$retention, " +
+      "targets=$targets, " +
+      "editionDefaults=$editionDefaults, " +
+      "features=$features, " +
+      "featureSupport=$featureSupport, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FieldOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var ctype: CType? = null
+
+    public var packed: Boolean? = null
+
+    public var deprecated: Boolean? = null
+
+    public var lazy: Boolean? = null
+
+    public var jstype: JSType? = null
+
+    public var weak: Boolean? = null
+
+    public var unverifiedLazy: Boolean? = null
+
+    public var debugRedact: Boolean? = null
+
+    public var retention: OptionRetention? = null
+
+    public var targets: List<OptionTargetType> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var editionDefaults: List<EditionDefault> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var features: FeatureSet? = null
+
+    public var featureSupport: FeatureSupport? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FieldOptions =
+      FieldOptions(
+        ctype,
+        packed,
+        deprecated,
+        lazy,
+        jstype,
+        weak,
+        unverifiedLazy,
+        debugRedact,
+        retention,
+        freezeList(targets),
+        freezeList(editionDefaults),
+        features,
+        featureSupport,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FieldOptions): Builder =
+        Builder().also {
+          it.ctype = msg.ctype
+          it.packed = msg.packed
+          it.deprecated = msg.deprecated
+          it.lazy = msg.lazy
+          it.jstype = msg.jstype
+          it.weak = msg.weak
+          it.unverifiedLazy = msg.unverifiedLazy
+          it.debugRedact = msg.debugRedact
+          it.retention = msg.retention
+          it.targets = msg.targets
+          it.editionDefaults = msg.editionDefaults
+          it.features = msg.features
+          it.featureSupport = msg.featureSupport
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FieldOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FieldOptions {
+      var ctype: CType? = null
+      var packed: Boolean? = null
+      var deprecated: Boolean? = null
+      var lazy: Boolean? = null
+      var jstype: JSType? = null
+      var weak: Boolean? = null
+      var unverifiedLazy: Boolean? = null
+      var debugRedact: Boolean? = null
+      var retention: OptionRetention? = null
+      var targets: ListBuilder<OptionTargetType>? = null
+      var editionDefaults: ListBuilder<EditionDefault>? = null
+      var features: FeatureSet? = null
+      var featureSupport: FeatureSupport? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FieldOptions(
+              ctype,
+              packed,
+              deprecated,
+              lazy,
+              jstype,
+              weak,
+              unverifiedLazy,
+              debugRedact,
+              retention,
+              targets?.build() ?: emptyList(),
+              editionDefaults?.build() ?: emptyList(),
+              features,
+              featureSupport,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            ctype = reader.readEnum(CType)
+          }
+
+          16u -> {
+            packed = reader.readBool()
+          }
+
+          24u -> {
+            deprecated = reader.readBool()
+          }
+
+          40u -> {
+            lazy = reader.readBool()
+          }
+
+          48u -> {
+            jstype = reader.readEnum(JSType)
+          }
+
+          80u -> {
+            weak = reader.readBool()
+          }
+
+          120u -> {
+            unverifiedLazy = reader.readBool()
+          }
+
+          128u -> {
+            debugRedact = reader.readBool()
+          }
+
+          136u -> {
+            retention = reader.readEnum(OptionRetention)
+          }
+
+          152u -> {
+            targets =
+              (targets ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readEnum(OptionTargetType))
+                }
+              }
+          }
+
+          154u -> {
+            targets =
+              (targets ?: listBuilder()).apply {
+                reader.readRepeated(true) {
+                  add(reader.readEnum(OptionTargetType))
+                }
+              }
+          }
+
+          162u -> {
+            editionDefaults =
+              (editionDefaults ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(EditionDefault))
+                }
+              }
+          }
+
+          170u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          178u -> {
+            featureSupport = reader.readMessage(FeatureSupport)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FieldOptions =
+      Builder().apply(dsl).build()
+  }
+
+  public sealed class CType(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    /**
+     * Default mode.
+     */
+    public object STRING : CType(0, "STRING")
+
+    /**
+     * The option [ctype=CORD] may be applied to a non-repeated field of type "bytes". It indicates that in C++, the data should be stored in a Cord instead of a string.  For very large strings, this may reduce memory fragmentation. It may also allow better performance when parsing from a Cord, or when parsing with aliasing enabled, as the parsed Cord may then alias the original buffer.
+     */
+    public object CORD : CType(1, "CORD")
+
+    public object STRING_PIECE : CType(2, "STRING_PIECE")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : CType(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<CType> {
+      override fun deserialize(`value`: Int): CType =
+        when (value) {
+          0 -> STRING
+          1 -> CORD
+          2 -> STRING_PIECE
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class JSType(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    /**
+     * Use the default type.
+     */
+    public object JS_NORMAL : JSType(0, "JS_NORMAL")
+
+    /**
+     * Use JavaScript strings.
+     */
+    public object JS_STRING : JSType(1, "JS_STRING")
+
+    /**
+     * Use JavaScript numbers.
+     */
+    public object JS_NUMBER : JSType(2, "JS_NUMBER")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : JSType(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<JSType> {
+      override fun deserialize(`value`: Int): JSType =
+        when (value) {
+          0 -> JS_NORMAL
+          1 -> JS_STRING
+          2 -> JS_NUMBER
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  /**
+   * If set to RETENTION_SOURCE, the option will be omitted from the binary.
+   */
+  public sealed class OptionRetention(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object RETENTION_UNKNOWN : OptionRetention(0, "RETENTION_UNKNOWN")
+
+    public object RETENTION_RUNTIME : OptionRetention(1, "RETENTION_RUNTIME")
+
+    public object RETENTION_SOURCE : OptionRetention(2, "RETENTION_SOURCE")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : OptionRetention(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<OptionRetention> {
+      override fun deserialize(`value`: Int): OptionRetention =
+        when (value) {
+          0 -> RETENTION_UNKNOWN
+          1 -> RETENTION_RUNTIME
+          2 -> RETENTION_SOURCE
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  /**
+   * This indicates the types of entities that the field may apply to when used as an option. If it is unset, then the field may be freely used as an option on any kind of entity.
+   */
+  public sealed class OptionTargetType(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object TARGET_TYPE_UNKNOWN : OptionTargetType(0, "TARGET_TYPE_UNKNOWN")
+
+    public object TARGET_TYPE_FILE : OptionTargetType(1, "TARGET_TYPE_FILE")
+
+    public object TARGET_TYPE_EXTENSION_RANGE : OptionTargetType(2, "TARGET_TYPE_EXTENSION_RANGE")
+
+    public object TARGET_TYPE_MESSAGE : OptionTargetType(3, "TARGET_TYPE_MESSAGE")
+
+    public object TARGET_TYPE_FIELD : OptionTargetType(4, "TARGET_TYPE_FIELD")
+
+    public object TARGET_TYPE_ONEOF : OptionTargetType(5, "TARGET_TYPE_ONEOF")
+
+    public object TARGET_TYPE_ENUM : OptionTargetType(6, "TARGET_TYPE_ENUM")
+
+    public object TARGET_TYPE_ENUM_ENTRY : OptionTargetType(7, "TARGET_TYPE_ENUM_ENTRY")
+
+    public object TARGET_TYPE_SERVICE : OptionTargetType(8, "TARGET_TYPE_SERVICE")
+
+    public object TARGET_TYPE_METHOD : OptionTargetType(9, "TARGET_TYPE_METHOD")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : OptionTargetType(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<OptionTargetType> {
+      override fun deserialize(`value`: Int): OptionTargetType =
+        when (value) {
+          0 -> TARGET_TYPE_UNKNOWN
+          1 -> TARGET_TYPE_FILE
+          2 -> TARGET_TYPE_EXTENSION_RANGE
+          3 -> TARGET_TYPE_MESSAGE
+          4 -> TARGET_TYPE_FIELD
+          5 -> TARGET_TYPE_ONEOF
+          6 -> TARGET_TYPE_ENUM
+          7 -> TARGET_TYPE_ENUM_ENTRY
+          8 -> TARGET_TYPE_SERVICE
+          9 -> TARGET_TYPE_METHOD
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  @GeneratedMessage("google.protobuf.FieldOptions.EditionDefault")
+  public class EditionDefault private constructor(
+    private val _value: LazyReference<Bytes, String>?,
+    @GeneratedProperty(3)
+    public val edition: Edition?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (_value != null) {
+        result += sizeOf(18u) + sizeOf(_value.wireValue())
+      }
+      if (edition != null) {
+        result += sizeOf(24u) + sizeOf(edition)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    @GeneratedProperty(2)
+    public val `value`: String?
+      get() = _value?.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (_value != null) {
+        writer.writeTag(18u).write(_value.wireValue())
+      }
+      if (edition != null) {
+        writer.writeTag(24u).write(edition)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is EditionDefault &&
+        other.`value` == this.`value` &&
+        other.edition == this.edition &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + `value`.hashCode()
+      result = 31 * result + edition.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "EditionDefault(" +
+        "`value`=$`value`, " +
+        "edition=$edition" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): EditionDefault =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      private var _valueRef: LazyReference<Bytes, String>? = null
+
+      public var `value`: String?
+        get() = _valueRef?.value()
+        set(newValue) {
+          _valueRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      public var edition: Edition? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): EditionDefault =
+        EditionDefault(
+          _valueRef,
+          edition,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: EditionDefault): Builder =
+          Builder().also {
+            it._valueRef = msg._value
+            it.edition = msg.edition
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<EditionDefault>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): EditionDefault {
+        var `value`: Bytes? = null
+        var edition: Edition? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return EditionDefault(
+                `value`?.let { LazyReference(it, StringConverter) },
+                edition,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            18u -> {
+              `value` = StringConverter.readValidatedBytes(reader)
+            }
+
+            24u -> {
+              edition = reader.readEnum(Edition)
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): EditionDefault =
+        Builder().apply(dsl).build()
+    }
+  }
+
+  /**
+   * Information about the support window of a feature.
+   */
+  @GeneratedMessage("google.protobuf.FieldOptions.FeatureSupport")
+  public class FeatureSupport private constructor(
+    /**
+     * The edition that this feature was first available in.  In editions earlier than this one, the default assigned to EDITION_LEGACY will be used, and proto files will not be able to override it.
+     */
+    @GeneratedProperty(1)
+    public val editionIntroduced: Edition?,
+    /**
+     * The edition this feature becomes deprecated in.  Using this after this edition may trigger warnings.
+     */
+    @GeneratedProperty(2)
+    public val editionDeprecated: Edition?,
+    private val _deprecationWarning: LazyReference<Bytes, String>?,
+    /**
+     * The edition this feature is no longer available in.  In editions after this one, the last default assigned will be used, and proto files will not be able to override it.
+     */
+    @GeneratedProperty(4)
+    public val editionRemoved: Edition?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (editionIntroduced != null) {
+        result += sizeOf(8u) + sizeOf(editionIntroduced)
+      }
+      if (editionDeprecated != null) {
+        result += sizeOf(16u) + sizeOf(editionDeprecated)
+      }
+      if (_deprecationWarning != null) {
+        result += sizeOf(26u) + sizeOf(_deprecationWarning.wireValue())
+      }
+      if (editionRemoved != null) {
+        result += sizeOf(32u) + sizeOf(editionRemoved)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    /**
+     * The deprecation warning text if this feature is used after the edition it was marked deprecated in.
+     */
+    @GeneratedProperty(3)
+    public val deprecationWarning: String?
+      get() = _deprecationWarning?.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (editionIntroduced != null) {
+        writer.writeTag(8u).write(editionIntroduced)
+      }
+      if (editionDeprecated != null) {
+        writer.writeTag(16u).write(editionDeprecated)
+      }
+      if (_deprecationWarning != null) {
+        writer.writeTag(26u).write(_deprecationWarning.wireValue())
+      }
+      if (editionRemoved != null) {
+        writer.writeTag(32u).write(editionRemoved)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is FeatureSupport &&
+        other.editionIntroduced == this.editionIntroduced &&
+        other.editionDeprecated == this.editionDeprecated &&
+        other.deprecationWarning == this.deprecationWarning &&
+        other.editionRemoved == this.editionRemoved &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + editionIntroduced.hashCode()
+      result = 31 * result + editionDeprecated.hashCode()
+      result = 31 * result + deprecationWarning.hashCode()
+      result = 31 * result + editionRemoved.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "FeatureSupport(" +
+        "editionIntroduced=$editionIntroduced, " +
+        "editionDeprecated=$editionDeprecated, " +
+        "deprecationWarning=$deprecationWarning, " +
+        "editionRemoved=$editionRemoved" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): FeatureSupport =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var editionIntroduced: Edition? = null
+
+      public var editionDeprecated: Edition? = null
+
+      private var _deprecationWarningRef: LazyReference<Bytes, String>? = null
+
+      public var deprecationWarning: String?
+        get() = _deprecationWarningRef?.value()
+        set(newValue) {
+          _deprecationWarningRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      public var editionRemoved: Edition? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): FeatureSupport =
+        FeatureSupport(
+          editionIntroduced,
+          editionDeprecated,
+          _deprecationWarningRef,
+          editionRemoved,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: FeatureSupport): Builder =
+          Builder().also {
+            it.editionIntroduced = msg.editionIntroduced
+            it.editionDeprecated = msg.editionDeprecated
+            it._deprecationWarningRef = msg._deprecationWarning
+            it.editionRemoved = msg.editionRemoved
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<FeatureSupport>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): FeatureSupport {
+        var editionIntroduced: Edition? = null
+        var editionDeprecated: Edition? = null
+        var deprecationWarning: Bytes? = null
+        var editionRemoved: Edition? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return FeatureSupport(
+                editionIntroduced,
+                editionDeprecated,
+                deprecationWarning?.let { LazyReference(it, StringConverter) },
+                editionRemoved,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              editionIntroduced = reader.readEnum(Edition)
+            }
+
+            16u -> {
+              editionDeprecated = reader.readEnum(Edition)
+            }
+
+            26u -> {
+              deprecationWarning = StringConverter.readValidatedBytes(reader)
+            }
+
+            32u -> {
+              editionRemoved = reader.readEnum(Edition)
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): FeatureSupport =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+@GeneratedMessage("google.protobuf.OneofOptions")
+public class OneofOptions private constructor(
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(1)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (features != null) {
+      result += sizeOf(10u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (features != null) {
+      writer.writeTag(10u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is OneofOptions &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "OneofOptions(" +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): OneofOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): OneofOptions =
+      OneofOptions(
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: OneofOptions): Builder =
+        Builder().also {
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<OneofOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): OneofOptions {
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return OneofOptions(
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): OneofOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("google.protobuf.EnumOptions")
+public class EnumOptions private constructor(
+  /**
+   * Set this option to true to allow mapping different tag names to the same value.
+   */
+  @GeneratedProperty(2)
+  public val allowAlias: Boolean?,
+  /**
+   * Is this enum deprecated? Depending on the target platform, this can emit Deprecated annotations for the enum, or it will be completely ignored; in the very least, this is a formalization for deprecating enums.
+   */
+  @GeneratedProperty(3)
+  public val deprecated: Boolean?,
+  /**
+   * Enable the legacy handling of JSON field name conflicts.  This lowercases and strips underscored from the fields before comparison in proto3 only. The new behavior takes `json_name` into account and applies to proto2 as well. TODO Remove this legacy behavior once downstream teams have had time to migrate.
+   */
+  @GeneratedProperty(6)
+  @Deprecated("deprecated in proto")
+  public val deprecatedLegacyJsonFieldConflicts: Boolean?,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(7)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (allowAlias != null) {
+      result += sizeOf(16u) + 1
+    }
+    if (deprecated != null) {
+      result += sizeOf(24u) + 1
+    }
+    if (deprecatedLegacyJsonFieldConflicts != null) {
+      result += sizeOf(48u) + 1
+    }
+    if (features != null) {
+      result += sizeOf(58u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (allowAlias != null) {
+      writer.writeTag(16u).write(allowAlias)
+    }
+    if (deprecated != null) {
+      writer.writeTag(24u).write(deprecated)
+    }
+    if (deprecatedLegacyJsonFieldConflicts != null) {
+      writer.writeTag(48u).write(deprecatedLegacyJsonFieldConflicts)
+    }
+    if (features != null) {
+      writer.writeTag(58u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is EnumOptions &&
+      other.allowAlias == this.allowAlias &&
+      other.deprecated == this.deprecated &&
+      other.deprecatedLegacyJsonFieldConflicts == this.deprecatedLegacyJsonFieldConflicts &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + allowAlias.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + deprecatedLegacyJsonFieldConflicts.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "EnumOptions(" +
+      "allowAlias=$allowAlias, " +
+      "deprecated=$deprecated, " +
+      "deprecatedLegacyJsonFieldConflicts=$deprecatedLegacyJsonFieldConflicts, " +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): EnumOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var allowAlias: Boolean? = null
+
+    public var deprecated: Boolean? = null
+
+    @Deprecated("deprecated in proto")
+    public var deprecatedLegacyJsonFieldConflicts: Boolean? = null
+
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): EnumOptions =
+      EnumOptions(
+        allowAlias,
+        deprecated,
+        deprecatedLegacyJsonFieldConflicts,
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: EnumOptions): Builder =
+        Builder().also {
+          it.allowAlias = msg.allowAlias
+          it.deprecated = msg.deprecated
+          it.deprecatedLegacyJsonFieldConflicts = msg.deprecatedLegacyJsonFieldConflicts
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<EnumOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): EnumOptions {
+      var allowAlias: Boolean? = null
+      var deprecated: Boolean? = null
+      var deprecatedLegacyJsonFieldConflicts: Boolean? = null
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return EnumOptions(
+              allowAlias,
+              deprecated,
+              deprecatedLegacyJsonFieldConflicts,
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          16u -> {
+            allowAlias = reader.readBool()
+          }
+
+          24u -> {
+            deprecated = reader.readBool()
+          }
+
+          48u -> {
+            deprecatedLegacyJsonFieldConflicts = reader.readBool()
+          }
+
+          58u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): EnumOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("google.protobuf.EnumValueOptions")
+public class EnumValueOptions private constructor(
+  /**
+   * Is this enum value deprecated? Depending on the target platform, this can emit Deprecated annotations for the enum value, or it will be completely ignored; in the very least, this is a formalization for deprecating enum values.
+   */
+  @GeneratedProperty(1)
+  public val deprecated: Boolean?,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(2)
+  public val features: FeatureSet?,
+  /**
+   * Indicate that fields annotated with this enum value should not be printed out when using debug formats, e.g. when the field contains sensitive credentials.
+   */
+  @GeneratedProperty(3)
+  public val debugRedact: Boolean?,
+  /**
+   * Information about the support window of a feature value.
+   */
+  @GeneratedProperty(4)
+  public val featureSupport: FieldOptions.FeatureSupport?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (deprecated != null) {
+      result += sizeOf(8u) + 1
+    }
+    if (features != null) {
+      result += sizeOf(18u) + sizeOf(features)
+    }
+    if (debugRedact != null) {
+      result += sizeOf(24u) + 1
+    }
+    if (featureSupport != null) {
+      result += sizeOf(34u) + sizeOf(featureSupport)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (deprecated != null) {
+      writer.writeTag(8u).write(deprecated)
+    }
+    if (features != null) {
+      writer.writeTag(18u).write(features)
+    }
+    if (debugRedact != null) {
+      writer.writeTag(24u).write(debugRedact)
+    }
+    if (featureSupport != null) {
+      writer.writeTag(34u).write(featureSupport)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is EnumValueOptions &&
+      other.deprecated == this.deprecated &&
+      other.features == this.features &&
+      other.debugRedact == this.debugRedact &&
+      other.featureSupport == this.featureSupport &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + debugRedact.hashCode()
+    result = 31 * result + featureSupport.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "EnumValueOptions(" +
+      "deprecated=$deprecated, " +
+      "features=$features, " +
+      "debugRedact=$debugRedact, " +
+      "featureSupport=$featureSupport, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): EnumValueOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var deprecated: Boolean? = null
+
+    public var features: FeatureSet? = null
+
+    public var debugRedact: Boolean? = null
+
+    public var featureSupport: FieldOptions.FeatureSupport? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): EnumValueOptions =
+      EnumValueOptions(
+        deprecated,
+        features,
+        debugRedact,
+        featureSupport,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: EnumValueOptions): Builder =
+        Builder().also {
+          it.deprecated = msg.deprecated
+          it.features = msg.features
+          it.debugRedact = msg.debugRedact
+          it.featureSupport = msg.featureSupport
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<EnumValueOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): EnumValueOptions {
+      var deprecated: Boolean? = null
+      var features: FeatureSet? = null
+      var debugRedact: Boolean? = null
+      var featureSupport: FieldOptions.FeatureSupport? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return EnumValueOptions(
+              deprecated,
+              features,
+              debugRedact,
+              featureSupport,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            deprecated = reader.readBool()
+          }
+
+          18u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          24u -> {
+            debugRedact = reader.readBool()
+          }
+
+          34u -> {
+            featureSupport = reader.readMessage(FieldOptions.FeatureSupport)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): EnumValueOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("google.protobuf.ServiceOptions")
+public class ServiceOptions private constructor(
+  /**
+   * Is this service deprecated? Depending on the target platform, this can emit Deprecated annotations for the service, or it will be completely ignored; in the very least, this is a formalization for deprecating services.
+   */
+  @GeneratedProperty(33)
+  public val deprecated: Boolean?,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(34)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (deprecated != null) {
+      result += sizeOf(264u) + 1
+    }
+    if (features != null) {
+      result += sizeOf(274u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (deprecated != null) {
+      writer.writeTag(264u).write(deprecated)
+    }
+    if (features != null) {
+      writer.writeTag(274u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is ServiceOptions &&
+      other.deprecated == this.deprecated &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "ServiceOptions(" +
+      "deprecated=$deprecated, " +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): ServiceOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var deprecated: Boolean? = null
+
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): ServiceOptions =
+      ServiceOptions(
+        deprecated,
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: ServiceOptions): Builder =
+        Builder().also {
+          it.deprecated = msg.deprecated
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<ServiceOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): ServiceOptions {
+      var deprecated: Boolean? = null
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return ServiceOptions(
+              deprecated,
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          264u -> {
+            deprecated = reader.readBool()
+          }
+
+          274u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): ServiceOptions =
+      Builder().apply(dsl).build()
+  }
+}
+
+@GeneratedMessage("google.protobuf.MethodOptions")
+public class MethodOptions private constructor(
+  /**
+   * Is this method deprecated? Depending on the target platform, this can emit Deprecated annotations for the method, or it will be completely ignored; in the very least, this is a formalization for deprecating methods.
+   */
+  @GeneratedProperty(33)
+  public val deprecated: Boolean?,
+  @GeneratedProperty(34)
+  public val idempotencyLevel: IdempotencyLevel?,
+  /**
+   * Any features defined in the specific edition. WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(35)
+  public val features: FeatureSet?,
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @GeneratedProperty(999)
+  public val uninterpretedOption: List<UninterpretedOption>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (deprecated != null) {
+      result += sizeOf(264u) + 1
+    }
+    if (idempotencyLevel != null) {
+      result += sizeOf(272u) + sizeOf(idempotencyLevel)
+    }
+    if (features != null) {
+      result += sizeOf(282u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (deprecated != null) {
+      writer.writeTag(264u).write(deprecated)
+    }
+    if (idempotencyLevel != null) {
+      writer.writeTag(272u).write(idempotencyLevel)
+    }
+    if (features != null) {
+      writer.writeTag(282u).write(features)
+    }
+    uninterpretedOption.forEach { writer.writeTag(7994u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is MethodOptions &&
+      other.deprecated == this.deprecated &&
+      other.idempotencyLevel == this.idempotencyLevel &&
+      other.features == this.features &&
+      other.uninterpretedOption == this.uninterpretedOption &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + deprecated.hashCode()
+    result = 31 * result + idempotencyLevel.hashCode()
+    result = 31 * result + features.hashCode()
+    result = 31 * result + uninterpretedOption.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "MethodOptions(" +
+      "deprecated=$deprecated, " +
+      "idempotencyLevel=$idempotencyLevel, " +
+      "features=$features, " +
+      "uninterpretedOption=$uninterpretedOption" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): MethodOptions =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var deprecated: Boolean? = null
+
+    public var idempotencyLevel: IdempotencyLevel? = null
+
+    public var features: FeatureSet? = null
+
+    public var uninterpretedOption: List<UninterpretedOption> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): MethodOptions =
+      MethodOptions(
+        deprecated,
+        idempotencyLevel,
+        features,
+        freezeList(uninterpretedOption),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: MethodOptions): Builder =
+        Builder().also {
+          it.deprecated = msg.deprecated
+          it.idempotencyLevel = msg.idempotencyLevel
+          it.features = msg.features
+          it.uninterpretedOption = msg.uninterpretedOption
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<MethodOptions>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): MethodOptions {
+      var deprecated: Boolean? = null
+      var idempotencyLevel: IdempotencyLevel? = null
+      var features: FeatureSet? = null
+      var uninterpretedOption: ListBuilder<UninterpretedOption>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return MethodOptions(
+              deprecated,
+              idempotencyLevel,
+              features,
+              uninterpretedOption?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          264u -> {
+            deprecated = reader.readBool()
+          }
+
+          272u -> {
+            idempotencyLevel = reader.readEnum(IdempotencyLevel)
+          }
+
+          282u -> {
+            features = reader.readMessage(FeatureSet)
+          }
+
+          7994u -> {
+            uninterpretedOption =
+              (uninterpretedOption ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(UninterpretedOption))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): MethodOptions =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * Is this method side-effect-free (or safe in HTTP parlance), or idempotent, or neither? HTTP based RPC implementation may choose GET verb for safe methods, and PUT verb for idempotent methods instead of the default POST.
+   */
+  public sealed class IdempotencyLevel(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object IDEMPOTENCY_UNKNOWN : IdempotencyLevel(0, "IDEMPOTENCY_UNKNOWN")
+
+    public object NO_SIDE_EFFECTS : IdempotencyLevel(1, "NO_SIDE_EFFECTS")
+
+    public object IDEMPOTENT : IdempotencyLevel(2, "IDEMPOTENT")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : IdempotencyLevel(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<IdempotencyLevel> {
+      override fun deserialize(`value`: Int): IdempotencyLevel =
+        when (value) {
+          0 -> IDEMPOTENCY_UNKNOWN
+          1 -> NO_SIDE_EFFECTS
+          2 -> IDEMPOTENT
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+}
+
+/**
+ * A message representing a option the parser does not recognize. This only appears in options protos created by the compiler::Parser class. DescriptorPool resolves these when building Descriptor objects. Therefore, options protos in descriptor objects (e.g. returned by Descriptor::options(), or produced by Descriptor::CopyTo()) will never have UninterpretedOptions in them.
+ */
+@GeneratedMessage("google.protobuf.UninterpretedOption")
+public class UninterpretedOption private constructor(
+  @GeneratedProperty(2)
+  public val name: List<NamePart>,
+  private val _identifierValue: LazyReference<Bytes, String>?,
+  @GeneratedProperty(4)
+  public val positiveIntValue: ULong?,
+  @GeneratedProperty(5)
+  public val negativeIntValue: Long?,
+  @GeneratedProperty(6)
+  public val doubleValue: Double?,
+  @GeneratedProperty(7)
+  public val stringValue: Bytes?,
+  private val _aggregateValue: LazyReference<Bytes, String>?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (name.isNotEmpty()) {
+      result += (sizeOf(18u) * name.size) + name.sumOf { sizeOf(it) }
+    }
+    if (_identifierValue != null) {
+      result += sizeOf(26u) + sizeOf(_identifierValue.wireValue())
+    }
+    if (positiveIntValue != null) {
+      result += sizeOf(32u) + sizeOf(positiveIntValue)
+    }
+    if (negativeIntValue != null) {
+      result += sizeOf(40u) + sizeOf(negativeIntValue)
+    }
+    if (doubleValue != null) {
+      result += sizeOf(49u) + 8
+    }
+    if (stringValue != null) {
+      result += sizeOf(58u) + sizeOf(stringValue)
+    }
+    if (_aggregateValue != null) {
+      result += sizeOf(66u) + sizeOf(_aggregateValue.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * The value of the uninterpreted option, in whatever type the tokenizer identified it as during parsing. Exactly one of these should be set.
+   */
+  @GeneratedProperty(3)
+  public val identifierValue: String?
+    get() = _identifierValue?.value()
+
+  @GeneratedProperty(8)
+  public val aggregateValue: String?
+    get() = _aggregateValue?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    name.forEach { writer.writeTag(18u).write(it) }
+    if (_identifierValue != null) {
+      writer.writeTag(26u).write(_identifierValue.wireValue())
+    }
+    if (positiveIntValue != null) {
+      writer.writeTag(32u).writeUInt64(positiveIntValue)
+    }
+    if (negativeIntValue != null) {
+      writer.writeTag(40u).write(negativeIntValue)
+    }
+    if (doubleValue != null) {
+      writer.writeTag(49u).write(doubleValue)
+    }
+    if (stringValue != null) {
+      writer.writeTag(58u).write(stringValue)
+    }
+    if (_aggregateValue != null) {
+      writer.writeTag(66u).write(_aggregateValue.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is UninterpretedOption &&
+      other.name == this.name &&
+      other.identifierValue == this.identifierValue &&
+      other.positiveIntValue == this.positiveIntValue &&
+      other.negativeIntValue == this.negativeIntValue &&
+      other.doubleValue == this.doubleValue &&
+      other.stringValue == this.stringValue &&
+      other.aggregateValue == this.aggregateValue &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + identifierValue.hashCode()
+    result = 31 * result + positiveIntValue.hashCode()
+    result = 31 * result + negativeIntValue.hashCode()
+    result = 31 * result + doubleValue.hashCode()
+    result = 31 * result + stringValue.hashCode()
+    result = 31 * result + aggregateValue.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "UninterpretedOption(" +
+      "name=$name, " +
+      "identifierValue=$identifierValue, " +
+      "positiveIntValue=$positiveIntValue, " +
+      "negativeIntValue=$negativeIntValue, " +
+      "doubleValue=$doubleValue, " +
+      "stringValue=$stringValue, " +
+      "aggregateValue=$aggregateValue" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): UninterpretedOption =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var name: List<NamePart> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    private var _identifierValueRef: LazyReference<Bytes, String>? = null
+
+    public var identifierValue: String?
+      get() = _identifierValueRef?.value()
+      set(newValue) {
+        _identifierValueRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var positiveIntValue: ULong? = null
+
+    public var negativeIntValue: Long? = null
+
+    public var doubleValue: Double? = null
+
+    public var stringValue: Bytes? = null
+
+    private var _aggregateValueRef: LazyReference<Bytes, String>? = null
+
+    public var aggregateValue: String?
+      get() = _aggregateValueRef?.value()
+      set(newValue) {
+        _aggregateValueRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): UninterpretedOption =
+      UninterpretedOption(
+        freezeList(name),
+        _identifierValueRef,
+        positiveIntValue,
+        negativeIntValue,
+        doubleValue,
+        stringValue,
+        _aggregateValueRef,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: UninterpretedOption): Builder =
+        Builder().also {
+          it.name = msg.name
+          it._identifierValueRef = msg._identifierValue
+          it.positiveIntValue = msg.positiveIntValue
+          it.negativeIntValue = msg.negativeIntValue
+          it.doubleValue = msg.doubleValue
+          it.stringValue = msg.stringValue
+          it._aggregateValueRef = msg._aggregateValue
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<UninterpretedOption>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): UninterpretedOption {
+      var name: ListBuilder<NamePart>? = null
+      var identifierValue: Bytes? = null
+      var positiveIntValue: ULong? = null
+      var negativeIntValue: Long? = null
+      var doubleValue: Double? = null
+      var stringValue: Bytes? = null
+      var aggregateValue: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return UninterpretedOption(
+              name?.build() ?: emptyList(),
+              identifierValue?.let { LazyReference(it, StringConverter) },
+              positiveIntValue,
+              negativeIntValue,
+              doubleValue,
+              stringValue,
+              aggregateValue?.let { LazyReference(it, StringConverter) },
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          18u -> {
+            name =
+              (name ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(NamePart))
+                }
+              }
+          }
+
+          26u -> {
+            identifierValue = StringConverter.readValidatedBytes(reader)
+          }
+
+          32u -> {
+            positiveIntValue = reader.readUInt64()
+          }
+
+          40u -> {
+            negativeIntValue = reader.readInt64()
+          }
+
+          49u -> {
+            doubleValue = reader.readDouble()
+          }
+
+          58u -> {
+            stringValue = reader.readBytes()
+          }
+
+          66u -> {
+            aggregateValue = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): UninterpretedOption =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * The name of the uninterpreted option.  Each string represents a segment in a dot-separated name.  is_extension is true iff a segment represents an extension (denoted with parentheses in options specs in .proto files). E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents "foo.(bar.baz).moo".
+   */
+  @GeneratedMessage("google.protobuf.UninterpretedOption.NamePart")
+  public class NamePart private constructor(
+    private val _namePart: LazyReference<Bytes, String>,
+    @GeneratedProperty(2)
+    public val isExtension: Boolean,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (_namePart.wireValue().isNotEmpty()) {
+        result += sizeOf(10u) + sizeOf(_namePart.wireValue())
+      }
+      if (isExtension) {
+        result += sizeOf(16u) + 1
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    @GeneratedProperty(1)
+    public val namePart: String
+      get() = _namePart.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (_namePart.wireValue().isNotEmpty()) {
+        writer.writeTag(10u).write(_namePart.wireValue())
+      }
+      if (isExtension) {
+        writer.writeTag(16u).write(isExtension)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is NamePart &&
+        other.namePart == this.namePart &&
+        other.isExtension == this.isExtension &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + namePart.hashCode()
+      result = 31 * result + isExtension.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "NamePart(" +
+        "namePart=$namePart, " +
+        "isExtension=$isExtension" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): NamePart =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      private var _namePartRef: LazyReference<Bytes, String>? = null
+
+      public var namePart: String
+        get() = _namePartRef?.value() ?: ""
+        set(newValue) {
+          _namePartRef = LazyReference(newValue, StringConverter)
+        }
+
+      public var isExtension: Boolean = false
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): NamePart =
+        NamePart(
+          _namePartRef ?: LazyReference(Bytes.empty(), StringConverter),
+          isExtension,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: NamePart): Builder =
+          Builder().also {
+            it._namePartRef = msg._namePart
+            it.isExtension = msg.isExtension
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<NamePart>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): NamePart {
+        var namePart: Bytes? = null
+        var isExtension = false
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return NamePart(
+                LazyReference(namePart ?: Bytes.empty(), StringConverter),
+                isExtension,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            10u -> {
+              namePart = StringConverter.readValidatedBytes(reader)
+            }
+
+            16u -> {
+              isExtension = reader.readBool()
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): NamePart =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+/**
+ * TODO Enums in C++ gencode (and potentially other languages) are not well scoped.  This means that each of the feature enums below can clash with each other.  The short names we've chosen maximize call-site readability, but leave us very open to this scenario.  A future feature will be designed and implemented to handle this, hopefully before we ever hit a conflict here.
+ */
+@GeneratedMessage("google.protobuf.FeatureSet")
+public class FeatureSet private constructor(
+  @GeneratedProperty(1)
+  public val fieldPresence: FieldPresence?,
+  @GeneratedProperty(2)
+  public val enumType: EnumType?,
+  @GeneratedProperty(3)
+  public val repeatedFieldEncoding: RepeatedFieldEncoding?,
+  @GeneratedProperty(4)
+  public val utf8Validation: Utf8Validation?,
+  @GeneratedProperty(5)
+  public val messageEncoding: MessageEncoding?,
+  @GeneratedProperty(6)
+  public val jsonFormat: JsonFormat?,
+  @GeneratedProperty(7)
+  public val enforceNamingStyle: EnforceNamingStyle?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (fieldPresence != null) {
+      result += sizeOf(8u) + sizeOf(fieldPresence)
+    }
+    if (enumType != null) {
+      result += sizeOf(16u) + sizeOf(enumType)
+    }
+    if (repeatedFieldEncoding != null) {
+      result += sizeOf(24u) + sizeOf(repeatedFieldEncoding)
+    }
+    if (utf8Validation != null) {
+      result += sizeOf(32u) + sizeOf(utf8Validation)
+    }
+    if (messageEncoding != null) {
+      result += sizeOf(40u) + sizeOf(messageEncoding)
+    }
+    if (jsonFormat != null) {
+      result += sizeOf(48u) + sizeOf(jsonFormat)
+    }
+    if (enforceNamingStyle != null) {
+      result += sizeOf(56u) + sizeOf(enforceNamingStyle)
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (fieldPresence != null) {
+      writer.writeTag(8u).write(fieldPresence)
+    }
+    if (enumType != null) {
+      writer.writeTag(16u).write(enumType)
+    }
+    if (repeatedFieldEncoding != null) {
+      writer.writeTag(24u).write(repeatedFieldEncoding)
+    }
+    if (utf8Validation != null) {
+      writer.writeTag(32u).write(utf8Validation)
+    }
+    if (messageEncoding != null) {
+      writer.writeTag(40u).write(messageEncoding)
+    }
+    if (jsonFormat != null) {
+      writer.writeTag(48u).write(jsonFormat)
+    }
+    if (enforceNamingStyle != null) {
+      writer.writeTag(56u).write(enforceNamingStyle)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FeatureSet &&
+      other.fieldPresence == this.fieldPresence &&
+      other.enumType == this.enumType &&
+      other.repeatedFieldEncoding == this.repeatedFieldEncoding &&
+      other.utf8Validation == this.utf8Validation &&
+      other.messageEncoding == this.messageEncoding &&
+      other.jsonFormat == this.jsonFormat &&
+      other.enforceNamingStyle == this.enforceNamingStyle &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + fieldPresence.hashCode()
+    result = 31 * result + enumType.hashCode()
+    result = 31 * result + repeatedFieldEncoding.hashCode()
+    result = 31 * result + utf8Validation.hashCode()
+    result = 31 * result + messageEncoding.hashCode()
+    result = 31 * result + jsonFormat.hashCode()
+    result = 31 * result + enforceNamingStyle.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FeatureSet(" +
+      "fieldPresence=$fieldPresence, " +
+      "enumType=$enumType, " +
+      "repeatedFieldEncoding=$repeatedFieldEncoding, " +
+      "utf8Validation=$utf8Validation, " +
+      "messageEncoding=$messageEncoding, " +
+      "jsonFormat=$jsonFormat, " +
+      "enforceNamingStyle=$enforceNamingStyle" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FeatureSet =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var fieldPresence: FieldPresence? = null
+
+    public var enumType: EnumType? = null
+
+    public var repeatedFieldEncoding: RepeatedFieldEncoding? = null
+
+    public var utf8Validation: Utf8Validation? = null
+
+    public var messageEncoding: MessageEncoding? = null
+
+    public var jsonFormat: JsonFormat? = null
+
+    public var enforceNamingStyle: EnforceNamingStyle? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FeatureSet =
+      FeatureSet(
+        fieldPresence,
+        enumType,
+        repeatedFieldEncoding,
+        utf8Validation,
+        messageEncoding,
+        jsonFormat,
+        enforceNamingStyle,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FeatureSet): Builder =
+        Builder().also {
+          it.fieldPresence = msg.fieldPresence
+          it.enumType = msg.enumType
+          it.repeatedFieldEncoding = msg.repeatedFieldEncoding
+          it.utf8Validation = msg.utf8Validation
+          it.messageEncoding = msg.messageEncoding
+          it.jsonFormat = msg.jsonFormat
+          it.enforceNamingStyle = msg.enforceNamingStyle
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FeatureSet>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FeatureSet {
+      var fieldPresence: FieldPresence? = null
+      var enumType: EnumType? = null
+      var repeatedFieldEncoding: RepeatedFieldEncoding? = null
+      var utf8Validation: Utf8Validation? = null
+      var messageEncoding: MessageEncoding? = null
+      var jsonFormat: JsonFormat? = null
+      var enforceNamingStyle: EnforceNamingStyle? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FeatureSet(
+              fieldPresence,
+              enumType,
+              repeatedFieldEncoding,
+              utf8Validation,
+              messageEncoding,
+              jsonFormat,
+              enforceNamingStyle,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            fieldPresence = reader.readEnum(FieldPresence)
+          }
+
+          16u -> {
+            enumType = reader.readEnum(EnumType)
+          }
+
+          24u -> {
+            repeatedFieldEncoding = reader.readEnum(RepeatedFieldEncoding)
+          }
+
+          32u -> {
+            utf8Validation = reader.readEnum(Utf8Validation)
+          }
+
+          40u -> {
+            messageEncoding = reader.readEnum(MessageEncoding)
+          }
+
+          48u -> {
+            jsonFormat = reader.readEnum(JsonFormat)
+          }
+
+          56u -> {
+            enforceNamingStyle = reader.readEnum(EnforceNamingStyle)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FeatureSet =
+      Builder().apply(dsl).build()
+  }
+
+  public sealed class FieldPresence(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object FIELD_PRESENCE_UNKNOWN : FieldPresence(0, "FIELD_PRESENCE_UNKNOWN")
+
+    public object EXPLICIT : FieldPresence(1, "EXPLICIT")
+
+    public object IMPLICIT : FieldPresence(2, "IMPLICIT")
+
+    public object LEGACY_REQUIRED : FieldPresence(3, "LEGACY_REQUIRED")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : FieldPresence(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<FieldPresence> {
+      override fun deserialize(`value`: Int): FieldPresence =
+        when (value) {
+          0 -> FIELD_PRESENCE_UNKNOWN
+          1 -> EXPLICIT
+          2 -> IMPLICIT
+          3 -> LEGACY_REQUIRED
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class EnumType(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object ENUM_TYPE_UNKNOWN : EnumType(0, "ENUM_TYPE_UNKNOWN")
+
+    public object OPEN : EnumType(1, "OPEN")
+
+    public object CLOSED : EnumType(2, "CLOSED")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : EnumType(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<EnumType> {
+      override fun deserialize(`value`: Int): EnumType =
+        when (value) {
+          0 -> ENUM_TYPE_UNKNOWN
+          1 -> OPEN
+          2 -> CLOSED
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class RepeatedFieldEncoding(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object REPEATED_FIELD_ENCODING_UNKNOWN : RepeatedFieldEncoding(0, "REPEATED_FIELD_ENCODING_UNKNOWN")
+
+    public object PACKED : RepeatedFieldEncoding(1, "PACKED")
+
+    public object EXPANDED : RepeatedFieldEncoding(2, "EXPANDED")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : RepeatedFieldEncoding(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<RepeatedFieldEncoding> {
+      override fun deserialize(`value`: Int): RepeatedFieldEncoding =
+        when (value) {
+          0 -> REPEATED_FIELD_ENCODING_UNKNOWN
+          1 -> PACKED
+          2 -> EXPANDED
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class Utf8Validation(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object UTF8_VALIDATION_UNKNOWN : Utf8Validation(0, "UTF8_VALIDATION_UNKNOWN")
+
+    public object VERIFY : Utf8Validation(2, "VERIFY")
+
+    public object NONE : Utf8Validation(3, "NONE")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : Utf8Validation(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<Utf8Validation> {
+      override fun deserialize(`value`: Int): Utf8Validation =
+        when (value) {
+          0 -> UTF8_VALIDATION_UNKNOWN
+          2 -> VERIFY
+          3 -> NONE
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class MessageEncoding(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object MESSAGE_ENCODING_UNKNOWN : MessageEncoding(0, "MESSAGE_ENCODING_UNKNOWN")
+
+    public object LENGTH_PREFIXED : MessageEncoding(1, "LENGTH_PREFIXED")
+
+    public object DELIMITED : MessageEncoding(2, "DELIMITED")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : MessageEncoding(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<MessageEncoding> {
+      override fun deserialize(`value`: Int): MessageEncoding =
+        when (value) {
+          0 -> MESSAGE_ENCODING_UNKNOWN
+          1 -> LENGTH_PREFIXED
+          2 -> DELIMITED
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class JsonFormat(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object JSON_FORMAT_UNKNOWN : JsonFormat(0, "JSON_FORMAT_UNKNOWN")
+
+    public object ALLOW : JsonFormat(1, "ALLOW")
+
+    public object LEGACY_BEST_EFFORT : JsonFormat(2, "LEGACY_BEST_EFFORT")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : JsonFormat(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<JsonFormat> {
+      override fun deserialize(`value`: Int): JsonFormat =
+        when (value) {
+          0 -> JSON_FORMAT_UNKNOWN
+          1 -> ALLOW
+          2 -> LEGACY_BEST_EFFORT
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  public sealed class EnforceNamingStyle(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object ENFORCE_NAMING_STYLE_UNKNOWN : EnforceNamingStyle(0, "ENFORCE_NAMING_STYLE_UNKNOWN")
+
+    public object STYLE2024 : EnforceNamingStyle(1, "STYLE2024")
+
+    public object STYLE_LEGACY : EnforceNamingStyle(2, "STYLE_LEGACY")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : EnforceNamingStyle(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<EnforceNamingStyle> {
+      override fun deserialize(`value`: Int): EnforceNamingStyle =
+        when (value) {
+          0 -> ENFORCE_NAMING_STYLE_UNKNOWN
+          1 -> STYLE2024
+          2 -> STYLE_LEGACY
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+}
+
+/**
+ * A compiled specification for the defaults of a set of features.  These messages are generated from FeatureSet extensions and can be used to seed feature resolution. The resolution with this object becomes a simple search for the closest matching edition, followed by proto merges.
+ */
+@GeneratedMessage("google.protobuf.FeatureSetDefaults")
+public class FeatureSetDefaults private constructor(
+  @GeneratedProperty(1)
+  public val defaults: List<FeatureSetEditionDefault>,
+  /**
+   * The minimum supported edition (inclusive) when this was constructed. Editions before this will not have defaults.
+   */
+  @GeneratedProperty(4)
+  public val minimumEdition: Edition?,
+  /**
+   * The maximum known edition (inclusive) when this was constructed. Editions after this will not have reliable defaults.
+   */
+  @GeneratedProperty(5)
+  public val maximumEdition: Edition?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (defaults.isNotEmpty()) {
+      result += (sizeOf(10u) * defaults.size) + defaults.sumOf { sizeOf(it) }
+    }
+    if (minimumEdition != null) {
+      result += sizeOf(32u) + sizeOf(minimumEdition)
+    }
+    if (maximumEdition != null) {
+      result += sizeOf(40u) + sizeOf(maximumEdition)
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    defaults.forEach { writer.writeTag(10u).write(it) }
+    if (minimumEdition != null) {
+      writer.writeTag(32u).write(minimumEdition)
+    }
+    if (maximumEdition != null) {
+      writer.writeTag(40u).write(maximumEdition)
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is FeatureSetDefaults &&
+      other.defaults == this.defaults &&
+      other.minimumEdition == this.minimumEdition &&
+      other.maximumEdition == this.maximumEdition &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + defaults.hashCode()
+    result = 31 * result + minimumEdition.hashCode()
+    result = 31 * result + maximumEdition.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "FeatureSetDefaults(" +
+      "defaults=$defaults, " +
+      "minimumEdition=$minimumEdition, " +
+      "maximumEdition=$maximumEdition" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): FeatureSetDefaults =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var defaults: List<FeatureSetEditionDefault> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var minimumEdition: Edition? = null
+
+    public var maximumEdition: Edition? = null
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): FeatureSetDefaults =
+      FeatureSetDefaults(
+        freezeList(defaults),
+        minimumEdition,
+        maximumEdition,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: FeatureSetDefaults): Builder =
+        Builder().also {
+          it.defaults = msg.defaults
+          it.minimumEdition = msg.minimumEdition
+          it.maximumEdition = msg.maximumEdition
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<FeatureSetDefaults>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): FeatureSetDefaults {
+      var defaults: ListBuilder<FeatureSetEditionDefault>? = null
+      var minimumEdition: Edition? = null
+      var maximumEdition: Edition? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return FeatureSetDefaults(
+              defaults?.build() ?: emptyList(),
+              minimumEdition,
+              maximumEdition,
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            defaults =
+              (defaults ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FeatureSetEditionDefault))
+                }
+              }
+          }
+
+          32u -> {
+            minimumEdition = reader.readEnum(Edition)
+          }
+
+          40u -> {
+            maximumEdition = reader.readEnum(Edition)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): FeatureSetDefaults =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * A map from every known edition with a unique set of defaults to its defaults. Not all editions may be contained here.  For a given edition, the defaults at the closest matching edition ordered at or before it should be used.  This field must be in strict ascending order by edition.
+   */
+  @GeneratedMessage("google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault")
+  public class FeatureSetEditionDefault private constructor(
+    @GeneratedProperty(3)
+    public val edition: Edition?,
+    /**
+     * Defaults of features that can be overridden in this edition.
+     */
+    @GeneratedProperty(4)
+    public val overridableFeatures: FeatureSet?,
+    /**
+     * Defaults of features that can't be overridden in this edition.
+     */
+    @GeneratedProperty(5)
+    public val fixedFeatures: FeatureSet?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (edition != null) {
+        result += sizeOf(24u) + sizeOf(edition)
+      }
+      if (overridableFeatures != null) {
+        result += sizeOf(34u) + sizeOf(overridableFeatures)
+      }
+      if (fixedFeatures != null) {
+        result += sizeOf(42u) + sizeOf(fixedFeatures)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (edition != null) {
+        writer.writeTag(24u).write(edition)
+      }
+      if (overridableFeatures != null) {
+        writer.writeTag(34u).write(overridableFeatures)
+      }
+      if (fixedFeatures != null) {
+        writer.writeTag(42u).write(fixedFeatures)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is FeatureSetEditionDefault &&
+        other.edition == this.edition &&
+        other.overridableFeatures == this.overridableFeatures &&
+        other.fixedFeatures == this.fixedFeatures &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + edition.hashCode()
+      result = 31 * result + overridableFeatures.hashCode()
+      result = 31 * result + fixedFeatures.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "FeatureSetEditionDefault(" +
+        "edition=$edition, " +
+        "overridableFeatures=$overridableFeatures, " +
+        "fixedFeatures=$fixedFeatures" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): FeatureSetEditionDefault =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var edition: Edition? = null
+
+      public var overridableFeatures: FeatureSet? = null
+
+      public var fixedFeatures: FeatureSet? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): FeatureSetEditionDefault =
+        FeatureSetEditionDefault(
+          edition,
+          overridableFeatures,
+          fixedFeatures,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: FeatureSetEditionDefault): Builder =
+          Builder().also {
+            it.edition = msg.edition
+            it.overridableFeatures = msg.overridableFeatures
+            it.fixedFeatures = msg.fixedFeatures
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<FeatureSetEditionDefault>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): FeatureSetEditionDefault {
+        var edition: Edition? = null
+        var overridableFeatures: FeatureSet? = null
+        var fixedFeatures: FeatureSet? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return FeatureSetEditionDefault(
+                edition,
+                overridableFeatures,
+                fixedFeatures,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            24u -> {
+              edition = reader.readEnum(Edition)
+            }
+
+            34u -> {
+              overridableFeatures = reader.readMessage(FeatureSet)
+            }
+
+            42u -> {
+              fixedFeatures = reader.readMessage(FeatureSet)
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): FeatureSetEditionDefault =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+/**
+ * Encapsulates information about the original source file from which a FileDescriptorProto was generated.
+ */
+@GeneratedMessage("google.protobuf.SourceCodeInfo")
+public class SourceCodeInfo private constructor(
+  /**
+   * A Location identifies a piece of source code in a .proto file which corresponds to a particular definition.  This information is intended to be useful to IDEs, code indexers, documentation generators, and similar tools.
+   *
+   *  For example, say we have a file like:   message Foo {     optional string foo = 1;   } Let's look at just the field definition:   optional string foo = 1;   ^       ^^     ^^  ^  ^^^   a       bc     de  f  ghi We have the following locations:   span   path               represents   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+   *
+   *  Notes: - A location may refer to a repeated field itself (i.e. not to any   particular index within it).  This is used whenever a set of elements are   logically enclosed in a single code segment.  For example, an entire   extend block (possibly containing multiple extension definitions) will   have an outer location whose path refers to the "extensions" repeated   field without an index. - Multiple locations may have the same path.  This happens when a single   logical declaration is spread out across multiple places.  The most   obvious example is the "extend" block again -- there may be multiple   extend blocks in the same scope, each of which will have the same path. - A location's span is not always a subset of its parent's span.  For   example, the "extendee" of an extension declaration appears at the   beginning of the "extend" block and is shared by all extensions within   the block. - Just because a location's span is a subset of some other location's span   does not mean that it is a descendant.  For example, a "group" defines   both a type and a field in a single declaration.  Thus, the locations   corresponding to the type and field and their components will overlap. - Code which tries to interpret locations should probably be designed to   ignore those that it doesn't understand, as more types of locations could   be recorded in the future.
+   */
+  @GeneratedProperty(1)
+  public val location: List<Location>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (location.isNotEmpty()) {
+      result += (sizeOf(10u) * location.size) + location.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    location.forEach { writer.writeTag(10u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is SourceCodeInfo &&
+      other.location == this.location &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + location.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "SourceCodeInfo(" +
+      "location=$location" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): SourceCodeInfo =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var location: List<Location> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): SourceCodeInfo =
+      SourceCodeInfo(
+        freezeList(location),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: SourceCodeInfo): Builder =
+        Builder().also {
+          it.location = msg.location
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<SourceCodeInfo>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): SourceCodeInfo {
+      var location: ListBuilder<Location>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return SourceCodeInfo(
+              location?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            location =
+              (location ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(Location))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): SourceCodeInfo =
+      Builder().apply(dsl).build()
+  }
+
+  @GeneratedMessage("google.protobuf.SourceCodeInfo.Location")
+  public class Location private constructor(
+    /**
+     * Identifies which part of the FileDescriptorProto was defined at this location.
+     *
+     *  Each element is a field number or an index.  They form a path from the root FileDescriptorProto to the place where the definition appears. For example, this path:   [ 4, 3, 2, 7, 1 ] refers to:   file.message_type(3)  // 4, 3       .field(7)         // 2, 7       .name()           // 1 This is because FileDescriptorProto.message_type has field number 4:   repeated DescriptorProto message_type = 4; and DescriptorProto.field has field number 2:   repeated FieldDescriptorProto field = 2; and FieldDescriptorProto.name has field number 1:   optional string name = 1;
+     *
+     *  Thus, the above path gives the location of a field name.  If we removed the last element:   [ 4, 3, 2, 7 ] this path refers to the whole field declaration (from the beginning of the label to the terminating semicolon).
+     */
+    @GeneratedProperty(1)
+    public val path: List<Int>,
+    /**
+     * Always has exactly three or four elements: start line, start column, end line (optional, otherwise assumed same as start line), end column. These are packed into a single field for efficiency.  Note that line and column numbers are zero-based -- typically you will want to add 1 to each before displaying to a user.
+     */
+    @GeneratedProperty(2)
+    public val span: List<Int>,
+    private val _leadingComments: LazyReference<Bytes, String>?,
+    private val _trailingComments: LazyReference<Bytes, String>?,
+    @GeneratedProperty(6)
+    public val leadingDetachedComments: List<String>,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (path.isNotEmpty()) {
+        result += sizeOf(10u) + path.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
+      }
+      if (span.isNotEmpty()) {
+        result += sizeOf(18u) + span.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
+      }
+      if (_leadingComments != null) {
+        result += sizeOf(26u) + sizeOf(_leadingComments.wireValue())
+      }
+      if (_trailingComments != null) {
+        result += sizeOf(34u) + sizeOf(_trailingComments.wireValue())
+      }
+      if (leadingDetachedComments.isNotEmpty()) {
+        result +=
+          @Suppress("UNCHECKED_CAST")
+          (leadingDetachedComments as LazyConvertingList<Bytes, Any>).let { list ->
+            (sizeOf(50u) * list.size) +
+              run {
+                var sum = 0
+                for (i in list.indices) sum += sizeOf(list.wireGet(i))
+                sum
+              }
+          }
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    /**
+     * If this SourceCodeInfo represents a complete declaration, these are any comments appearing before and after the declaration which appear to be attached to the declaration.
+     *
+     *  A series of line comments appearing on consecutive lines, with no other tokens appearing on those lines, will be treated as a single comment.
+     *
+     *  leading_detached_comments will keep paragraphs of comments that appear before (but not connected to) the current element. Each paragraph, separated by empty lines, will be one comment element in the repeated field.
+     *
+     *  Only the comment content is provided; comment markers (e.g. //) are stripped out.  For block comments, leading whitespace and an asterisk will be stripped from the beginning of each line other than the first. Newlines are included in the output.
+     *
+     *  Examples:
+     *
+     *    optional int32 foo = 1;  // Comment attached to foo.   // Comment attached to bar.   optional int32 bar = 2;
+     *
+     *    optional string baz = 3;   // Comment attached to baz.   // Another line attached to baz.
+     *
+     *    // Comment attached to moo.   //   // Another line attached to moo.   optional double moo = 4;
+     *
+     *    // Detached comment for corge. This is not leading or trailing comments   // to moo or corge because there are blank lines separating it from   // both.
+     *
+     *    // Detached comment for corge paragraph 2.
+     *
+     *    optional string corge = 5;   &#47;* Block comment attached    * to corge.  Leading asterisks    * will be removed. *&#47;   &#47;* Block comment attached to    * grault. *&#47;   optional int32 grault = 6;
+     *
+     *    // ignored detached comments.
+     */
+    @GeneratedProperty(3)
+    public val leadingComments: String?
+      get() = _leadingComments?.value()
+
+    @GeneratedProperty(4)
+    public val trailingComments: String?
+      get() = _trailingComments?.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (path.isNotEmpty()) {
+        writer.writeTag(10u).writeUInt32(path.sumOf { sizeOf(it) }.toUInt())
+        path.forEach { writer.write(it) }
+      }
+      if (span.isNotEmpty()) {
+        writer.writeTag(18u).writeUInt32(span.sumOf { sizeOf(it) }.toUInt())
+        span.forEach { writer.write(it) }
+      }
+      if (_leadingComments != null) {
+        writer.writeTag(26u).write(_leadingComments.wireValue())
+      }
+      if (_trailingComments != null) {
+        writer.writeTag(34u).write(_trailingComments.wireValue())
+      }
+      if (leadingDetachedComments.isNotEmpty()) {
+        @Suppress("UNCHECKED_CAST")
+        (leadingDetachedComments as LazyConvertingList<Bytes, Any>).wireForEach { writer.writeTag(50u).write(it) }
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is Location &&
+        other.path == this.path &&
+        other.span == this.span &&
+        other.leadingComments == this.leadingComments &&
+        other.trailingComments == this.trailingComments &&
+        other.leadingDetachedComments == this.leadingDetachedComments &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + path.hashCode()
+      result = 31 * result + span.hashCode()
+      result = 31 * result + leadingComments.hashCode()
+      result = 31 * result + trailingComments.hashCode()
+      result = 31 * result + leadingDetachedComments.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "Location(" +
+        "path=$path, " +
+        "span=$span, " +
+        "leadingComments=$leadingComments, " +
+        "trailingComments=$trailingComments, " +
+        "leadingDetachedComments=$leadingDetachedComments" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): Location =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var path: List<Int> = emptyList()
+        set(newValue) {
+          field = freezeList(newValue)
+        }
+
+      public var span: List<Int> = emptyList()
+        set(newValue) {
+          field = freezeList(newValue)
+        }
+
+      private var _leadingCommentsRef: LazyReference<Bytes, String>? = null
+
+      public var leadingComments: String?
+        get() = _leadingCommentsRef?.value()
+        set(newValue) {
+          _leadingCommentsRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      private var _trailingCommentsRef: LazyReference<Bytes, String>? = null
+
+      public var trailingComments: String?
+        get() = _trailingCommentsRef?.value()
+        set(newValue) {
+          _trailingCommentsRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      public var leadingDetachedComments: List<String> = emptyList()
+        set(newValue) {
+          field = if (newValue is LazyConvertingList<*, *>) newValue else LazyConvertingList.fromKotlin(newValue, StringConverter)
+        }
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): Location =
+        Location(
+          freezeList(path),
+          freezeList(span),
+          _leadingCommentsRef,
+          _trailingCommentsRef,
+          leadingDetachedComments,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: Location): Builder =
+          Builder().also {
+            it.path = msg.path
+            it.span = msg.span
+            it._leadingCommentsRef = msg._leadingComments
+            it._trailingCommentsRef = msg._trailingComments
+            it.leadingDetachedComments = msg.leadingDetachedComments
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<Location>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): Location {
+        var path: ListBuilder<Int>? = null
+        var span: ListBuilder<Int>? = null
+        var leadingComments: Bytes? = null
+        var trailingComments: Bytes? = null
+        var leadingDetachedComments: ListBuilder<Any?>? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return Location(
+                path?.build() ?: emptyList(),
+                span?.build() ?: emptyList(),
+                leadingComments?.let { LazyReference(it, StringConverter) },
+                trailingComments?.let { LazyReference(it, StringConverter) },
+                leadingDetachedComments?.build()?.let { LazyConvertingList<Bytes, String>(it, StringConverter) } ?: emptyList(),
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              path =
+                (path ?: listBuilder()).apply {
+                  reader.readRepeated(false) {
+                    add(reader.readInt32())
+                  }
+                }
+            }
+
+            10u -> {
+              path =
+                (path ?: listBuilder()).apply {
+                  reader.readRepeated(true) {
+                    add(reader.readInt32())
+                  }
+                }
+            }
+
+            16u -> {
+              span =
+                (span ?: listBuilder()).apply {
+                  reader.readRepeated(false) {
+                    add(reader.readInt32())
+                  }
+                }
+            }
+
+            18u -> {
+              span =
+                (span ?: listBuilder()).apply {
+                  reader.readRepeated(true) {
+                    add(reader.readInt32())
+                  }
+                }
+            }
+
+            26u -> {
+              leadingComments = StringConverter.readValidatedBytes(reader)
+            }
+
+            34u -> {
+              trailingComments = StringConverter.readValidatedBytes(reader)
+            }
+
+            50u -> {
+              leadingDetachedComments =
+                (leadingDetachedComments ?: listBuilder()).apply {
+                  reader.readRepeated(false) {
+                    add(LazyReference(StringConverter.readValidatedBytes(reader), StringConverter))
+                  }
+                }
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): Location =
+        Builder().apply(dsl).build()
+    }
+  }
+}
+
+/**
+ * Describes the relationship between generated code and its original source file. A GeneratedCodeInfo message is associated with only one generated source file, but may contain references to different source .proto files.
+ */
+@GeneratedMessage("google.protobuf.GeneratedCodeInfo")
+public class GeneratedCodeInfo private constructor(
+  /**
+   * An Annotation connects some span of text in generated code to an element of its generating .proto file.
+   */
+  @GeneratedProperty(1)
+  public val `annotation`: List<Annotation>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (`annotation`.isNotEmpty()) {
+      result += (sizeOf(10u) * `annotation`.size) + `annotation`.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    `annotation`.forEach { writer.writeTag(10u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is GeneratedCodeInfo &&
+      other.`annotation` == this.`annotation` &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + `annotation`.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "GeneratedCodeInfo(" +
+      "`annotation`=$`annotation`" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): GeneratedCodeInfo =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var `annotation`: List<Annotation> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): GeneratedCodeInfo =
+      GeneratedCodeInfo(
+        freezeList(`annotation`),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: GeneratedCodeInfo): Builder =
+        Builder().also {
+          it.`annotation` = msg.`annotation`
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<GeneratedCodeInfo>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): GeneratedCodeInfo {
+      var `annotation`: ListBuilder<Annotation>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return GeneratedCodeInfo(
+              `annotation`?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            `annotation` =
+              (`annotation` ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(Annotation))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): GeneratedCodeInfo =
+      Builder().apply(dsl).build()
+  }
+
+  @GeneratedMessage("google.protobuf.GeneratedCodeInfo.Annotation")
+  public class Annotation private constructor(
+    /**
+     * Identifies the element in the original source .proto file. This field is formatted the same as SourceCodeInfo.Location.path.
+     */
+    @GeneratedProperty(1)
+    public val path: List<Int>,
+    private val _sourceFile: LazyReference<Bytes, String>?,
+    /**
+     * Identifies the starting offset in bytes in the generated code that relates to the identified object.
+     */
+    @GeneratedProperty(3)
+    public val begin: Int?,
+    /**
+     * Identifies the ending offset in bytes in the generated code that relates to the identified object. The end offset should be one past the last relevant byte (so the length of the text = end - begin).
+     */
+    @GeneratedProperty(4)
+    public val end: Int?,
+    @GeneratedProperty(5)
+    public val semantic: Semantic?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (path.isNotEmpty()) {
+        result += sizeOf(10u) + path.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
+      }
+      if (_sourceFile != null) {
+        result += sizeOf(18u) + sizeOf(_sourceFile.wireValue())
+      }
+      if (begin != null) {
+        result += sizeOf(24u) + sizeOf(begin)
+      }
+      if (end != null) {
+        result += sizeOf(32u) + sizeOf(end)
+      }
+      if (semantic != null) {
+        result += sizeOf(40u) + sizeOf(semantic)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    /**
+     * Identifies the filesystem path to the original source .proto.
+     */
+    @GeneratedProperty(2)
+    public val sourceFile: String?
+      get() = _sourceFile?.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (path.isNotEmpty()) {
+        writer.writeTag(10u).writeUInt32(path.sumOf { sizeOf(it) }.toUInt())
+        path.forEach { writer.write(it) }
+      }
+      if (_sourceFile != null) {
+        writer.writeTag(18u).write(_sourceFile.wireValue())
+      }
+      if (begin != null) {
+        writer.writeTag(24u).write(begin)
+      }
+      if (end != null) {
+        writer.writeTag(32u).write(end)
+      }
+      if (semantic != null) {
+        writer.writeTag(40u).write(semantic)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is Annotation &&
+        other.path == this.path &&
+        other.sourceFile == this.sourceFile &&
+        other.begin == this.begin &&
+        other.end == this.end &&
+        other.semantic == this.semantic &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + path.hashCode()
+      result = 31 * result + sourceFile.hashCode()
+      result = 31 * result + begin.hashCode()
+      result = 31 * result + end.hashCode()
+      result = 31 * result + semantic.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "Annotation(" +
+        "path=$path, " +
+        "sourceFile=$sourceFile, " +
+        "begin=$begin, " +
+        "end=$end, " +
+        "semantic=$semantic" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): Annotation =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      public var path: List<Int> = emptyList()
+        set(newValue) {
+          field = freezeList(newValue)
+        }
+
+      private var _sourceFileRef: LazyReference<Bytes, String>? = null
+
+      public var sourceFile: String?
+        get() = _sourceFileRef?.value()
+        set(newValue) {
+          _sourceFileRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      public var begin: Int? = null
+
+      public var end: Int? = null
+
+      public var semantic: Semantic? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): Annotation =
+        Annotation(
+          freezeList(path),
+          _sourceFileRef,
+          begin,
+          end,
+          semantic,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: Annotation): Builder =
+          Builder().also {
+            it.path = msg.path
+            it._sourceFileRef = msg._sourceFile
+            it.begin = msg.begin
+            it.end = msg.end
+            it.semantic = msg.semantic
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<Annotation>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): Annotation {
+        var path: ListBuilder<Int>? = null
+        var sourceFile: Bytes? = null
+        var begin: Int? = null
+        var end: Int? = null
+        var semantic: Semantic? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return Annotation(
+                path?.build() ?: emptyList(),
+                sourceFile?.let { LazyReference(it, StringConverter) },
+                begin,
+                end,
+                semantic,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            8u -> {
+              path =
+                (path ?: listBuilder()).apply {
+                  reader.readRepeated(false) {
+                    add(reader.readInt32())
+                  }
+                }
+            }
+
+            10u -> {
+              path =
+                (path ?: listBuilder()).apply {
+                  reader.readRepeated(true) {
+                    add(reader.readInt32())
+                  }
+                }
+            }
+
+            18u -> {
+              sourceFile = StringConverter.readValidatedBytes(reader)
+            }
+
+            24u -> {
+              begin = reader.readInt32()
+            }
+
+            32u -> {
+              end = reader.readInt32()
+            }
+
+            40u -> {
+              semantic = reader.readEnum(Semantic)
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): Annotation =
+        Builder().apply(dsl).build()
+    }
+
+    /**
+     * Represents the identified object's effect on the element in the original .proto file.
+     */
+    public sealed class Semantic(
+      override val `value`: Int,
+      override val name: String
+    ) : Enum() {
+      /**
+       * There is no effect or the effect is indescribable.
+       */
+      public object NONE : Semantic(0, "NONE")
+
+      /**
+       * The element is set or otherwise mutated.
+       */
+      public object SET : Semantic(1, "SET")
+
+      /**
+       * An alias to the element is returned.
+       */
+      public object ALIAS : Semantic(2, "ALIAS")
+
+      public class UNRECOGNIZED(
+        `value`: Int
+      ) : Semantic(value, "UNRECOGNIZED")
+
+      public companion object Deserializer : EnumDeserializer<Semantic> {
+        override fun deserialize(`value`: Int): Semantic =
+          when (value) {
+            0 -> NONE
+            1 -> SET
+            2 -> ALIAS
+            else -> UNRECOGNIZED(value)
+          }
+      }
+    }
+  }
+}

--- a/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/compiler/Plugin.kt
+++ b/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/compiler/Plugin.kt
@@ -1,0 +1,952 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("DEPRECATION")
+@file:OptIn(protokt.v1.OnlyForUseByGeneratedProtoCode::class)
+
+package protokt.v1.google.protobuf.compiler
+
+import protokt.v1.AbstractDeserializer
+import protokt.v1.AbstractMessage
+import protokt.v1.BuilderDsl
+import protokt.v1.BuilderScope
+import protokt.v1.Bytes
+import protokt.v1.Collections.freezeList
+import protokt.v1.Collections.listBuilder
+import protokt.v1.Enum
+import protokt.v1.EnumDeserializer
+import protokt.v1.GeneratedMessage
+import protokt.v1.GeneratedProperty
+import protokt.v1.LazyConvertingList
+import protokt.v1.LazyReference
+import protokt.v1.ListBuilder
+import protokt.v1.OnlyForUseByGeneratedProtoCode
+import protokt.v1.Reader
+import protokt.v1.Sizes.sizeOf
+import protokt.v1.StringConverter
+import protokt.v1.UnknownFieldSet
+import protokt.v1.Writer
+import protokt.v1.google.protobuf.FileDescriptorProto
+import protokt.v1.google.protobuf.GeneratedCodeInfo
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.OptIn
+import kotlin.String
+import kotlin.Suppress
+import kotlin.ULong
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmStatic
+
+/**
+ * The version number of protocol compiler.
+ */
+@GeneratedMessage("google.protobuf.compiler.Version")
+public class Version private constructor(
+  @GeneratedProperty(1)
+  public val major: Int?,
+  @GeneratedProperty(2)
+  public val minor: Int?,
+  @GeneratedProperty(3)
+  public val patch: Int?,
+  private val _suffix: LazyReference<Bytes, String>?,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (major != null) {
+      result += sizeOf(8u) + sizeOf(major)
+    }
+    if (minor != null) {
+      result += sizeOf(16u) + sizeOf(minor)
+    }
+    if (patch != null) {
+      result += sizeOf(24u) + sizeOf(patch)
+    }
+    if (_suffix != null) {
+      result += sizeOf(34u) + sizeOf(_suffix.wireValue())
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should be empty for mainline stable releases.
+   */
+  @GeneratedProperty(4)
+  public val suffix: String?
+    get() = _suffix?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (major != null) {
+      writer.writeTag(8u).write(major)
+    }
+    if (minor != null) {
+      writer.writeTag(16u).write(minor)
+    }
+    if (patch != null) {
+      writer.writeTag(24u).write(patch)
+    }
+    if (_suffix != null) {
+      writer.writeTag(34u).write(_suffix.wireValue())
+    }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is Version &&
+      other.major == this.major &&
+      other.minor == this.minor &&
+      other.patch == this.patch &&
+      other.suffix == this.suffix &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + major.hashCode()
+    result = 31 * result + minor.hashCode()
+    result = 31 * result + patch.hashCode()
+    result = 31 * result + suffix.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "Version(" +
+      "major=$major, " +
+      "minor=$minor, " +
+      "patch=$patch, " +
+      "suffix=$suffix" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): Version =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var major: Int? = null
+
+    public var minor: Int? = null
+
+    public var patch: Int? = null
+
+    private var _suffixRef: LazyReference<Bytes, String>? = null
+
+    public var suffix: String?
+      get() = _suffixRef?.value()
+      set(newValue) {
+        _suffixRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): Version =
+      Version(
+        major,
+        minor,
+        patch,
+        _suffixRef,
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: Version): Builder =
+        Builder().also {
+          it.major = msg.major
+          it.minor = msg.minor
+          it.patch = msg.patch
+          it._suffixRef = msg._suffix
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<Version>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): Version {
+      var major: Int? = null
+      var minor: Int? = null
+      var patch: Int? = null
+      var suffix: Bytes? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return Version(
+              major,
+              minor,
+              patch,
+              suffix?.let { LazyReference(it, StringConverter) },
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          8u -> {
+            major = reader.readInt32()
+          }
+
+          16u -> {
+            minor = reader.readInt32()
+          }
+
+          24u -> {
+            patch = reader.readInt32()
+          }
+
+          34u -> {
+            suffix = StringConverter.readValidatedBytes(reader)
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): Version =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * An encoded CodeGeneratorRequest is written to the plugin's stdin.
+ */
+@GeneratedMessage("google.protobuf.compiler.CodeGeneratorRequest")
+public class CodeGeneratorRequest private constructor(
+  /**
+   * The .proto files that were explicitly listed on the command-line.  The code generator should generate code only for these files.  Each file's descriptor will be included in proto_file, below.
+   */
+  @GeneratedProperty(1)
+  public val fileToGenerate: List<String>,
+  private val _parameter: LazyReference<Bytes, String>?,
+  /**
+   * The version number of protocol compiler.
+   */
+  @GeneratedProperty(3)
+  public val compilerVersion: Version?,
+  /**
+   * FileDescriptorProtos for all files in files_to_generate and everything they import.  The files will appear in topological order, so each file appears before any file that imports it.
+   *
+   *  Note: the files listed in files_to_generate will include runtime-retention options only, but all other files will include source-retention options. The source_file_descriptors field below is available in case you need source-retention options for files_to_generate.
+   *
+   *  protoc guarantees that all proto_files will be written after the fields above, even though this is not technically guaranteed by the protobuf wire format.  This theoretically could allow a plugin to stream in the FileDescriptorProtos and handle them one by one rather than read the entire set into memory at once.  However, as of this writing, this is not similarly optimized on protoc's end -- it will store all fields in memory at once before sending them to the plugin.
+   *
+   *  Type names of fields and extensions in the FileDescriptorProto are always fully qualified.
+   */
+  @GeneratedProperty(15)
+  public val protoFile: List<FileDescriptorProto>,
+  /**
+   * File descriptors with all options, including source-retention options. These descriptors are only provided for the files listed in files_to_generate.
+   */
+  @GeneratedProperty(17)
+  public val sourceFileDescriptors: List<FileDescriptorProto>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (fileToGenerate.isNotEmpty()) {
+      result +=
+        @Suppress("UNCHECKED_CAST")
+        (fileToGenerate as LazyConvertingList<Bytes, Any>).let { list ->
+          (sizeOf(10u) * list.size) +
+            run {
+              var sum = 0
+              for (i in list.indices) sum += sizeOf(list.wireGet(i))
+              sum
+            }
+        }
+    }
+    if (_parameter != null) {
+      result += sizeOf(18u) + sizeOf(_parameter.wireValue())
+    }
+    if (compilerVersion != null) {
+      result += sizeOf(26u) + sizeOf(compilerVersion)
+    }
+    if (protoFile.isNotEmpty()) {
+      result += (sizeOf(122u) * protoFile.size) + protoFile.sumOf { sizeOf(it) }
+    }
+    if (sourceFileDescriptors.isNotEmpty()) {
+      result += (sizeOf(138u) * sourceFileDescriptors.size) + sourceFileDescriptors.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * The generator parameter passed on the command-line.
+   */
+  @GeneratedProperty(2)
+  public val parameter: String?
+    get() = _parameter?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (fileToGenerate.isNotEmpty()) {
+      @Suppress("UNCHECKED_CAST")
+      (fileToGenerate as LazyConvertingList<Bytes, Any>).wireForEach { writer.writeTag(10u).write(it) }
+    }
+    if (_parameter != null) {
+      writer.writeTag(18u).write(_parameter.wireValue())
+    }
+    if (compilerVersion != null) {
+      writer.writeTag(26u).write(compilerVersion)
+    }
+    protoFile.forEach { writer.writeTag(122u).write(it) }
+    sourceFileDescriptors.forEach { writer.writeTag(138u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is CodeGeneratorRequest &&
+      other.fileToGenerate == this.fileToGenerate &&
+      other.parameter == this.parameter &&
+      other.compilerVersion == this.compilerVersion &&
+      other.protoFile == this.protoFile &&
+      other.sourceFileDescriptors == this.sourceFileDescriptors &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + fileToGenerate.hashCode()
+    result = 31 * result + parameter.hashCode()
+    result = 31 * result + compilerVersion.hashCode()
+    result = 31 * result + protoFile.hashCode()
+    result = 31 * result + sourceFileDescriptors.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "CodeGeneratorRequest(" +
+      "fileToGenerate=$fileToGenerate, " +
+      "parameter=$parameter, " +
+      "compilerVersion=$compilerVersion, " +
+      "protoFile=$protoFile, " +
+      "sourceFileDescriptors=$sourceFileDescriptors" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): CodeGeneratorRequest =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    public var fileToGenerate: List<String> = emptyList()
+      set(newValue) {
+        field = if (newValue is LazyConvertingList<*, *>) newValue else LazyConvertingList.fromKotlin(newValue, StringConverter)
+      }
+
+    private var _parameterRef: LazyReference<Bytes, String>? = null
+
+    public var parameter: String?
+      get() = _parameterRef?.value()
+      set(newValue) {
+        _parameterRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var compilerVersion: Version? = null
+
+    public var protoFile: List<FileDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var sourceFileDescriptors: List<FileDescriptorProto> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): CodeGeneratorRequest =
+      CodeGeneratorRequest(
+        fileToGenerate,
+        _parameterRef,
+        compilerVersion,
+        freezeList(protoFile),
+        freezeList(sourceFileDescriptors),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: CodeGeneratorRequest): Builder =
+        Builder().also {
+          it.fileToGenerate = msg.fileToGenerate
+          it._parameterRef = msg._parameter
+          it.compilerVersion = msg.compilerVersion
+          it.protoFile = msg.protoFile
+          it.sourceFileDescriptors = msg.sourceFileDescriptors
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<CodeGeneratorRequest>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): CodeGeneratorRequest {
+      var fileToGenerate: ListBuilder<Any?>? = null
+      var parameter: Bytes? = null
+      var compilerVersion: Version? = null
+      var protoFile: ListBuilder<FileDescriptorProto>? = null
+      var sourceFileDescriptors: ListBuilder<FileDescriptorProto>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return CodeGeneratorRequest(
+              fileToGenerate?.build()?.let { LazyConvertingList<Bytes, String>(it, StringConverter) } ?: emptyList(),
+              parameter?.let { LazyReference(it, StringConverter) },
+              compilerVersion,
+              protoFile?.build() ?: emptyList(),
+              sourceFileDescriptors?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            fileToGenerate =
+              (fileToGenerate ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(LazyReference(StringConverter.readValidatedBytes(reader), StringConverter))
+                }
+              }
+          }
+
+          18u -> {
+            parameter = StringConverter.readValidatedBytes(reader)
+          }
+
+          26u -> {
+            compilerVersion = reader.readMessage(Version)
+          }
+
+          122u -> {
+            protoFile =
+              (protoFile ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FileDescriptorProto))
+                }
+              }
+          }
+
+          138u -> {
+            sourceFileDescriptors =
+              (sourceFileDescriptors ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(FileDescriptorProto))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): CodeGeneratorRequest =
+      Builder().apply(dsl).build()
+  }
+}
+
+/**
+ * The plugin writes an encoded CodeGeneratorResponse to stdout.
+ */
+@GeneratedMessage("google.protobuf.compiler.CodeGeneratorResponse")
+public class CodeGeneratorResponse private constructor(
+  private val _error: LazyReference<Bytes, String>?,
+  /**
+   * A bitmask of supported features that the code generator supports. This is a bitwise "or" of values from the Feature enum.
+   */
+  @GeneratedProperty(2)
+  public val supportedFeatures: ULong?,
+  /**
+   * The minimum edition this plugin supports.  This will be treated as an Edition enum, but we want to allow unknown values.  It should be specified according the edition enum value, *not* the edition number.  Only takes effect for plugins that have FEATURE_SUPPORTS_EDITIONS set.
+   */
+  @GeneratedProperty(3)
+  public val minimumEdition: Int?,
+  /**
+   * The maximum edition this plugin supports.  This will be treated as an Edition enum, but we want to allow unknown values.  It should be specified according the edition enum value, *not* the edition number.  Only takes effect for plugins that have FEATURE_SUPPORTS_EDITIONS set.
+   */
+  @GeneratedProperty(4)
+  public val maximumEdition: Int?,
+  @GeneratedProperty(15)
+  public val `file`: List<File>,
+  override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+) : AbstractMessage() {
+  private val __serializedSize: Int by lazy {
+    var result = 0
+    if (_error != null) {
+      result += sizeOf(10u) + sizeOf(_error.wireValue())
+    }
+    if (supportedFeatures != null) {
+      result += sizeOf(16u) + sizeOf(supportedFeatures)
+    }
+    if (minimumEdition != null) {
+      result += sizeOf(24u) + sizeOf(minimumEdition)
+    }
+    if (maximumEdition != null) {
+      result += sizeOf(32u) + sizeOf(maximumEdition)
+    }
+    if (`file`.isNotEmpty()) {
+      result += (sizeOf(122u) * `file`.size) + `file`.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    result
+  }
+
+  /**
+   * Error message.  If non-empty, code generation failed.  The plugin process should exit with status code zero even if it reports an error in this way.
+   *
+   *  This should be used to indicate errors in .proto files which prevent the code generator from generating correct code.  Errors which indicate a problem in protoc itself -- such as the input CodeGeneratorRequest being unparseable -- should be reported by writing a message to stderr and exiting with a non-zero status code.
+   */
+  @GeneratedProperty(1)
+  public val error: String?
+    get() = _error?.value()
+
+  override fun serializedSize(): Int =
+    __serializedSize
+
+  override fun serialize(writer: Writer) {
+    if (_error != null) {
+      writer.writeTag(10u).write(_error.wireValue())
+    }
+    if (supportedFeatures != null) {
+      writer.writeTag(16u).writeUInt64(supportedFeatures)
+    }
+    if (minimumEdition != null) {
+      writer.writeTag(24u).write(minimumEdition)
+    }
+    if (maximumEdition != null) {
+      writer.writeTag(32u).write(maximumEdition)
+    }
+    `file`.forEach { writer.writeTag(122u).write(it) }
+    writer.writeUnknown(unknownFields)
+  }
+
+  override fun equals(other: Any?): Boolean =
+    other is CodeGeneratorResponse &&
+      other.error == this.error &&
+      other.supportedFeatures == this.supportedFeatures &&
+      other.minimumEdition == this.minimumEdition &&
+      other.maximumEdition == this.maximumEdition &&
+      other.`file` == this.`file` &&
+      other.unknownFields == unknownFields
+
+  override fun hashCode(): Int {
+    var result = unknownFields.hashCode()
+    result = 31 * result + error.hashCode()
+    result = 31 * result + supportedFeatures.hashCode()
+    result = 31 * result + minimumEdition.hashCode()
+    result = 31 * result + maximumEdition.hashCode()
+    result = 31 * result + `file`.hashCode()
+    return result
+  }
+
+  override fun toString(): String =
+    "CodeGeneratorResponse(" +
+      "error=$error, " +
+      "supportedFeatures=$supportedFeatures, " +
+      "minimumEdition=$minimumEdition, " +
+      "maximumEdition=$maximumEdition, " +
+      "`file`=$`file`" +
+      if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+  public fun toBuilder(): Builder =
+    Builder.from(this)
+
+  public fun copy(builder: Builder.() -> Unit): CodeGeneratorResponse =
+    toBuilder().apply { builder() }.build()
+
+  @BuilderDsl
+  public class Builder : BuilderScope {
+    private var _errorRef: LazyReference<Bytes, String>? = null
+
+    public var error: String?
+      get() = _errorRef?.value()
+      set(newValue) {
+        _errorRef = newValue?.let { LazyReference(it, StringConverter) }
+      }
+
+    public var supportedFeatures: ULong? = null
+
+    public var minimumEdition: Int? = null
+
+    public var maximumEdition: Int? = null
+
+    public var `file`: List<File> = emptyList()
+      set(newValue) {
+        field = freezeList(newValue)
+      }
+
+    public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+    public fun build(): CodeGeneratorResponse =
+      CodeGeneratorResponse(
+        _errorRef,
+        supportedFeatures,
+        minimumEdition,
+        maximumEdition,
+        freezeList(`file`),
+        unknownFields
+      )
+
+    public companion object Factory {
+      @OnlyForUseByGeneratedProtoCode
+      internal fun from(msg: CodeGeneratorResponse): Builder =
+        Builder().also {
+          it._errorRef = msg._error
+          it.supportedFeatures = msg.supportedFeatures
+          it.minimumEdition = msg.minimumEdition
+          it.maximumEdition = msg.maximumEdition
+          it.`file` = msg.`file`
+          it.unknownFields = msg.unknownFields
+        }
+    }
+  }
+
+  public companion object Deserializer : AbstractDeserializer<CodeGeneratorResponse>() {
+    @JvmStatic
+    override fun deserialize(reader: Reader): CodeGeneratorResponse {
+      var error: Bytes? = null
+      var supportedFeatures: ULong? = null
+      var minimumEdition: Int? = null
+      var maximumEdition: Int? = null
+      var `file`: ListBuilder<File>? = null
+      var unknownFields: UnknownFieldSet.Builder? = null
+
+      while (true) {
+        when (reader.readTag()) {
+          0u -> {
+            return CodeGeneratorResponse(
+              error?.let { LazyReference(it, StringConverter) },
+              supportedFeatures,
+              minimumEdition,
+              maximumEdition,
+              `file`?.build() ?: emptyList(),
+              UnknownFieldSet.from(unknownFields)
+            )
+          }
+
+          10u -> {
+            error = StringConverter.readValidatedBytes(reader)
+          }
+
+          16u -> {
+            supportedFeatures = reader.readUInt64()
+          }
+
+          24u -> {
+            minimumEdition = reader.readInt32()
+          }
+
+          32u -> {
+            maximumEdition = reader.readInt32()
+          }
+
+          122u -> {
+            `file` =
+              (`file` ?: listBuilder()).apply {
+                reader.readRepeated(false) {
+                  add(reader.readMessage(File))
+                }
+              }
+          }
+
+          else -> {
+            unknownFields =
+              (unknownFields ?: UnknownFieldSet.Builder()).also {
+                it.add(reader.readUnknown())
+              }
+          }
+        }
+      }
+    }
+
+    @JvmStatic
+    public operator fun invoke(dsl: Builder.() -> Unit): CodeGeneratorResponse =
+      Builder().apply(dsl).build()
+  }
+
+  /**
+   * Sync with code_generator.h.
+   */
+  public sealed class Feature(
+    override val `value`: Int,
+    override val name: String
+  ) : Enum() {
+    public object NONE : Feature(0, "NONE")
+
+    public object PROTO3_OPTIONAL : Feature(1, "PROTO3_OPTIONAL")
+
+    public object SUPPORTS_EDITIONS : Feature(2, "SUPPORTS_EDITIONS")
+
+    public class UNRECOGNIZED(
+      `value`: Int
+    ) : Feature(value, "UNRECOGNIZED")
+
+    public companion object Deserializer : EnumDeserializer<Feature> {
+      override fun deserialize(`value`: Int): Feature =
+        when (value) {
+          0 -> NONE
+          1 -> PROTO3_OPTIONAL
+          2 -> SUPPORTS_EDITIONS
+          else -> UNRECOGNIZED(value)
+        }
+    }
+  }
+
+  /**
+   * Represents a single generated file.
+   */
+  @GeneratedMessage("google.protobuf.compiler.CodeGeneratorResponse.File")
+  public class File private constructor(
+    private val _name: LazyReference<Bytes, String>?,
+    private val _insertionPoint: LazyReference<Bytes, String>?,
+    private val _content: LazyReference<Bytes, String>?,
+    /**
+     * Information describing the file content being inserted. If an insertion point is used, this information will be appropriately offset and inserted into the code generation metadata for the generated files.
+     */
+    @GeneratedProperty(16)
+    public val generatedCodeInfo: GeneratedCodeInfo?,
+    override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+  ) : AbstractMessage() {
+    private val __serializedSize: Int by lazy {
+      var result = 0
+      if (_name != null) {
+        result += sizeOf(10u) + sizeOf(_name.wireValue())
+      }
+      if (_insertionPoint != null) {
+        result += sizeOf(18u) + sizeOf(_insertionPoint.wireValue())
+      }
+      if (_content != null) {
+        result += sizeOf(122u) + sizeOf(_content.wireValue())
+      }
+      if (generatedCodeInfo != null) {
+        result += sizeOf(130u) + sizeOf(generatedCodeInfo)
+      }
+      result += unknownFields.size()
+      result
+    }
+
+    /**
+     * The file name, relative to the output directory.  The name must not contain "." or ".." components and must be relative, not be absolute (so, the file cannot lie outside the output directory).  "/" must be used as the path separator, not "\".
+     *
+     *  If the name is omitted, the content will be appended to the previous file.  This allows the generator to break large files into small chunks, and allows the generated text to be streamed back to protoc so that large files need not reside completely in memory at one time.  Note that as of this writing protoc does not optimize for this -- it will read the entire CodeGeneratorResponse before writing files to disk.
+     */
+    @GeneratedProperty(1)
+    public val name: String?
+      get() = _name?.value()
+
+    /**
+     * If non-empty, indicates that the named file should already exist, and the content here is to be inserted into that file at a defined insertion point.  This feature allows a code generator to extend the output produced by another code generator.  The original generator may provide insertion points by placing special annotations in the file that look like:   @@protoc_insertion_point(NAME) The annotation can have arbitrary text before and after it on the line, which allows it to be placed in a comment.  NAME should be replaced with an identifier naming the point -- this is what other generators will use as the insertion_point.  Code inserted at this point will be placed immediately above the line containing the insertion point (thus multiple insertions to the same point will come out in the order they were added). The double-@ is intended to make it unlikely that the generated code could contain things that look like insertion points by accident.
+     *
+     *  For example, the C++ code generator places the following line in the .pb.h files that it generates:   // @@protoc_insertion_point(namespace_scope) This line appears within the scope of the file's package namespace, but outside of any particular class.  Another plugin can then specify the insertion_point "namespace_scope" to generate additional classes or other declarations that should be placed in this scope.
+     *
+     *  Note that if the line containing the insertion point begins with whitespace, the same whitespace will be added to every line of the inserted text.  This is useful for languages like Python, where indentation matters.  In these languages, the insertion point comment should be indented the same amount as any inserted code will need to be in order to work correctly in that context.
+     *
+     *  The code generator that generates the initial file and the one which inserts into it must both run as part of a single invocation of protoc. Code generators are executed in the order in which they appear on the command line.
+     *
+     *  If |insertion_point| is present, |name| must also be present.
+     */
+    @GeneratedProperty(2)
+    public val insertionPoint: String?
+      get() = _insertionPoint?.value()
+
+    /**
+     * The file contents.
+     */
+    @GeneratedProperty(15)
+    public val content: String?
+      get() = _content?.value()
+
+    override fun serializedSize(): Int =
+      __serializedSize
+
+    override fun serialize(writer: Writer) {
+      if (_name != null) {
+        writer.writeTag(10u).write(_name.wireValue())
+      }
+      if (_insertionPoint != null) {
+        writer.writeTag(18u).write(_insertionPoint.wireValue())
+      }
+      if (_content != null) {
+        writer.writeTag(122u).write(_content.wireValue())
+      }
+      if (generatedCodeInfo != null) {
+        writer.writeTag(130u).write(generatedCodeInfo)
+      }
+      writer.writeUnknown(unknownFields)
+    }
+
+    override fun equals(other: Any?): Boolean =
+      other is File &&
+        other.name == this.name &&
+        other.insertionPoint == this.insertionPoint &&
+        other.content == this.content &&
+        other.generatedCodeInfo == this.generatedCodeInfo &&
+        other.unknownFields == unknownFields
+
+    override fun hashCode(): Int {
+      var result = unknownFields.hashCode()
+      result = 31 * result + name.hashCode()
+      result = 31 * result + insertionPoint.hashCode()
+      result = 31 * result + content.hashCode()
+      result = 31 * result + generatedCodeInfo.hashCode()
+      return result
+    }
+
+    override fun toString(): String =
+      "File(" +
+        "name=$name, " +
+        "insertionPoint=$insertionPoint, " +
+        "content=$content, " +
+        "generatedCodeInfo=$generatedCodeInfo" +
+        if (unknownFields.isEmpty()) ")" else ", unknownFields=$unknownFields)"
+
+    public fun toBuilder(): Builder =
+      Builder.from(this)
+
+    public fun copy(builder: Builder.() -> Unit): File =
+      toBuilder().apply { builder() }.build()
+
+    @BuilderDsl
+    public class Builder : BuilderScope {
+      private var _nameRef: LazyReference<Bytes, String>? = null
+
+      public var name: String?
+        get() = _nameRef?.value()
+        set(newValue) {
+          _nameRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      private var _insertionPointRef: LazyReference<Bytes, String>? = null
+
+      public var insertionPoint: String?
+        get() = _insertionPointRef?.value()
+        set(newValue) {
+          _insertionPointRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      private var _contentRef: LazyReference<Bytes, String>? = null
+
+      public var content: String?
+        get() = _contentRef?.value()
+        set(newValue) {
+          _contentRef = newValue?.let { LazyReference(it, StringConverter) }
+        }
+
+      public var generatedCodeInfo: GeneratedCodeInfo? = null
+
+      public var unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
+
+      public fun build(): File =
+        File(
+          _nameRef,
+          _insertionPointRef,
+          _contentRef,
+          generatedCodeInfo,
+          unknownFields
+        )
+
+      public companion object Factory {
+        @OnlyForUseByGeneratedProtoCode
+        internal fun from(msg: File): Builder =
+          Builder().also {
+            it._nameRef = msg._name
+            it._insertionPointRef = msg._insertionPoint
+            it._contentRef = msg._content
+            it.generatedCodeInfo = msg.generatedCodeInfo
+            it.unknownFields = msg.unknownFields
+          }
+      }
+    }
+
+    public companion object Deserializer : AbstractDeserializer<File>() {
+      @JvmStatic
+      override fun deserialize(reader: Reader): File {
+        var name: Bytes? = null
+        var insertionPoint: Bytes? = null
+        var content: Bytes? = null
+        var generatedCodeInfo: GeneratedCodeInfo? = null
+        var unknownFields: UnknownFieldSet.Builder? = null
+
+        while (true) {
+          when (reader.readTag()) {
+            0u -> {
+              return File(
+                name?.let { LazyReference(it, StringConverter) },
+                insertionPoint?.let { LazyReference(it, StringConverter) },
+                content?.let { LazyReference(it, StringConverter) },
+                generatedCodeInfo,
+                UnknownFieldSet.from(unknownFields)
+              )
+            }
+
+            10u -> {
+              name = StringConverter.readValidatedBytes(reader)
+            }
+
+            18u -> {
+              insertionPoint = StringConverter.readValidatedBytes(reader)
+            }
+
+            122u -> {
+              content = StringConverter.readValidatedBytes(reader)
+            }
+
+            130u -> {
+              generatedCodeInfo = reader.readMessage(GeneratedCodeInfo)
+            }
+
+            else -> {
+              unknownFields =
+                (unknownFields ?: UnknownFieldSet.Builder()).also {
+                  it.add(reader.readUnknown())
+                }
+            }
+          }
+        }
+      }
+
+      @JvmStatic
+      public operator fun invoke(dsl: Builder.() -> Unit): File =
+        Builder().apply(dsl).build()
+    }
+  }
+}

--- a/protokt-codegen/build.gradle.kts
+++ b/protokt-codegen/build.gradle.kts
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import com.google.protobuf.gradle.proto
 import protokt.v1.gradle.CODEGEN_NAME
 
 plugins {
@@ -58,7 +57,8 @@ kotlin {
 }
 
 dependencies {
-    implementation(project(":protokt-runtime"))
+    implementation(project(":protokt-bootstrap"))
+    implementation(project(":protokt-runtime-protobuf-java"))
     implementation(project(":protokt-runtime-grpc-lite"))
     implementation(project(":grpc-kotlin-shim"))
 
@@ -103,14 +103,105 @@ tasks.withType<Test> {
     }
 }
 
+val bootstrapDir = rootProject.file("protokt-bootstrap/src/main/kotlin")
+
+val downloadWellKnownProtos by tasks.registering {
+    val outputDir = layout.buildDirectory.dir("well-known-protos")
+    val version = libs.versions.protobuf.java.get()
+    outputs.dir(outputDir)
+
+    doLast {
+        val baseUrl = "https://raw.githubusercontent.com/protocolbuffers/protobuf/v$version/src"
+        val protos = listOf(
+            "google/protobuf/descriptor.proto",
+            "google/protobuf/compiler/plugin.proto"
+        )
+        protos.forEach { proto ->
+            val target = outputDir.get().file(proto).asFile
+            target.parentFile.mkdirs()
+            uri("$baseUrl/$proto").toURL().openStream().use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            }
+        }
+    }
+}
+
+val regenerateBootstrap by tasks.registering(Exec::class) {
+    description = "Regenerates checked-in bootstrap types from descriptor.proto, plugin.proto, and protokt.proto"
+    group = "protokt"
+    dependsOn("installDist", downloadWellKnownProtos)
+
+    val protoc = configurations.named("protobufToolsLocator_protoc").map { it.singleFile }
+    val codegen = layout.buildDirectory.file("install/$CODEGEN_NAME/bin/$CODEGEN_NAME")
+    val extensionsProtoDir = rootProject.file("extensions/protokt-extensions-lite/src/extensions-proto")
+    val wellKnownProtosDir = layout.buildDirectory.dir("well-known-protos")
+    val outputDir = temporaryDir
+
+    inputs.file(codegen)
+    inputs.dir(extensionsProtoDir)
+    outputs.dir(bootstrapDir)
+
+    doFirst {
+        outputDir.deleteRecursively()
+        outputDir.mkdirs()
+    }
+
+    commandLine(
+        protoc.get().absolutePath,
+        "--plugin=protoc-gen-custom=${codegen.get().asFile.absolutePath}",
+        "--custom_out=$outputDir",
+        "--custom_opt=kotlin_target=jvm,generate_types=true,generate_descriptors=false",
+        "--proto_path=${wellKnownProtosDir.get().asFile.absolutePath}",
+        "--proto_path=$extensionsProtoDir",
+        "google/protobuf/descriptor.proto",
+        "google/protobuf/compiler/plugin.proto",
+        "protokt/v1/protokt.proto"
+    )
+
+    doLast {
+        copy {
+            from("$outputDir/protokt/v1/google/protobuf/descriptor.kt")
+            into("$bootstrapDir/protokt/v1/google/protobuf")
+            rename { "Descriptor.kt" }
+        }
+        copy {
+            from("$outputDir/protokt/v1/google/protobuf/compiler/plugin.kt")
+            into("$bootstrapDir/protokt/v1/google/protobuf/compiler")
+            rename { "Plugin.kt" }
+        }
+        copy {
+            from("$outputDir/protokt/v1/protokt.kt")
+            into("$bootstrapDir/protokt/v1")
+            rename { "Protokt.kt" }
+        }
+    }
+}
+
+val verifyBootstrap by tasks.registering {
+    description = "Verifies checked-in bootstrap types match what the current codegen would generate"
+    group = "protokt"
+    dependsOn(regenerateBootstrap)
+
+    doLast {
+        val tempDir = regenerateBootstrap.get().temporaryDir
+        val pairs = listOf(
+            file("$tempDir/protokt/v1/google/protobuf/descriptor.kt") to file("$bootstrapDir/protokt/v1/google/protobuf/Descriptor.kt"),
+            file("$tempDir/protokt/v1/google/protobuf/compiler/plugin.kt") to file("$bootstrapDir/protokt/v1/google/protobuf/compiler/Plugin.kt"),
+            file("$tempDir/protokt/v1/protokt.kt") to file("$bootstrapDir/protokt/v1/Protokt.kt")
+        )
+        pairs.forEach { (generated, checkedIn) ->
+            check(generated.readText() == checkedIn.readText()) {
+                "Bootstrap file ${checkedIn.name} is out of date. Run: ./gradlew :protokt-codegen:regenerateBootstrap"
+            }
+        }
+    }
+}
+
 sourceSets {
     main {
         java {
             srcDir("../shared-src/codegen")
             srcDir("../shared-src/reflect")
-        }
-        proto {
-            srcDir("../extensions/protokt-extensions-lite/src/extensions-proto")
         }
     }
 }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/Main.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/Main.kt
@@ -15,13 +15,7 @@
 
 package protokt.v1.codegen
 
-import com.google.protobuf.DescriptorProtos.Edition
-import com.google.protobuf.ExtensionRegistry
-import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
-import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
-import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.Feature
 import com.squareup.kotlinpoet.FileSpec
-import com.toasttab.protokt.v1.ProtoktProtos
 import io.github.oshai.kotlinlogging.KotlinLoggingConfiguration
 import protokt.v1.codegen.generate.generateFile
 import protokt.v1.codegen.util.ErrorContext.withFileName
@@ -31,6 +25,9 @@ import protokt.v1.codegen.util.formatErrorMessage
 import protokt.v1.codegen.util.generateGrpcKotlinStubs
 import protokt.v1.codegen.util.parseFileContents
 import protokt.v1.codegen.util.tidy
+import protokt.v1.google.protobuf.Edition
+import protokt.v1.google.protobuf.compiler.CodeGeneratorRequest
+import protokt.v1.google.protobuf.compiler.CodeGeneratorResponse
 import java.io.InputStream
 import java.io.OutputStream
 import java.io.PrintStream
@@ -52,56 +49,46 @@ internal fun main(`in`: InputStream, out: OutputStream, err: PrintStream) =
     }
 
 private fun main(`in`: InputStream, out: OutputStream) {
-    val req = parseCodeGeneratorRequest(`in`)
+    val req = CodeGeneratorRequest.deserialize(`in`)
     val params = PluginParams(parseParams(req))
-    val filesToGenerate = req.fileToGenerateList.toSet()
+    val filesToGenerate = req.fileToGenerate.toSet()
 
-    val files = req.protoFileList
+    val files = req.protoFile
         .filter { filesToGenerate.contains(it.name) }
         .mapNotNull { fdp ->
-            val context = GeneratorContext(fdp, params, req.protoFileList)
-            val fileSpec = withFileName(fdp.name) { generateFile(parseFileContents(context)) }
+            val context = GeneratorContext(fdp, params, req.protoFile)
+            val fileSpec = withFileName(fdp.name.orEmpty()) { generateFile(parseFileContents(context)) }
             fileSpec?.let { response(it, context) }
         }
 
     val grpcKotlinFiles = generateGrpcKotlinStubs(params, req)
 
-    CodeGeneratorResponse.newBuilder()
-        .setSupportedFeatures(
+    CodeGeneratorResponse {
+        supportedFeatures =
             (
-                Feature.FEATURE_PROTO3_OPTIONAL_VALUE or
-                    Feature.FEATURE_SUPPORTS_EDITIONS_VALUE
-                ).toLong()
-        )
-        // we don't support all of proto2 but we have to say we support it for protovalidate examples
-        .setMinimumEdition(Edition.EDITION_PROTO2_VALUE)
-        // we don't actually support 2023 yet but we have to say we support it for protovalidate examples
-        .setMaximumEdition(Edition.EDITION_2023_VALUE)
-        .addAllFile(files)
-        .addAllFile(grpcKotlinFiles)
-        .build()
-        .writeTo(out)
+                CodeGeneratorResponse.Feature.PROTO3_OPTIONAL.value or
+                    CodeGeneratorResponse.Feature.SUPPORTS_EDITIONS.value
+                ).toULong()
+
+        minimumEdition = Edition.EDITION_PROTO2.value
+        maximumEdition = Edition.EDITION_2023.value
+        file = files + grpcKotlinFiles
+    }.serialize(out)
 }
 
 private fun response(fileSpec: FileSpec, context: GeneratorContext) =
-    CodeGeneratorResponse.File
-        .newBuilder()
-        .setContent(tidy(fileSpec.toString(), context.formatOutput))
-        .setName(fileSpec.name)
-        .build()
-
-private fun parseParams(req: CodeGeneratorRequest) =
-    if (req.parameter == null || req.parameter.isEmpty()) {
-        emptyMap()
-    } else {
-        req.parameter
-            .split(',')
-            .associate { it.substringBefore('=') to it.substringAfter('=', "") }
+    CodeGeneratorResponse.File {
+        content = tidy(fileSpec.toString(), context.formatOutput)
+        name = fileSpec.name
     }
 
-private fun parseCodeGeneratorRequest(`in`: InputStream) =
-    CodeGeneratorRequest.parseFrom(
-        `in`,
-        ExtensionRegistry.newInstance()
-            .also { ProtoktProtos.registerAllExtensions(it) }
-    )
+private fun parseParams(req: CodeGeneratorRequest) =
+    req.parameter.orEmpty().let { param ->
+        if (param.isEmpty()) {
+            emptyMap()
+        } else {
+            param
+                .split(',')
+                .associate { it.substringBefore('=') to it.substringAfter('=', "") }
+        }
+    }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/EnumGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/EnumGenerator.kt
@@ -15,8 +15,6 @@
 
 package protokt.v1.codegen.generate
 
-import com.google.protobuf.DescriptorProtos.DescriptorProto.ENUM_TYPE_FIELD_NUMBER
-import com.google.protobuf.DescriptorProtos.EnumDescriptorProto.VALUE_FIELD_NUMBER
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -39,14 +37,14 @@ private class EnumGenerator(
     val e: Enum,
     val ctx: Context
 ) {
-    private val enumPath = listOf(ENUM_TYPE_FIELD_NUMBER, e.index)
+    private val enumPath = listOf(4, e.index) // DescriptorProto.ENUM_TYPE_FIELD_NUMBER
 
     fun generate() =
         TypeSpec.classBuilder(e.className).apply {
             addModifiers(KModifier.SEALED)
             superclass(protokt.v1.Enum::class)
             addKDoc()
-            handleDeprecation(e.options.default.deprecated, e.options.protokt.deprecationMessage)
+            handleDeprecation(e.options.default.deprecated == true, e.options.protokt.deprecationMessage)
             addConstructor()
             addEnumValues()
             addDeserializer()
@@ -60,7 +58,7 @@ private class EnumGenerator(
 
     private fun TypeSpec.Builder.addKDoc(value: Enum.Value) =
         apply {
-            baseLocation(ctx, enumPath + listOf(VALUE_FIELD_NUMBER, value.index))
+            baseLocation(ctx, enumPath + listOf(2, value.index)) // EnumDescriptorProto.VALUE_FIELD_NUMBER
                 ?.cleanDocumentation()
                 ?.let { addKdoc(formatDoc(it)) }
         }
@@ -84,7 +82,7 @@ private class EnumGenerator(
                     addKDoc(it)
                     addSuperclassConstructorParameter(it.number.toString())
                     addSuperclassConstructorParameter("\"${it.valueName}\"")
-                    handleDeprecation(it.options.default.deprecated, it.options.protokt.deprecationMessage)
+                    handleDeprecation(it.options.default.deprecated == true, it.options.protokt.deprecationMessage)
                 }.build()
             }
         )

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ExtensionGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ExtensionGenerator.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen.generate
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.asTypeName
+import protokt.v1.Extension
+import protokt.v1.ExtensionCodecs
+import protokt.v1.RepeatedExtension
+import protokt.v1.codegen.util.ProtoExtension
+import protokt.v1.codegen.util.ProtoFileContents
+import protokt.v1.reflect.FieldType
+
+internal fun generateExtensions(contents: ProtoFileContents): List<PropertySpec> {
+    if (!contents.info.context.generateTypes || !contents.info.context.kotlinTarget.isPrimaryTarget) {
+        return emptyList()
+    }
+    return contents.extensions.flatMap { ext ->
+        listOf(generateExtensionProperty(ext), generateExtensionAccessor(ext))
+    }
+}
+
+private fun generateExtensionProperty(ext: ProtoExtension): PropertySpec {
+    val containerClass =
+        if (ext.repeated) {
+            RepeatedExtension::class.asTypeName()
+        } else {
+            Extension::class.asTypeName()
+        }
+
+    val valueTypeName = ext.valueClassName ?: ext.fieldType.protoktFieldType.asTypeName()
+    val propertyType = containerClass.parameterizedBy(ext.extendee, valueTypeName)
+
+    return PropertySpec
+        .builder("${ext.fieldName}Extension", propertyType)
+        .addModifiers(com.squareup.kotlinpoet.KModifier.PRIVATE)
+        .initializer(
+            "%T(%Lu, %L)",
+            if (ext.repeated) RepeatedExtension::class else Extension::class,
+            ext.number,
+            codecFor(ext)
+        )
+        .build()
+}
+
+private fun generateExtensionAccessor(ext: ProtoExtension): PropertySpec {
+    val valueTypeName = ext.valueClassName ?: ext.fieldType.protoktFieldType.asTypeName()
+
+    val returnType =
+        if (ext.repeated) {
+            List::class.asTypeName().parameterizedBy(valueTypeName)
+        } else {
+            valueTypeName.copy(nullable = true)
+        }
+
+    return PropertySpec
+        .builder(ext.fieldName, returnType)
+        .addAnnotation(
+            com.squareup.kotlinpoet.AnnotationSpec.builder(Suppress::class)
+                .addMember("%S", "EXTENSION_SHADOWED_BY_MEMBER")
+                .build()
+        )
+        .receiver(ext.extendee)
+        .getter(
+            com.squareup.kotlinpoet.FunSpec.getterBuilder()
+                .addCode("return this[${ext.fieldName}Extension]")
+                .build()
+        )
+        .build()
+}
+
+private fun codecFor(ext: ProtoExtension): CodeBlock =
+    when (ext.fieldType) {
+        FieldType.Message ->
+            CodeBlock.of("%T.message(%T)", ExtensionCodecs::class, ext.valueClassName!!)
+
+        FieldType.Enum ->
+            CodeBlock.of("%T.enum(%T)", ExtensionCodecs::class, ext.valueClassName!!)
+
+        FieldType.Bool -> CodeBlock.of("%T.bool", ExtensionCodecs::class)
+
+        FieldType.Double -> CodeBlock.of("%T.double", ExtensionCodecs::class)
+
+        FieldType.Float -> CodeBlock.of("%T.float", ExtensionCodecs::class)
+
+        FieldType.Fixed32 -> CodeBlock.of("%T.fixed32", ExtensionCodecs::class)
+
+        FieldType.Fixed64 -> CodeBlock.of("%T.fixed64", ExtensionCodecs::class)
+
+        FieldType.Int32 -> CodeBlock.of("%T.int32", ExtensionCodecs::class)
+
+        FieldType.Int64 -> CodeBlock.of("%T.int64", ExtensionCodecs::class)
+
+        FieldType.SFixed32 -> CodeBlock.of("%T.sfixed32", ExtensionCodecs::class)
+
+        FieldType.SFixed64 -> CodeBlock.of("%T.sfixed64", ExtensionCodecs::class)
+
+        FieldType.SInt32 -> CodeBlock.of("%T.sint32", ExtensionCodecs::class)
+
+        FieldType.SInt64 -> CodeBlock.of("%T.sint64", ExtensionCodecs::class)
+
+        FieldType.UInt32 -> CodeBlock.of("%T.uint32", ExtensionCodecs::class)
+
+        FieldType.UInt64 -> CodeBlock.of("%T.uint64", ExtensionCodecs::class)
+
+        FieldType.String -> CodeBlock.of("%T.string", ExtensionCodecs::class)
+
+        FieldType.Bytes -> CodeBlock.of("%T.bytes", ExtensionCodecs::class)
+    }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileDescriptorEncoding.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileDescriptorEncoding.kt
@@ -15,7 +15,7 @@
 
 package protokt.v1.codegen.generate
 
-import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import protokt.v1.google.protobuf.FileDescriptorProto
 
 // For the Java implementation of descriptor encoding, see:
 // https://github.com/protocolbuffers/protobuf/blob/5e84a6169cf0f9716c9285c95c860bcb355dbdc1/src/google/protobuf/compiler/java/java_shared_code_generator.cc#L119
@@ -45,7 +45,7 @@ private const val BYTES_PER_PART = BYTES_PER_LINE * LINES_PER_PART
 // embedded raw, which is what we want.
 fun encodeFileDescriptor(fileDescriptorProto: FileDescriptorProto): List<List<String>> {
     val parts = mutableListOf<MutableList<String>>()
-    val bytes = fileDescriptorProto.toByteArray()
+    val bytes = fileDescriptorProto.serialize()
     for (i in bytes.indices step BYTES_PER_LINE) {
         if (i % BYTES_PER_PART == 0) {
             parts.add(mutableListOf())

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileDescriptorResolver.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileDescriptorResolver.kt
@@ -15,7 +15,6 @@
 
 package protokt.v1.codegen.generate
 
-import com.google.protobuf.DescriptorProtos
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -32,6 +31,8 @@ import protokt.v1.codegen.util.Message
 import protokt.v1.codegen.util.PROTOKT_V1_GOOGLE_PROTO
 import protokt.v1.codegen.util.ProtoFileContents
 import protokt.v1.codegen.util.TopLevelType
+import protokt.v1.google.protobuf.DescriptorProto
+import protokt.v1.google.protobuf.FileDescriptorProto
 
 class FileDescriptorInfo(
     val fdp: TypeSpec,
@@ -90,9 +91,7 @@ private constructor(
     private fun fileDescriptorParts() =
         encodeFileDescriptor(
             clearJsonInfo(
-                ctx.fdp.toBuilder()
-                    .clearSourceCodeInfo()
-                    .build()
+                ctx.fdp.copy { sourceCodeInfo = null }
             )
         )
 
@@ -101,40 +100,26 @@ private constructor(
             .map { CodeBlock.of("%T.descriptor", it) }
             .joinToCode(",\n")
 
-    private fun clearJsonInfo(fileDescriptorProto: DescriptorProtos.FileDescriptorProto) =
-        fileDescriptorProto.toBuilder()
-            .clearMessageType()
-            .addAllMessageType(clearJsonInfo(fileDescriptorProto.messageTypeList))
-            .build()
+    private fun clearJsonInfo(fileDescriptorProto: FileDescriptorProto) =
+        fileDescriptorProto.copy { messageType = clearJsonInfo(fileDescriptorProto.messageType) }
 
-    private fun clearJsonInfo(descriptorProtos: Iterable<DescriptorProtos.DescriptorProto>): Iterable<DescriptorProtos.DescriptorProto> =
+    private fun clearJsonInfo(descriptorProtos: List<DescriptorProto>): List<DescriptorProto> =
         descriptorProtos.map { dp ->
-            dp.toBuilder()
-                .clearField()
-                .addAllField(
-                    dp.fieldList
-                        .map { fdp ->
-                            fdp.toBuilder()
-                                .clearJsonName()
-                                .build()
-                        }
-                )
-                .clearNestedType()
-                .addAllNestedType(
-                    clearJsonInfo(dp.nestedTypeList)
-                )
-                .build()
+            dp.copy {
+                field = dp.field.map { fdp -> fdp.copy { jsonName = null } }
+                nestedType = clearJsonInfo(dp.nestedType)
+            }
         }
 
     private fun dependencies() =
-        ctx.fdp.dependencyList
+        ctx.fdp.dependency
             .filter {
                 // We don't generate anything for files without any of the
                 // following; e.g., a file containing only extensions.
                 ctx.allFilesByName.getValue(it).let { fdp ->
-                    fdp.messageTypeCount +
-                        fdp.enumTypeCount +
-                        fdp.serviceCount > 0
+                    fdp.messageType.size +
+                        fdp.enumType.size +
+                        fdp.service.size > 0
                 }
             }.map {
                 ClassName(
@@ -162,8 +147,8 @@ private constructor(
                     )
                     .apply {
                         if (
-                            containingTypes.any { it.options.default.deprecated } ||
-                            enum.options.default.deprecated
+                            containingTypes.any { it.options.default.deprecated == true } ||
+                            enum.options.default.deprecated == true
                         ) {
                             addAnnotation(
                                 AnnotationSpec.builder(Suppress::class)
@@ -209,8 +194,8 @@ private constructor(
                     )
                     .apply {
                         if (
-                            containingTypes.any { it.options.default.deprecated } ||
-                            msg.options.default.deprecated
+                            containingTypes.any { it.options.default.deprecated == true } ||
+                            msg.options.default.deprecated == true
                         ) {
                             addAnnotation(
                                 AnnotationSpec.builder(Suppress::class)

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FileGenerator.kt
@@ -64,6 +64,15 @@ private class FileGenerator(
             builder.addType(it.typeSpec)
         }
 
+        val extensionProps = generateExtensions(contents)
+        if (extensionProps.isNotEmpty()) {
+            builder.addImport("protokt.v1", "get")
+        }
+        extensionProps.forEach {
+            anyCodeAdded = true
+            builder.addProperty(it)
+        }
+
         if (contents.info.context.generateDescriptors && contents.info.context.kotlinTarget.isPrimaryTarget) {
             val fileDescriptorInfo = FileDescriptorResolver.resolveFileDescriptor(contents)
 

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MapEntryGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MapEntryGenerator.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
@@ -28,6 +29,7 @@ import protokt.v1.AbstractMessage
 import protokt.v1.Bytes
 import protokt.v1.Reader
 import protokt.v1.StringConverter
+import protokt.v1.UnknownFieldSet
 import protokt.v1.Writer
 import protokt.v1.codegen.generate.CodeGenerator.Context
 import protokt.v1.codegen.generate.Wrapper.interceptDefaultValue
@@ -80,6 +82,12 @@ private class MapEntryGenerator(
             superclass(AbstractMessage::class)
             addProperty(keyProp)
             addProperty(valProp)
+            addProperty(
+                PropertySpec.builder("unknownFields", UnknownFieldSet::class)
+                    .addModifiers(KModifier.OVERRIDE)
+                    .initializer("%T.empty()", UnknownFieldSet::class)
+                    .build()
+            )
             addConstructor()
             addMessageSize()
             addSerialize()

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageDocumentationAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageDocumentationAnnotator.kt
@@ -15,26 +15,24 @@
 
 package protokt.v1.codegen.generate
 
-import com.google.protobuf.DescriptorProtos.DescriptorProto.NESTED_TYPE_FIELD_NUMBER
-import com.google.protobuf.DescriptorProtos.FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER
-import com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location
 import protokt.v1.codegen.generate.CodeGenerator.Context
+import protokt.v1.google.protobuf.SourceCodeInfo
 
 internal fun annotateMessageDocumentation(ctx: Context) =
     baseLocation(ctx)?.cleanDocumentation()
 
 internal fun baseLocation(ctx: Context, extraPath: List<Int> = emptyList()) =
-    ctx.info.sourceCodeInfo.locationList.firstOrNull { it.pathList == basePath(ctx) + extraPath }
+    ctx.info.sourceCodeInfo?.location?.firstOrNull { it.path == basePath(ctx) + extraPath }
 
 private fun basePath(ctx: Context): List<Int> {
     val path = mutableListOf<Int>()
 
     ctx.enclosing.forEachIndexed { idx, it ->
         if (idx == 0) {
-            path.add(MESSAGE_TYPE_FIELD_NUMBER)
+            path.add(4) // FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER
             path.add(it.index)
         } else {
-            path.add(NESTED_TYPE_FIELD_NUMBER)
+            path.add(3) // DescriptorProto.NESTED_TYPE_FIELD_NUMBER
             path.add(it.index)
         }
     }
@@ -43,9 +41,9 @@ private fun basePath(ctx: Context): List<Int> {
 }
 
 // todo: see if an empty list passed upwards behaves the same as null, and if so, end this with a call to .orEmpty()
-fun Location.cleanDocumentation(): List<String>? =
+fun SourceCodeInfo.Location.cleanDocumentation(): List<String>? =
     leadingComments
-        .takeIf { it.isNotEmpty() }
+        ?.takeIf { it.isNotEmpty() }
         ?.run {
             substringBeforeLast("\n")
                 .split("\n")

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -92,6 +92,7 @@ private class MessageGenerator(
             addProperties(props.constructorPropertySpecs)
             addProperty(
                 PropertySpec.builder("unknownFields", UnknownFieldSet::class)
+                    .addModifiers(KModifier.OVERRIDE)
                     .initializer("unknownFields")
                     .build()
             )

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -79,7 +79,7 @@ private class MessageGenerator(
                     .build()
             )
             handleDeprecation(
-                msg.options.default.deprecated,
+                msg.options.default.deprecated == true,
                 msg.options.protokt.deprecationMessage
             )
         }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/OneofGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/OneofGenerator.kt
@@ -240,7 +240,7 @@ private class OneofGenerator(
         )
 
     private fun deprecation(f: StandardField) =
-        if (f.options.default.deprecated) {
+        if (f.options.default.deprecated == true) {
             renderOptions(
                 f.options.protokt.deprecationMessage
             )

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyAnnotator.kt
@@ -109,7 +109,7 @@ private class PropertyAnnotator(
     }
 
     private fun deprecation(f: StandardField) =
-        if (f.options.default.deprecated) {
+        if (f.options.default.deprecated == true) {
             renderOptions(
                 f.options.protokt.deprecationMessage
             )

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyDocumentationAnnotator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/PropertyDocumentationAnnotator.kt
@@ -15,8 +15,6 @@
 
 package protokt.v1.codegen.generate
 
-import com.google.protobuf.DescriptorProtos.DescriptorProto.FIELD_FIELD_NUMBER
-import com.google.protobuf.DescriptorProtos.DescriptorProto.ONEOF_DECL_FIELD_NUMBER
 import protokt.v1.codegen.generate.CodeGenerator.Context
 import protokt.v1.codegen.util.Field
 import protokt.v1.codegen.util.Oneof
@@ -33,8 +31,10 @@ private class PropertyDocumentationAnnotator(
         baseLocation(
             ctx,
             when (field) {
-                is StandardField -> listOf(FIELD_FIELD_NUMBER, field.index)
-                is Oneof -> listOf(ONEOF_DECL_FIELD_NUMBER, field.index)
+                is StandardField -> listOf(2, field.index)
+
+                // DescriptorProto.FIELD_FIELD_NUMBER
+                is Oneof -> listOf(8, field.index) // DescriptorProto.ONEOF_DECL_FIELD_NUMBER
             }
         )?.cleanDocumentation()
 }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/EnumParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/EnumParser.kt
@@ -16,8 +16,9 @@
 package protokt.v1.codegen.util
 
 import com.google.common.base.CaseFormat
-import com.google.protobuf.DescriptorProtos.EnumDescriptorProto
-import com.toasttab.protokt.v1.ProtoktProtos
+import protokt.v1.enum
+import protokt.v1.enumValue
+import protokt.v1.google.protobuf.EnumDescriptorProto
 
 internal class EnumParser(
     private val ctx: GeneratorContext,
@@ -27,32 +28,32 @@ internal class EnumParser(
 ) {
     fun toEnum(): Enum {
         val enumTypeNamePrefixToStrip =
-            (CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, desc.name) + '_')
+            (CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, desc.name.orEmpty()) + '_')
                 .takeIf {
-                    desc.valueList.all { e ->
-                        e.name.startsWith(it) && e.name.length > it.length && !e.name[it.length].isDigit()
+                    desc.value.all { e ->
+                        e.name.orEmpty().startsWith(it) && e.name.orEmpty().length > it.length && !e.name.orEmpty()[it.length].isDigit()
                     }
                 }
 
-        val simpleNames = enclosingMessages + desc.name
+        val simpleNames = enclosingMessages + desc.name.orEmpty()
 
         return Enum(
-            values = desc.valueList.mapIndexed { enumIdx, t ->
+            values = desc.value.mapIndexed { enumIdx, t ->
                 Enum.Value(
-                    t.number,
-                    t.name,
-                    newEnumValueName(enumTypeNamePrefixToStrip, t.name),
+                    t.number ?: 0,
+                    t.name.orEmpty(),
+                    newEnumValueName(enumTypeNamePrefixToStrip, t.name.orEmpty()),
                     EnumValueOptions(
-                        t.options,
-                        t.options.getExtension(ProtoktProtos.enumValue)
+                        t.options ?: protokt.v1.google.protobuf.EnumValueOptions {},
+                        t.options?.enumValue ?: protokt.v1.EnumValueOptions {}
                     ),
                     enumIdx
                 )
             },
             index = idx,
             options = EnumOptions(
-                desc.options,
-                desc.options.getExtension(ProtoktProtos.enum_)
+                desc.options ?: protokt.v1.google.protobuf.EnumOptions {},
+                desc.options?.`enum` ?: protokt.v1.EnumOptions {}
             ),
             className = ctx.className(simpleNames),
             deserializerClassName = ctx.className(simpleNames + DESERIALIZER)

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/FieldParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/FieldParser.kt
@@ -18,19 +18,19 @@ package protokt.v1.codegen.util
 import com.google.common.base.CaseFormat.LOWER_CAMEL
 import com.google.common.base.CaseFormat.LOWER_UNDERSCORE
 import com.google.common.base.CaseFormat.UPPER_CAMEL
-import com.google.protobuf.DescriptorProtos.DescriptorProto
-import com.google.protobuf.DescriptorProtos.FeatureSet
-import com.google.protobuf.DescriptorProtos.FeatureSet.FieldPresence
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type
-import com.google.protobuf.DescriptorProtos.FileDescriptorProto
-import com.google.protobuf.DescriptorProtos.OneofDescriptorProto
 import com.squareup.kotlinpoet.ClassName
-import com.toasttab.protokt.v1.ProtoktProtos
 import protokt.v1.codegen.generate.Wrapper.wrapped
 import protokt.v1.codegen.util.ErrorContext.withFieldName
+import protokt.v1.google.protobuf.DescriptorProto
+import protokt.v1.google.protobuf.FeatureSet
+import protokt.v1.google.protobuf.FeatureSet.FieldPresence
+import protokt.v1.google.protobuf.FieldDescriptorProto
+import protokt.v1.google.protobuf.FieldDescriptorProto.Label.OPTIONAL
+import protokt.v1.google.protobuf.FieldDescriptorProto.Label.REPEATED
+import protokt.v1.google.protobuf.FileDescriptorProto
+import protokt.v1.google.protobuf.OneofDescriptorProto
+import protokt.v1.oneof
+import protokt.v1.property
 import protokt.v1.reflect.FieldType
 import protokt.v1.reflect.typeName
 
@@ -45,13 +45,13 @@ internal class FieldParser(
         val generatedOneofIndices = mutableSetOf<Int>()
         val fields = mutableListOf<Field>()
 
-        desc.fieldList.forEachIndexed { idx, t ->
-            withFieldName(t.name) {
-                if (t.type != Type.TYPE_GROUP) {
-                    t.oneofIndex.takeIf { t.hasOneofIndex() }?.let { oneofIndex ->
+        desc.field.forEachIndexed { idx, t ->
+            withFieldName(t.name.orEmpty()) {
+                if (t.type != FieldDescriptorProto.Type.GROUP) {
+                    t.oneofIndex?.let { oneofIndex ->
                         if (oneofIndex !in generatedOneofIndices) {
                             generatedOneofIndices.add(oneofIndex)
-                            fields.add(toOneof(idx, desc, desc.getOneofDecl(oneofIndex), t, fields))
+                            fields.add(toOneof(idx, desc, desc.oneofDecl[oneofIndex], t, fields))
                         }
                     } ?: fields.add(toStandard(idx, t))
                 }
@@ -68,12 +68,12 @@ internal class FieldParser(
         field: FieldDescriptorProto,
         fields: List<Field>
     ): Field {
-        if (field.proto3Optional) {
+        if (field.proto3Optional == true) {
             return toStandard(idx, field)
         }
 
         val oneofFieldDescriptors =
-            desc.fieldList.filter { it.hasOneofIndex() && it.oneofIndex == field.oneofIndex }
+            desc.field.filter { it.oneofIndex != null && it.oneofIndex == field.oneofIndex }
 
         val oneofStdFields =
             oneofFieldDescriptors.mapIndexed { fdpIdx, fdp ->
@@ -85,17 +85,17 @@ internal class FieldParser(
                 it.fieldName to LOWER_CAMEL.to(UPPER_CAMEL, it.fieldName)
             }
 
-        val name = LOWER_UNDERSCORE.to(UPPER_CAMEL, oneof.name)
+        val name = LOWER_UNDERSCORE.to(UPPER_CAMEL, oneof.name.orEmpty())
 
         return Oneof(
             name = name,
-            className = ClassName(ctx.kotlinPackage, enclosingMessages + desc.name + name),
+            className = ClassName(ctx.kotlinPackage, enclosingMessages + desc.name.orEmpty() + name),
             fieldTypeNames = fieldTypeNames,
-            fieldName = LOWER_UNDERSCORE.to(LOWER_CAMEL, oneof.name),
+            fieldName = LOWER_UNDERSCORE.to(LOWER_CAMEL, oneof.name.orEmpty()),
             fields = oneofStdFields,
             options = OneofOptions(
-                oneof.options,
-                oneof.options.getExtension(ProtoktProtos.oneof)
+                oneof.options ?: protokt.v1.google.protobuf.OneofOptions {},
+                oneof.options?.oneof ?: protokt.v1.OneofOptions {}
             ),
             // index relative to all oneofs in this message
             index = idx - fields.filterIsInstance<StandardField>().count()
@@ -107,9 +107,9 @@ internal class FieldParser(
         fdp: FieldDescriptorProto,
         withinOneof: Boolean = false
     ): StandardField {
-        val fieldType = FieldType.from(fdp.type)
-        val protoktOptions = fdp.options.getExtension(ProtoktProtos.property)
-        val repeated = fdp.label == LABEL_REPEATED
+        val fieldType = FieldType.from((fdp.type ?: FieldDescriptorProto.Type.STRING).value)
+        val protoktOptions = fdp.options?.property ?: protokt.v1.FieldOptions {}
+        val repeated = fdp.label == REPEATED
         val mapEntry = mapEntry(fdp, protoktOptions)
         if (mapEntry == null) {
             require(protoktOptions.keyWrap.isEmpty()) {
@@ -125,24 +125,25 @@ internal class FieldParser(
         }
         val optional = optional(fdp)
         val packed = packed(fieldType, fdp)
+        val number = fdp.number ?: 0
         val tag =
             if (repeated && packed) {
-                Tag.Packed(fdp.number)
+                Tag.Packed(number)
             } else {
-                Tag.Unpacked(fdp.number, fieldType.wireType)
+                Tag.Unpacked(number, fieldType.wireType)
             }
 
         val result = StandardField(
-            number = fdp.number,
+            number = number,
             tag = tag,
             type = fieldType,
             repeated = repeated,
             optional = !withinOneof && optional,
             packed = packed,
             mapEntry = mapEntry,
-            fieldName = camelCaseFieldName(fdp.name),
+            fieldName = camelCaseFieldName(fdp.name.orEmpty()),
             options = FieldOptions(
-                fdp.options,
+                fdp.options ?: protokt.v1.google.protobuf.FieldOptions {},
                 protoktOptions,
                 when {
                     keyWrap != null && idx == 0 -> keyWrap
@@ -150,8 +151,8 @@ internal class FieldParser(
                     else -> protoktOptions.wrap.takeIf { it.isNotEmpty() }
                 }
             ),
-            protoTypeName = fdp.typeName,
-            className = ClassName.bestGuess(typeName(fdp.typeName, fieldType)),
+            protoTypeName = fdp.typeName.orEmpty(),
+            className = ClassName.bestGuess(typeName(fdp.typeName.orEmpty(), fieldType)),
             index = idx
         )
 
@@ -162,16 +163,16 @@ internal class FieldParser(
         return result
     }
 
-    private fun mapEntry(fdp: FieldDescriptorProto, options: ProtoktProtos.FieldOptions) =
-        if (fdp.label == LABEL_REPEATED && fdp.type == Type.TYPE_MESSAGE) {
-            findMapEntry(ctx.fdp, fdp.typeName)
-                ?.takeIf { it.options.mapEntry }
+    private fun mapEntry(fdp: FieldDescriptorProto, options: protokt.v1.FieldOptions) =
+        if (fdp.label == REPEATED && fdp.type == FieldDescriptorProto.Type.MESSAGE) {
+            findMapEntry(ctx.fdp, fdp.typeName.orEmpty())
+                ?.takeIf { it.options?.mapEntry == true }
                 ?.let { entry ->
                     MessageParser(
                         ctx,
                         -1,
                         entry,
-                        enclosingMessages + desc.name,
+                        enclosingMessages + desc.name.orEmpty(),
                         options.keyWrap.takeIf { it.isNotEmpty() },
                         options.valueWrap.takeIf { it.isNotEmpty() }
                     ).toMessage()
@@ -188,11 +189,11 @@ internal class FieldParser(
         val (typeList, typeName) =
             if (parent == null) {
                 Pair(
-                    fdp.messageTypeList.filterNotNull(),
-                    name.removePrefix(".${fdp.`package`}.")
+                    fdp.messageType,
+                    name.removePrefix(".${fdp.`package`.orEmpty()}.")
                 )
             } else {
-                parent.nestedTypeList.filterNotNull() to name
+                parent.nestedType to name
             }
 
         typeName.indexOf('.').let { idx ->
@@ -209,31 +210,31 @@ internal class FieldParser(
     }
 
     private fun optional(fdp: FieldDescriptorProto) =
-        fdp.label != LABEL_REPEATED &&
+        fdp.label != REPEATED &&
             when {
-                ctx.proto2 -> fdp.label == LABEL_OPTIONAL
-                ctx.proto3 -> fdp.proto3Optional
-                ctx.edition2023 -> optional(ctx.fileOptions.default.features, fdp.options.features)
+                ctx.proto2 -> fdp.label == OPTIONAL
+                ctx.proto3 -> fdp.proto3Optional == true
+                ctx.edition2023 -> optional(ctx.fileOptions.default.features, fdp.options?.features)
                 else -> error("unexpected edition/syntax")
             }
 
-    private fun optional(fileFeatures: FeatureSet, fieldFeatures: FeatureSet) =
-        if (fileFeatures.fieldPresence == FieldPresence.EXPLICIT || !fileFeatures.hasFieldPresence()) {
-            fieldFeatures.fieldPresence !in setOf(FieldPresence.IMPLICIT, FieldPresence.LEGACY_REQUIRED)
+    private fun optional(fileFeatures: FeatureSet?, fieldFeatures: FeatureSet?) =
+        if (fileFeatures?.fieldPresence == FieldPresence.EXPLICIT || fileFeatures?.fieldPresence == null) {
+            fieldFeatures?.fieldPresence !in setOf(FieldPresence.IMPLICIT, FieldPresence.LEGACY_REQUIRED)
         } else {
-            fieldFeatures.fieldPresence == FieldPresence.EXPLICIT
+            fieldFeatures?.fieldPresence == FieldPresence.EXPLICIT
         }
 
     private fun packed(type: FieldType, fdp: FieldDescriptorProto) =
         type.packable &&
             // marginal support for proto2
             (
-                (ctx.proto2 && fdp.options.packed) ||
+                (ctx.proto2 && fdp.options?.packed == true) ||
                     // packed if: proto3 and `packed` isn't set, or proto3
                     // and `packed` is true. If proto3, only explicitly
                     // setting `packed` to false disables packing, since
                     // the default value for an unset boolean is false.
-                    (ctx.proto3 && (!fdp.options.hasPacked() || (fdp.options.hasPacked() && fdp.options.packed)))
+                    (ctx.proto3 && (fdp.options?.packed == null || fdp.options?.packed == true))
                 )
 
     private fun validateNonNullOption(
@@ -254,7 +255,7 @@ internal class FieldParser(
 
         val typeName =
             when (field.type) {
-                FieldType.Enum, FieldType.Message -> fdp.typeName
+                FieldType.Enum, FieldType.Message -> fdp.typeName.orEmpty()
                 else -> field.type.typeName()
             }
 

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/FileContentParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/FileContentParser.kt
@@ -15,18 +15,62 @@
 
 package protokt.v1.codegen.util
 
-import com.google.protobuf.DescriptorProtos.DescriptorProto
-import com.google.protobuf.DescriptorProtos.EnumDescriptorProto
-import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto
+import com.squareup.kotlinpoet.ClassName
 import protokt.v1.codegen.util.ErrorContext.withEnumName
 import protokt.v1.codegen.util.ErrorContext.withMessageName
 import protokt.v1.codegen.util.ErrorContext.withServiceName
+import protokt.v1.google.protobuf.DescriptorProto
+import protokt.v1.google.protobuf.EnumDescriptorProto
+import protokt.v1.google.protobuf.FieldDescriptorProto
+import protokt.v1.google.protobuf.ServiceDescriptorProto
+import protokt.v1.reflect.FieldType
+import protokt.v1.reflect.requalifyProtoType
+import protokt.v1.reflect.typeName
 
 internal fun parseFileContents(ctx: GeneratorContext) =
     ProtoFileContents(
         ProtoFileInfo(ctx),
-        FileContentParser(ctx).parseContents()
+        FileContentParser(ctx).parseContents(),
+        parseExtensions(ctx)
     )
+
+private fun parseExtensions(ctx: GeneratorContext): List<ProtoExtension> =
+    ctx.fdp.extension.mapNotNull { fdp ->
+        val fieldType = FieldType.from((fdp.type ?: FieldDescriptorProto.Type.STRING).value)
+        val extendeeName = fdp.extendee?.removePrefix(".") ?: return@mapNotNull null
+
+        val valueClassName =
+            when (fieldType) {
+                FieldType.Message, FieldType.Enum ->
+                    ClassName.bestGuess(typeName(fdp.typeName.orEmpty(), fieldType))
+
+                else -> null
+            }
+
+        ProtoExtension(
+            fieldName = camelCase(fdp.name.orEmpty()),
+            number = fdp.number ?: 0,
+            extendee = ClassName.bestGuess(requalifyProtoType(".$extendeeName")),
+            fieldType = fieldType,
+            valueClassName = valueClassName,
+            repeated = fdp.label == FieldDescriptorProto.Label.REPEATED
+        )
+    }
+
+private fun camelCase(name: String): String {
+    if (!name.contains('_')) return name
+    return buildString {
+        var capitalizeNext = false
+        for (c in name) {
+            if (c == '_') {
+                capitalizeNext = true
+            } else {
+                append(if (capitalizeNext) c.uppercaseChar() else c)
+                capitalizeNext = false
+            }
+        }
+    }
+}
 
 internal class FileContentParser(
     private val ctx: GeneratorContext,
@@ -37,25 +81,25 @@ internal class FileContentParser(
 ) {
     constructor(ctx: GeneratorContext) : this(
         ctx,
-        ctx.fdp.enumTypeList,
-        ctx.fdp.messageTypeList,
-        ctx.fdp.serviceList,
+        ctx.fdp.enumType,
+        ctx.fdp.messageType,
+        ctx.fdp.service,
         emptyList()
     )
 
     fun parseContents(): List<TopLevelType> =
         enums.mapIndexed { idx, desc ->
-            withEnumName(desc.name) {
+            withEnumName(desc.name.orEmpty()) {
                 EnumParser(ctx, idx, desc, enclosingMessages).toEnum()
             }
         } +
             messages.mapIndexed { idx, desc ->
-                withMessageName((enclosingMessages + desc.name).joinToString(".")) {
+                withMessageName((enclosingMessages + desc.name.orEmpty()).joinToString(".")) {
                     MessageParser(ctx, idx, desc, enclosingMessages, null, null).toMessage()
                 }
             } +
             services.mapIndexed { idx, desc ->
-                withServiceName(desc.name) {
+                withServiceName(desc.name.orEmpty()) {
                     ServiceParser(idx, desc).toService()
                 }
             }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GeneratorContext.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GeneratorContext.kt
@@ -15,9 +15,9 @@
 
 package protokt.v1.codegen.util
 
-import com.google.protobuf.DescriptorProtos
-import com.google.protobuf.DescriptorProtos.FileDescriptorProto
-import com.toasttab.protokt.v1.ProtoktProtos
+import protokt.v1.file
+import protokt.v1.google.protobuf.Edition
+import protokt.v1.google.protobuf.FileDescriptorProto
 import protokt.v1.gradle.PROTOKT_VERSION
 
 internal class GeneratorContext(
@@ -43,19 +43,23 @@ internal class GeneratorContext(
     val fileDescriptorObjectName = allDescriptorClassNamesByFileName.getValue(fdp.name)
     val kotlinPackage = allPackagesByFileName.getValue(fdp.name)
 
-    val proto2 = !fdp.hasSyntax() || fdp.syntax == "proto2"
+    val proto2 = fdp.syntax == null || fdp.syntax == "proto2"
     val proto3 = fdp.syntax == "proto3"
-    val edition2023 = fdp.edition == DescriptorProtos.Edition.EDITION_2023
+    val edition2023 = fdp.edition == Edition.EDITION_2023
 }
 
 val FileDescriptorProto.fileOptions
-    get() = FileOptions(options, options.getExtension(ProtoktProtos.file))
+    get() =
+        FileOptions(
+            options ?: protokt.v1.google.protobuf.FileOptions {},
+            options?.file ?: protokt.v1.FileOptions {}
+        )
 
-private fun generateFdpObjectNames(files: List<FileDescriptorProto>): Map<String, String> =
+private fun generateFdpObjectNames(files: List<FileDescriptorProto>): Map<String?, String> =
     files.associate { fdp ->
         Pair(
             fdp.name,
             fdp.fileOptions.protokt.fileDescriptorObjectName.takeIf { it.isNotEmpty() }
-                ?: (fdp.name.substringBefore(".proto").substringAfterLast('/') + "_file_descriptor")
+                ?: (fdp.name.orEmpty().substringBefore(".proto").substringAfterLast('/') + "_file_descriptor")
         )
     }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GrpcKotlinGeneratorSupport.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/GrpcKotlinGeneratorSupport.kt
@@ -15,9 +15,9 @@
 
 package protokt.v1.codegen.util
 
-import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
-import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import io.grpc.kotlin.generator.GeneratorRunner
+import protokt.v1.google.protobuf.compiler.CodeGeneratorRequest
+import protokt.v1.google.protobuf.compiler.CodeGeneratorResponse
 import protokt.v1.reflect.resolvePackage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -31,33 +31,27 @@ internal fun generateGrpcKotlinStubs(
         params.generateGrpcKotlinStubs
     ) {
         val out = ReadableByteArrayOutputStream()
-        GeneratorRunner.mainAsProtocPlugin(stripPackages(request).toByteArray().inputStream(), out)
-        CodeGeneratorResponse.parseFrom(out.inputStream()).fileList
-            .map {
-                it.toBuilder()
-                    .setContent(tidy(it.content, params.formatOutput))
-                    .build()
-            }
+        GeneratorRunner.mainAsProtocPlugin(stripPackages(request).inputStream(), out)
+        CodeGeneratorResponse.deserialize(out.toByteArray())
+            .file
+            .map { it.copy { content = tidy(it.content.orEmpty(), params.formatOutput) } }
     } else {
         emptyList()
     }
 
-private fun stripPackages(request: CodeGeneratorRequest) =
-    request.toBuilder()
-        .clearProtoFile()
-        .addAllProtoFile(
-            request.protoFileList.map { fdp ->
-                fdp.toBuilder()
-                    .setOptions(
-                        fdp.options.toBuilder()
-                            .setJavaPackage(resolvePackage(fdp.`package`))
-                            .setJavaMultipleFiles(true)
-                            .build()
-                    )
-                    .build()
+private fun stripPackages(request: CodeGeneratorRequest): ByteArray =
+    request.copy {
+        protoFile =
+            request.protoFile.map { fdp ->
+                fdp.copy {
+                    options =
+                        (fdp.options ?: protokt.v1.google.protobuf.FileOptions {}).copy {
+                            javaPackage = resolvePackage(fdp.`package`.orEmpty())
+                            javaMultipleFiles = true
+                        }
+                }
             }
-        )
-        .build()
+    }.serialize()
 
 private class ReadableByteArrayOutputStream : ByteArrayOutputStream() {
     fun inputStream() =

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/MessageParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/MessageParser.kt
@@ -15,8 +15,8 @@
 
 package protokt.v1.codegen.util
 
-import com.google.protobuf.DescriptorProtos.DescriptorProto
-import com.toasttab.protokt.v1.ProtoktProtos
+import protokt.v1.`class`
+import protokt.v1.google.protobuf.DescriptorProto
 
 internal class MessageParser(
     private val ctx: GeneratorContext,
@@ -28,7 +28,7 @@ internal class MessageParser(
 ) {
     fun toMessage(): Message {
         val fieldList = FieldParser(ctx, desc, enclosingMessages, keyWrap, valueWrap).toFields()
-        val simpleNames = enclosingMessages + desc.name
+        val simpleNames = enclosingMessages + desc.name.orEmpty()
         return Message(
             fields = fieldList.sortedBy {
                 when (it) {
@@ -38,18 +38,18 @@ internal class MessageParser(
             },
             nestedTypes = FileContentParser(
                 ctx,
-                desc.enumTypeList,
-                desc.nestedTypeList,
+                desc.enumType,
+                desc.nestedType,
                 emptyList(),
                 simpleNames
             ).parseContents(),
-            mapEntry = desc.options.mapEntry,
+            mapEntry = desc.options?.mapEntry == true,
             options = MessageOptions(
-                desc.options,
-                desc.options.getExtension(ProtoktProtos.class_)
+                desc.options ?: protokt.v1.google.protobuf.MessageOptions {},
+                desc.options?.`class` ?: protokt.v1.MessageOptions {}
             ),
             index = idx,
-            fullProtobufTypeName = "${ctx.fdp.`package`}.${simpleNames.joinToString(".")}",
+            fullProtobufTypeName = "${ctx.fdp.`package`.orEmpty()}.${simpleNames.joinToString(".")}",
             className = ctx.className(simpleNames),
             deserializerClassName = ctx.className(simpleNames + DESERIALIZER)
         )

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/ServiceParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/ServiceParser.kt
@@ -15,12 +15,13 @@
 
 package protokt.v1.codegen.util
 
-import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
-import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto
 import com.squareup.kotlinpoet.ClassName
-import com.toasttab.protokt.v1.ProtoktProtos
 import io.grpc.kotlin.generator.protoc.ProtoMethodName
+import protokt.v1.google.protobuf.MethodDescriptorProto
+import protokt.v1.google.protobuf.ServiceDescriptorProto
+import protokt.v1.method
 import protokt.v1.reflect.requalifyProtoType
+import protokt.v1.service
 
 class ServiceParser(
     private val idx: Int,
@@ -28,27 +29,27 @@ class ServiceParser(
 ) {
     fun toService() =
         Service(
-            name = desc.name,
-            methods = desc.methodList.map(::toMethod),
-            deprecated = desc.options.deprecated,
+            name = desc.name.orEmpty(),
+            methods = desc.method.map(::toMethod),
+            deprecated = desc.options?.deprecated == true,
             options = ServiceOptions(
-                desc.options,
-                desc.options.getExtension(ProtoktProtos.service)
+                desc.options ?: protokt.v1.google.protobuf.ServiceOptions {},
+                desc.options?.service ?: protokt.v1.ServiceOptions {}
             ),
             index = idx
         )
 
     private fun toMethod(desc: MethodDescriptorProto) =
         Method(
-            name = ProtoMethodName(desc.name),
-            inputType = ClassName.bestGuess(requalifyProtoType(desc.inputType)),
-            outputType = ClassName.bestGuess(requalifyProtoType(desc.outputType)),
-            clientStreaming = desc.clientStreaming,
-            serverStreaming = desc.serverStreaming,
-            deprecated = desc.options.deprecated,
+            name = ProtoMethodName(desc.name.orEmpty()),
+            inputType = ClassName.bestGuess(requalifyProtoType(desc.inputType.orEmpty())),
+            outputType = ClassName.bestGuess(requalifyProtoType(desc.outputType.orEmpty())),
+            clientStreaming = desc.clientStreaming == true,
+            serverStreaming = desc.serverStreaming == true,
+            deprecated = desc.options?.deprecated == true,
             options = MethodOptions(
-                desc.options,
-                desc.options.getExtension(ProtoktProtos.method)
+                desc.options ?: protokt.v1.google.protobuf.MethodOptions {},
+                desc.options?.method ?: protokt.v1.MethodOptions {}
             )
         )
 }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/Types.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/Types.kt
@@ -15,12 +15,19 @@
 
 package protokt.v1.codegen.util
 
-import com.google.protobuf.DescriptorProtos
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
-import com.toasttab.protokt.v1.ProtoktProtos
 import io.grpc.kotlin.generator.protoc.ProtoMethodName
+import protokt.v1.google.protobuf.SourceCodeInfo
 import protokt.v1.reflect.FieldType
+import protokt.v1.google.protobuf.EnumOptions as PbEnumOptions
+import protokt.v1.google.protobuf.EnumValueOptions as PbEnumValueOptions
+import protokt.v1.google.protobuf.FieldOptions as PbFieldOptions
+import protokt.v1.google.protobuf.FileOptions as PbFileOptions
+import protokt.v1.google.protobuf.MessageOptions as PbMessageOptions
+import protokt.v1.google.protobuf.MethodOptions as PbMethodOptions
+import protokt.v1.google.protobuf.OneofOptions as PbOneofOptions
+import protokt.v1.google.protobuf.ServiceOptions as PbServiceOptions
 
 sealed class TopLevelType
 
@@ -36,8 +43,8 @@ class Message(
 ) : TopLevelType()
 
 data class MessageOptions(
-    val default: DescriptorProtos.MessageOptions,
-    val protokt: ProtoktProtos.MessageOptions
+    val default: PbMessageOptions,
+    val protokt: protokt.v1.MessageOptions
 )
 
 class Enum(
@@ -57,13 +64,13 @@ class Enum(
 }
 
 class EnumOptions(
-    val default: DescriptorProtos.EnumOptions,
-    val protokt: ProtoktProtos.EnumOptions
+    val default: PbEnumOptions,
+    val protokt: protokt.v1.EnumOptions
 )
 
 class EnumValueOptions(
-    val default: DescriptorProtos.EnumValueOptions,
-    val protokt: ProtoktProtos.EnumValueOptions
+    val default: PbEnumValueOptions,
+    val protokt: protokt.v1.EnumValueOptions
 )
 
 class Service(
@@ -75,8 +82,8 @@ class Service(
 ) : TopLevelType()
 
 class ServiceOptions(
-    val default: DescriptorProtos.ServiceOptions,
-    val protokt: ProtoktProtos.ServiceOptions
+    val default: PbServiceOptions,
+    val protokt: protokt.v1.ServiceOptions
 )
 
 class Method(
@@ -90,8 +97,8 @@ class Method(
 )
 
 class MethodOptions(
-    val default: DescriptorProtos.MethodOptions,
-    val protokt: ProtoktProtos.MethodOptions
+    val default: PbMethodOptions,
+    val protokt: protokt.v1.MethodOptions
 )
 
 sealed class Field {
@@ -139,34 +146,44 @@ internal class Oneof(
 ) : Field()
 
 class FieldOptions(
-    val default: DescriptorProtos.FieldOptions,
-    val protokt: ProtoktProtos.FieldOptions,
+    val default: PbFieldOptions,
+    val protokt: protokt.v1.FieldOptions,
     val wrap: String?
 )
 
 class OneofOptions(
-    val default: DescriptorProtos.OneofOptions,
-    val protokt: ProtoktProtos.OneofOptions
+    val default: PbOneofOptions,
+    val protokt: protokt.v1.OneofOptions
 )
 
 internal class ProtoFileInfo(
     val context: GeneratorContext
 ) {
-    val name = context.fdp.name
+    val name = context.fdp.name.orEmpty()
     val kotlinPackage = context.kotlinPackage
-    val protoPackage = context.fdp.`package`
+    val protoPackage = context.fdp.`package`.orEmpty()
     val options = context.fileOptions
-    val sourceCodeInfo = context.fdp.sourceCodeInfo
+    val sourceCodeInfo: SourceCodeInfo? = context.fdp.sourceCodeInfo
 }
 
 class FileOptions(
-    val default: DescriptorProtos.FileOptions,
-    val protokt: ProtoktProtos.FileOptions
+    val default: PbFileOptions,
+    val protokt: protokt.v1.FileOptions
+)
+
+internal class ProtoExtension(
+    val fieldName: String,
+    val number: Int,
+    val extendee: ClassName,
+    val fieldType: FieldType,
+    val valueClassName: ClassName?,
+    val repeated: Boolean
 )
 
 internal class ProtoFileContents(
     val info: ProtoFileInfo,
-    val types: List<TopLevelType>
+    val types: List<TopLevelType>,
+    val extensions: List<ProtoExtension> = emptyList()
 )
 
 class GeneratedType(

--- a/protokt-core-lite/api/protokt-core-lite.api
+++ b/protokt-core-lite/api/protokt-core-lite.api
@@ -5,7 +5,7 @@ public final class protokt/v1/google/protobuf/Any : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Any;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTypeUrl ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Lprotokt/v1/Bytes;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Any;
@@ -48,7 +48,7 @@ public final class protokt/v1/google/protobuf/Api : protokt/v1/AbstractMessage {
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getSourceContext ()Lprotokt/v1/google/protobuf/SourceContext;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Api;
@@ -95,7 +95,7 @@ public final class protokt/v1/google/protobuf/BoolValue : protokt/v1/AbstractMes
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BoolValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/BoolValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Z
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BoolValue;
@@ -140,7 +140,7 @@ public final class protokt/v1/google/protobuf/BytesValue : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BytesValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/BytesValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Lprotokt/v1/Bytes;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/BytesValue;
@@ -195,7 +195,7 @@ public final class protokt/v1/google/protobuf/DescriptorProto : protokt/v1/Abstr
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/MessageOptions;
 	public final fun getReservedName ()Ljava/util/List;
 	public final fun getReservedRange ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -250,7 +250,7 @@ public final class protokt/v1/google/protobuf/DescriptorProto$ExtensionRange : p
 	public final fun getEnd ()Ljava/lang/Integer;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/ExtensionRangeOptions;
 	public final fun getStart ()Ljava/lang/Integer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DescriptorProto$ExtensionRange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -290,7 +290,7 @@ public final class protokt/v1/google/protobuf/DescriptorProto$ReservedRange : pr
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnd ()Ljava/lang/Integer;
 	public final fun getStart ()Ljava/lang/Integer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DescriptorProto$ReservedRange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -326,7 +326,7 @@ public final class protokt/v1/google/protobuf/DoubleValue : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DoubleValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/DoubleValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()D
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/DoubleValue;
@@ -373,7 +373,7 @@ public final class protokt/v1/google/protobuf/Duration : protokt/v1/AbstractMess
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNanos ()I
 	public final fun getSeconds ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Duration;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -473,7 +473,7 @@ public final class protokt/v1/google/protobuf/Empty : protokt/v1/AbstractMessage
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Empty;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Empty;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Empty;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -511,7 +511,7 @@ public final class protokt/v1/google/protobuf/Enum : protokt/v1/AbstractMessage 
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getSourceContext ()Lprotokt/v1/google/protobuf/SourceContext;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Enum;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -559,7 +559,7 @@ public final class protokt/v1/google/protobuf/EnumDescriptorProto : protokt/v1/A
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/EnumOptions;
 	public final fun getReservedName ()Ljava/util/List;
 	public final fun getReservedRange ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumDescriptorProto;
@@ -604,7 +604,7 @@ public final class protokt/v1/google/protobuf/EnumDescriptorProto$EnumReservedRa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnd ()Ljava/lang/Integer;
 	public final fun getStart ()Ljava/lang/Integer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumDescriptorProto$EnumReservedRange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -645,7 +645,7 @@ public final class protokt/v1/google/protobuf/EnumOptions : protokt/v1/AbstractM
 	public final fun getDeprecatedLegacyJsonFieldConflicts ()Ljava/lang/Boolean;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -690,7 +690,7 @@ public final class protokt/v1/google/protobuf/EnumValue : protokt/v1/AbstractMes
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNumber ()I
 	public final fun getOptions ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumValue;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -731,7 +731,7 @@ public final class protokt/v1/google/protobuf/EnumValueDescriptorProto : protokt
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNumber ()Ljava/lang/Integer;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/EnumValueOptions;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumValueDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -774,7 +774,7 @@ public final class protokt/v1/google/protobuf/EnumValueOptions : protokt/v1/Abst
 	public final fun getFeatureSupport ()Lprotokt/v1/google/protobuf/FieldOptions$FeatureSupport;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/EnumValueOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -819,7 +819,7 @@ public final class protokt/v1/google/protobuf/ExtensionRangeOptions : protokt/v1
 	public final fun getDeclaration ()Ljava/util/List;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVerification ()Lprotokt/v1/google/protobuf/ExtensionRangeOptions$VerificationState;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ExtensionRangeOptions;
@@ -859,7 +859,7 @@ public final class protokt/v1/google/protobuf/ExtensionRangeOptions$Declaration 
 	public final fun getRepeated ()Ljava/lang/Boolean;
 	public final fun getReserved ()Ljava/lang/Boolean;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ExtensionRangeOptions$Declaration;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -937,7 +937,7 @@ public final class protokt/v1/google/protobuf/FeatureSet : protokt/v1/AbstractMe
 	public final fun getJsonFormat ()Lprotokt/v1/google/protobuf/FeatureSet$JsonFormat;
 	public final fun getMessageEncoding ()Lprotokt/v1/google/protobuf/FeatureSet$MessageEncoding;
 	public final fun getRepeatedFieldEncoding ()Lprotokt/v1/google/protobuf/FeatureSet$RepeatedFieldEncoding;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUtf8Validation ()Lprotokt/v1/google/protobuf/FeatureSet$Utf8Validation;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FeatureSet;
@@ -1187,7 +1187,7 @@ public final class protokt/v1/google/protobuf/FeatureSetDefaults : protokt/v1/Ab
 	public final fun getDefaults ()Ljava/util/List;
 	public final fun getMaximumEdition ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getMinimumEdition ()Lprotokt/v1/google/protobuf/Edition;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FeatureSetDefaults;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1228,7 +1228,7 @@ public final class protokt/v1/google/protobuf/FeatureSetDefaults$FeatureSetEditi
 	public final fun getEdition ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getFixedFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getOverridableFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FeatureSetDefaults$FeatureSetEditionDefault;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1276,7 +1276,7 @@ public final class protokt/v1/google/protobuf/Field : protokt/v1/AbstractMessage
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getPacked ()Z
 	public final fun getTypeUrl ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Field;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1463,7 +1463,7 @@ public final class protokt/v1/google/protobuf/FieldDescriptorProto : protokt/v1/
 	public final fun getProto3Optional ()Ljava/lang/Boolean;
 	public final fun getType ()Lprotokt/v1/google/protobuf/FieldDescriptorProto$Type;
 	public final fun getTypeName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1634,7 +1634,7 @@ public final class protokt/v1/google/protobuf/FieldMask : protokt/v1/AbstractMes
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FieldMask;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPaths ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldMask;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1680,7 +1680,7 @@ public final class protokt/v1/google/protobuf/FieldOptions : protokt/v1/Abstract
 	public final fun getRetention ()Lprotokt/v1/google/protobuf/FieldOptions$OptionRetention;
 	public final fun getTargets ()Ljava/util/List;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUnverifiedLazy ()Ljava/lang/Boolean;
 	public final fun getWeak ()Ljava/lang/Boolean;
 	public fun hashCode ()I
@@ -1771,7 +1771,7 @@ public final class protokt/v1/google/protobuf/FieldOptions$EditionDefault : prot
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FieldOptions$EditionDefault;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEdition ()Lprotokt/v1/google/protobuf/Edition;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldOptions$EditionDefault;
@@ -1812,7 +1812,7 @@ public final class protokt/v1/google/protobuf/FieldOptions$FeatureSupport : prot
 	public final fun getEditionDeprecated ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getEditionIntroduced ()Lprotokt/v1/google/protobuf/Edition;
 	public final fun getEditionRemoved ()Lprotokt/v1/google/protobuf/Edition;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FieldOptions$FeatureSupport;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1976,7 +1976,7 @@ public final class protokt/v1/google/protobuf/FileDescriptorProto : protokt/v1/A
 	public final fun getService ()Ljava/util/List;
 	public final fun getSourceCodeInfo ()Lprotokt/v1/google/protobuf/SourceCodeInfo;
 	public final fun getSyntax ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWeakDependency ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FileDescriptorProto;
@@ -2036,7 +2036,7 @@ public final class protokt/v1/google/protobuf/FileDescriptorSet : protokt/v1/Abs
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FileDescriptorSet;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFile ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FileDescriptorSet;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2091,7 +2091,7 @@ public final class protokt/v1/google/protobuf/FileOptions : protokt/v1/AbstractM
 	public final fun getRubyPackage ()Ljava/lang/String;
 	public final fun getSwiftPrefix ()Ljava/lang/String;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FileOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2193,7 +2193,7 @@ public final class protokt/v1/google/protobuf/FloatValue : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FloatValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/FloatValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()F
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/FloatValue;
@@ -2239,7 +2239,7 @@ public final class protokt/v1/google/protobuf/GeneratedCodeInfo : protokt/v1/Abs
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/GeneratedCodeInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnnotation ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/GeneratedCodeInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2259,7 +2259,7 @@ public final class protokt/v1/google/protobuf/GeneratedCodeInfo$Annotation : pro
 	public final fun getPath ()Ljava/util/List;
 	public final fun getSemantic ()Lprotokt/v1/google/protobuf/GeneratedCodeInfo$Annotation$Semantic;
 	public final fun getSourceFile ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/GeneratedCodeInfo$Annotation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2348,7 +2348,7 @@ public final class protokt/v1/google/protobuf/Int32Value : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int32Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Int32Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int32Value;
@@ -2393,7 +2393,7 @@ public final class protokt/v1/google/protobuf/Int64Value : protokt/v1/AbstractMe
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int64Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Int64Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()J
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Int64Value;
@@ -2438,7 +2438,7 @@ public final class protokt/v1/google/protobuf/ListValue : protokt/v1/AbstractMes
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ListValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/ListValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ListValue;
@@ -2480,7 +2480,7 @@ public final class protokt/v1/google/protobuf/MessageOptions : protokt/v1/Abstra
 	public final fun getMessageSetWireFormat ()Ljava/lang/Boolean;
 	public final fun getNoStandardDescriptorAccessor ()Ljava/lang/Boolean;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/MessageOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2533,7 +2533,7 @@ public final class protokt/v1/google/protobuf/Method : protokt/v1/AbstractMessag
 	public final fun getResponseStreaming ()Z
 	public final fun getResponseTypeUrl ()Ljava/lang/String;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Method;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2585,7 +2585,7 @@ public final class protokt/v1/google/protobuf/MethodDescriptorProto : protokt/v1
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/MethodOptions;
 	public final fun getOutputType ()Ljava/lang/String;
 	public final fun getServerStreaming ()Ljava/lang/Boolean;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/MethodDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2633,7 +2633,7 @@ public final class protokt/v1/google/protobuf/MethodOptions : protokt/v1/Abstrac
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getIdempotencyLevel ()Lprotokt/v1/google/protobuf/MethodOptions$IdempotencyLevel;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/MethodOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2703,7 +2703,7 @@ public final class protokt/v1/google/protobuf/Mixin : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRoot ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Mixin;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2761,7 +2761,7 @@ public final class protokt/v1/google/protobuf/OneofDescriptorProto : protokt/v1/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/OneofOptions;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/OneofDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2799,7 +2799,7 @@ public final class protokt/v1/google/protobuf/OneofOptions : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/OneofOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2836,7 +2836,7 @@ public final class protokt/v1/google/protobuf/Option : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Option;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Lprotokt/v1/google/protobuf/Any;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Option;
@@ -2876,7 +2876,7 @@ public final class protokt/v1/google/protobuf/ServiceDescriptorProto : protokt/v
 	public final fun getMethod ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOptions ()Lprotokt/v1/google/protobuf/ServiceOptions;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ServiceDescriptorProto;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2917,7 +2917,7 @@ public final class protokt/v1/google/protobuf/ServiceOptions : protokt/v1/Abstra
 	public final fun getDeprecated ()Ljava/lang/Boolean;
 	public final fun getFeatures ()Lprotokt/v1/google/protobuf/FeatureSet;
 	public final fun getUninterpretedOption ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/ServiceOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2956,7 +2956,7 @@ public final class protokt/v1/google/protobuf/SourceCodeInfo : protokt/v1/Abstra
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/SourceCodeInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLocation ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/SourceCodeInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2995,7 +2995,7 @@ public final class protokt/v1/google/protobuf/SourceCodeInfo$Location : protokt/
 	public final fun getPath ()Ljava/util/List;
 	public final fun getSpan ()Ljava/util/List;
 	public final fun getTrailingComments ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/SourceCodeInfo$Location;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3038,7 +3038,7 @@ public final class protokt/v1/google/protobuf/SourceContext : protokt/v1/Abstrac
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/SourceContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFileName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/SourceContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3072,7 +3072,7 @@ public final class protokt/v1/google/protobuf/StringValue : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/StringValue;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/StringValue;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/StringValue;
@@ -3118,7 +3118,7 @@ public final class protokt/v1/google/protobuf/Struct : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Struct;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFields ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Struct;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3182,7 +3182,7 @@ public final class protokt/v1/google/protobuf/Timestamp : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNanos ()I
 	public final fun getSeconds ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Timestamp;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3225,7 +3225,7 @@ public final class protokt/v1/google/protobuf/Type : protokt/v1/AbstractMessage 
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getSourceContext ()Lprotokt/v1/google/protobuf/SourceContext;
 	public final fun getSyntax ()Lprotokt/v1/google/protobuf/Syntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Type;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3271,7 +3271,7 @@ public final class protokt/v1/google/protobuf/UInt32Value : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt32Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/UInt32Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue-pVg5ArA ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt32Value;
@@ -3316,7 +3316,7 @@ public final class protokt/v1/google/protobuf/UInt64Value : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt64Value;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/UInt64Value;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue-s-VKNKU ()J
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UInt64Value;
@@ -3368,7 +3368,7 @@ public final class protokt/v1/google/protobuf/UninterpretedOption : protokt/v1/A
 	public final fun getNegativeIntValue ()Ljava/lang/Long;
 	public final fun getPositiveIntValue-6VbMDqA ()Lkotlin/ULong;
 	public final fun getStringValue ()Lprotokt/v1/Bytes;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UninterpretedOption;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3415,7 +3415,7 @@ public final class protokt/v1/google/protobuf/UninterpretedOption$NamePart : pro
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/UninterpretedOption$NamePart;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNamePart ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/UninterpretedOption$NamePart;
 	public final fun isExtension ()Z
@@ -3453,7 +3453,7 @@ public final class protokt/v1/google/protobuf/Value : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/protobuf/Value;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKind ()Lprotokt/v1/google/protobuf/Value$Kind;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/protobuf/Value;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3557,7 +3557,7 @@ public final class protokt/v1/pb/JavaFeatures : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/pb/JavaFeatures;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLegacyClosedEnum ()Ljava/lang/Boolean;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUseOldOuterClassnameDefault ()Ljava/lang/Boolean;
 	public final fun getUtf8Validation ()Lprotokt/v1/pb/JavaFeatures$Utf8Validation;
 	public fun hashCode ()I

--- a/protokt-reflect/api/protokt-reflect.api
+++ b/protokt-reflect/api/protokt-reflect.api
@@ -711,7 +711,7 @@ public final class protokt/v1/EnumOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -746,7 +746,7 @@ public final class protokt/v1/EnumValueOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/EnumValueOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/EnumValueOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -784,7 +784,7 @@ public final class protokt/v1/FieldOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getKeyWrap ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueWrap ()Ljava/lang/String;
 	public final fun getWrap ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -831,7 +831,7 @@ public final class protokt/v1/FileOptions : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/FileOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/FileOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -867,7 +867,7 @@ public final class protokt/v1/MessageOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MessageOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -905,7 +905,7 @@ public final class protokt/v1/MethodOptions : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestMarshaller ()Ljava/lang/String;
 	public final fun getResponseMarshaller ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/MethodOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -944,7 +944,7 @@ public final class protokt/v1/OneofOptions : protokt/v1/AbstractMessage {
 	public final fun getDeprecationMessage ()Ljava/lang/String;
 	public final fun getGenerateNonNullAccessor ()Z
 	public final fun getImplements ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/OneofOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -993,7 +993,7 @@ public final class protokt/v1/ServiceOptions : protokt/v1/AbstractMessage {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/ServiceOptions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/ServiceOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
@@ -23,7 +23,6 @@ import protokt.v1.Fixed64Val
 import protokt.v1.GeneratedProperty
 import protokt.v1.LengthDelimitedVal
 import protokt.v1.Message
-import protokt.v1.UnknownFieldSet
 import protokt.v1.VarintVal
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
@@ -99,7 +98,7 @@ internal object ProtoktReflect {
     }
 
     private fun getUnknownField(field: FieldDescriptor, message: Message) =
-        getUnknownFields(message)[field.number.toUInt()]?.let { value ->
+        message.unknownFields[field.number.toUInt()]?.let { value ->
             when {
                 value.varint.isNotEmpty() ->
                     value.varint
@@ -146,14 +145,3 @@ internal object ProtoktReflect {
     fun getField(message: Message, field: FieldDescriptor): Any? =
         getReflectedGettersByClass(message::class)(field, message)
 }
-
-internal fun getUnknownFields(message: Message) =
-    message::class
-        .declaredMemberProperties
-        .firstOrNull { it.returnType.classifier == UnknownFieldSet::class }
-        .let {
-            @Suppress("UNCHECKED_CAST")
-            it as KProperty1<Message, UnknownFieldSet>
-        }
-        .get(message)
-        .unknownFields

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
@@ -227,10 +227,11 @@ private fun convertMap(
     }
 }
 
+@OptIn(protokt.v1.OnlyForUseByGeneratedProtoCode::class)
 private fun mapUnknownFields(message: Message): UnknownFieldSet {
     val unknownFields = UnknownFieldSet.newBuilder()
 
-    getUnknownFields(message).forEach { (number, field) ->
+    message.unknownFields.forEach { number, field ->
         unknownFields.mergeField(
             number.toInt(),
             Field.newBuilder()

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
@@ -67,7 +67,7 @@ class RuntimeContext internal constructor(
 
     internal fun unwrap(value: Any, field: FieldDescriptor, wrap: String): Any {
         val proto = field.toProto()
-        val type = FieldType.from(proto.type)
+        val type = FieldType.from(proto.type.number)
         val converterDetails =
             classLookup.converter(
                 ClassLookup.evaluateProtobufTypeCanonicalName(

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -130,6 +130,43 @@ public abstract interface class protokt/v1/EnumDeserializer {
 	public abstract fun deserialize (I)Lprotokt/v1/Enum;
 }
 
+public final class protokt/v1/Extension {
+	public synthetic fun <init> (ILprotokt/v1/ExtensionCodec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getNumber-pVg5ArA ()I
+}
+
+public abstract interface class protokt/v1/ExtensionCodec {
+	public abstract fun decodeRepeated (Lprotokt/v1/UnknownFieldSet$Field;)Ljava/util/List;
+	public abstract fun decodeSingular (Lprotokt/v1/UnknownFieldSet$Field;)Ljava/lang/Object;
+	public abstract fun encode-qim9Vi0 (ILjava/lang/Object;)Lprotokt/v1/UnknownField;
+}
+
+public final class protokt/v1/ExtensionCodecs {
+	public static final field INSTANCE Lprotokt/v1/ExtensionCodecs;
+	public final fun enum (Lprotokt/v1/EnumDeserializer;)Lprotokt/v1/ExtensionCodec;
+	public final fun getBool ()Lprotokt/v1/ExtensionCodec;
+	public final fun getBytes ()Lprotokt/v1/ExtensionCodec;
+	public final fun getDouble ()Lprotokt/v1/ExtensionCodec;
+	public final fun getFixed32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getFixed64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getFloat ()Lprotokt/v1/ExtensionCodec;
+	public final fun getInt32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getInt64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSfixed32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSfixed64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSint32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getSint64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getString ()Lprotokt/v1/ExtensionCodec;
+	public final fun getUint32 ()Lprotokt/v1/ExtensionCodec;
+	public final fun getUint64 ()Lprotokt/v1/ExtensionCodec;
+	public final fun message (Lprotokt/v1/Deserializer;)Lprotokt/v1/ExtensionCodec;
+}
+
+public final class protokt/v1/ExtensionKt {
+	public static final fun get (Lprotokt/v1/Message;Lprotokt/v1/Extension;)Ljava/lang/Object;
+	public static final fun get (Lprotokt/v1/Message;Lprotokt/v1/RepeatedExtension;)Ljava/util/List;
+}
+
 public final class protokt/v1/Fixed32Val : protokt/v1/UnknownValue {
 	public static final synthetic fun box-impl (I)Lprotokt/v1/Fixed32Val;
 	public static fun constructor-impl (I)I
@@ -248,6 +285,7 @@ public abstract interface class protokt/v1/MapBuilder {
 }
 
 public abstract interface class protokt/v1/Message {
+	public abstract fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public abstract fun serialize ()[B
 	public fun serialize (Ljava/io/OutputStream;)V
 	public abstract fun serialize (Lprotokt/v1/Writer;)V
@@ -280,6 +318,11 @@ public abstract interface class protokt/v1/Reader {
 	public fun readUInt32-pVg5ArA ()I
 	public abstract fun readUInt64-s-VKNKU ()J
 	public fun readUnknown ()Lprotokt/v1/UnknownField;
+}
+
+public final class protokt/v1/RepeatedExtension {
+	public synthetic fun <init> (ILprotokt/v1/ExtensionCodec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getNumber-pVg5ArA ()I
 }
 
 public final class protokt/v1/Sizes {
@@ -331,8 +374,10 @@ public final class protokt/v1/UnknownField$Companion {
 public final class protokt/v1/UnknownFieldSet {
 	public static final field Companion Lprotokt/v1/UnknownFieldSet$Companion;
 	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun contains-WZ4Q5Ns (I)Z
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Ljava/util/Map;
+	public final fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public final fun get-WZ4Q5Ns (I)Lprotokt/v1/UnknownFieldSet$Field;
 	public fun hashCode ()I
 	public final fun isEmpty ()Z
 	public final fun size ()I

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Extension.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Extension.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+@Beta
+class Extension<in E : Message, out T>(
+    val number: UInt,
+    internal val codec: ExtensionCodec<@UnsafeVariance T>
+)
+
+@Beta
+class RepeatedExtension<in E : Message, out T>(
+    val number: UInt,
+    internal val codec: ExtensionCodec<@UnsafeVariance T>
+)
+
+@Beta
+operator fun <E : Message, T> E.get(ext: Extension<E, T>): T? {
+    val field = unknownFields[ext.number] ?: return null
+    return ext.codec.decodeSingular(field)
+}
+
+@Beta
+operator fun <E : Message, T> E.get(ext: RepeatedExtension<E, T>): List<T> {
+    val field = unknownFields[ext.number] ?: return emptyList()
+    return ext.codec.decodeRepeated(field)
+}

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+@Beta
+sealed interface ExtensionCodec<T> {
+    fun decodeSingular(field: UnknownFieldSet.Field): T?
+    fun decodeRepeated(field: UnknownFieldSet.Field): List<T>
+    fun encode(fieldNumber: UInt, value: T): UnknownField
+}
+
+@Beta
+object ExtensionCodecs {
+    val int32: ExtensionCodec<Int> =
+        VarintCodec({ it.toLong().toInt() }, { it.toLong().toULong() })
+
+    val int64: ExtensionCodec<Long> =
+        VarintCodec({ it.toLong() }, { it.toULong() })
+
+    val uint32: ExtensionCodec<UInt> =
+        VarintCodec({ it.toUInt() }, { it.toULong() })
+
+    val uint64: ExtensionCodec<ULong> =
+        VarintCodec({ it }, { it })
+
+    val sint32: ExtensionCodec<Int> =
+        VarintCodec(
+            {
+                val n = it.toInt()
+                (n ushr 1) xor -(n and 1)
+            },
+            {
+                val v = it
+                ((v shl 1) xor (v shr 31)).toUInt().toULong()
+            }
+        )
+
+    val sint64: ExtensionCodec<Long> =
+        VarintCodec(
+            {
+                val n = it.toLong()
+                (n ushr 1) xor -(n and 1)
+            },
+            {
+                val v = it
+                ((v shl 1) xor (v shr 63)).toULong()
+            }
+        )
+
+    val bool: ExtensionCodec<Boolean> =
+        VarintCodec({ it != 0uL }, { if (it) 1uL else 0uL })
+
+    val fixed32: ExtensionCodec<UInt> =
+        Fixed32Codec({ it }, { it })
+
+    val sfixed32: ExtensionCodec<Int> =
+        Fixed32Codec({ it.toInt() }, { it.toUInt() })
+
+    val float: ExtensionCodec<Float> =
+        Fixed32Codec({ Float.fromBits(it.toInt()) }, { it.toRawBits().toUInt() })
+
+    val fixed64: ExtensionCodec<ULong> =
+        Fixed64Codec({ it }, { it })
+
+    val sfixed64: ExtensionCodec<Long> =
+        Fixed64Codec({ it.toLong() }, { it.toULong() })
+
+    val double: ExtensionCodec<Double> =
+        Fixed64Codec({ Double.fromBits(it.toLong()) }, { it.toRawBits().toULong() })
+
+    val string: ExtensionCodec<String> =
+        LengthDelimitedCodec(
+            { it.value.value.decodeToString() },
+            { LengthDelimitedVal(Bytes(it.encodeToByteArray())) }
+        )
+
+    val bytes: ExtensionCodec<Bytes> =
+        LengthDelimitedCodec(
+            { it.value },
+            { LengthDelimitedVal(it) }
+        )
+
+    fun <T : Message> message(deserializer: Deserializer<T>): ExtensionCodec<T> =
+        LengthDelimitedCodec(
+            { deserializer.deserialize(it.value) },
+            { LengthDelimitedVal(Bytes(it.serialize())) }
+        )
+
+    fun <T : Enum> enum(deserializer: EnumDeserializer<T>): ExtensionCodec<T> =
+        VarintCodec({ deserializer.deserialize(it.toInt()) }, { it.value.toULong() })
+}
+
+private class VarintCodec<T>(
+    private val decode: (ULong) -> T,
+    private val encode: (T) -> ULong
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.varint.lastOrNull()?.let { decode(it.value) }
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.varint.map { decode(it.value) }
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.varint(fieldNumber, encode(value).toLong())
+}
+
+private class Fixed32Codec<T>(
+    private val decode: (UInt) -> T,
+    private val encode: (T) -> UInt
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.fixed32.lastOrNull()?.let { decode(it.value) }
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.fixed32.map { decode(it.value) }
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.fixed32(fieldNumber, encode(value))
+}
+
+private class Fixed64Codec<T>(
+    private val decode: (ULong) -> T,
+    private val encode: (T) -> ULong
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.fixed64.lastOrNull()?.let { decode(it.value) }
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.fixed64.map { decode(it.value) }
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.fixed64(fieldNumber, encode(value))
+}
+
+private class LengthDelimitedCodec<T>(
+    private val decode: (LengthDelimitedVal) -> T,
+    private val encode: (T) -> LengthDelimitedVal
+) : ExtensionCodec<T> {
+    override fun decodeSingular(field: UnknownFieldSet.Field): T? =
+        field.lengthDelimited.lastOrNull()?.let(decode)
+
+    override fun decodeRepeated(field: UnknownFieldSet.Field): List<T> =
+        field.lengthDelimited.map(decode)
+
+    override fun encode(fieldNumber: UInt, value: T): UnknownField =
+        UnknownField.lengthDelimited(fieldNumber, encode(value).value.value)
+}

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Message.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Message.kt
@@ -16,6 +16,8 @@
 package protokt.v1
 
 expect interface Message {
+    val unknownFields: UnknownFieldSet
+
     fun serializedSize(): Int
 
     fun serialize(writer: Writer)

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
@@ -20,23 +20,35 @@ import protokt.v1.Collections.freezeMap
 import protokt.v1.Sizes.sizeOf
 
 class UnknownFieldSet private constructor(
-    val unknownFields: Map<UInt, Field>
+    private val fieldMap: Map<UInt, Field>
 ) {
-    fun size() =
-        unknownFields.entries.sumOf { (k, v) -> v.size(k) }
+    operator fun get(fieldNumber: UInt): Field? =
+        fieldMap[fieldNumber]
 
-    fun isEmpty() =
-        unknownFields.isEmpty()
+    operator fun contains(fieldNumber: UInt): Boolean =
+        fieldNumber in fieldMap
+
+    fun isEmpty(): Boolean =
+        fieldMap.isEmpty()
+
+    @OnlyForUseByGeneratedProtoCode
+    fun size() =
+        fieldMap.entries.sumOf { (k, v) -> v.size(k) }
+
+    @OnlyForUseByGeneratedProtoCode
+    fun forEach(action: (UInt, Field) -> Unit) {
+        fieldMap.forEach { (k, v) -> action(k, v) }
+    }
 
     override fun equals(other: Any?) =
         other is UnknownFieldSet &&
-            other.unknownFields == unknownFields
+            other.fieldMap == fieldMap
 
     override fun hashCode() =
-        unknownFields.hashCode()
+        fieldMap.hashCode()
 
     override fun toString() =
-        "UnknownFieldSet(unknownFields=$unknownFields)"
+        "UnknownFieldSet(fields=$fieldMap)"
 
     companion object {
         private val EMPTY = UnknownFieldSet(emptyMap())

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Writer.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Writer.kt
@@ -72,7 +72,7 @@ interface Writer {
     }
 
     fun writeUnknown(u: UnknownFieldSet) {
-        u.unknownFields.forEach { (k, v) -> v.write(k, this) }
+        u.forEach { k, v -> v.write(k, this) }
     }
 
     fun toByteArray(): ByteArray

--- a/protokt-runtime/src/jvmMain/kotlin/protokt/v1/Message.kt
+++ b/protokt-runtime/src/jvmMain/kotlin/protokt/v1/Message.kt
@@ -18,6 +18,8 @@ package protokt.v1
 import java.io.OutputStream
 
 actual interface Message {
+    actual val unknownFields: UnknownFieldSet
+
     actual fun serializedSize(): Int
 
     actual fun serialize(writer: Writer)

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ExtensionTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ExtensionTest.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ExtensionTest {
+    @Test
+    fun `decode singular varint int32`() {
+        val field = fieldOf(VarintVal(42uL))
+        assertThat(ExtensionCodecs.int32.decodeSingular(field)).isEqualTo(42)
+    }
+
+    @Test
+    fun `decode singular varint int64`() {
+        val field = fieldOf(VarintVal(Long.MAX_VALUE.toULong()))
+        assertThat(ExtensionCodecs.int64.decodeSingular(field)).isEqualTo(Long.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular varint uint32`() {
+        val field = fieldOf(VarintVal(UInt.MAX_VALUE.toULong()))
+        assertThat(ExtensionCodecs.uint32.decodeSingular(field)).isEqualTo(UInt.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular varint uint64`() {
+        val field = fieldOf(VarintVal(ULong.MAX_VALUE))
+        assertThat(ExtensionCodecs.uint64.decodeSingular(field)).isEqualTo(ULong.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular varint sint32`() {
+        val encoded = ((-1 shl 1) xor (-1 shr 31)).toUInt().toULong()
+        val field = fieldOf(VarintVal(encoded))
+        assertThat(ExtensionCodecs.sint32.decodeSingular(field)).isEqualTo(-1)
+    }
+
+    @Test
+    fun `decode singular varint sint64`() {
+        val encoded = ((-1L shl 1) xor (-1L shr 63)).toULong()
+        val field = fieldOf(VarintVal(encoded))
+        assertThat(ExtensionCodecs.sint64.decodeSingular(field)).isEqualTo(-1L)
+    }
+
+    @Test
+    fun `decode singular varint bool`() {
+        assertThat(ExtensionCodecs.bool.decodeSingular(fieldOf(VarintVal(1uL)))).isTrue()
+        assertThat(ExtensionCodecs.bool.decodeSingular(fieldOf(VarintVal(0uL)))).isFalse()
+    }
+
+    @Test
+    fun `decode singular fixed32`() {
+        val field = fieldOf(Fixed32Val(0xDEADBEEFu))
+        assertThat(ExtensionCodecs.fixed32.decodeSingular(field)).isEqualTo(0xDEADBEEFu)
+    }
+
+    @Test
+    fun `decode singular sfixed32`() {
+        val field = fieldOf(Fixed32Val((-1).toUInt()))
+        assertThat(ExtensionCodecs.sfixed32.decodeSingular(field)).isEqualTo(-1)
+    }
+
+    @Test
+    fun `decode singular float`() {
+        val field = fieldOf(Fixed32Val(1.5f.toRawBits().toUInt()))
+        assertThat(ExtensionCodecs.float.decodeSingular(field)).isEqualTo(1.5f)
+    }
+
+    @Test
+    fun `decode singular fixed64`() {
+        val field = fieldOf(Fixed64Val(ULong.MAX_VALUE))
+        assertThat(ExtensionCodecs.fixed64.decodeSingular(field)).isEqualTo(ULong.MAX_VALUE)
+    }
+
+    @Test
+    fun `decode singular sfixed64`() {
+        val field = fieldOf(Fixed64Val((-1L).toULong()))
+        assertThat(ExtensionCodecs.sfixed64.decodeSingular(field)).isEqualTo(-1L)
+    }
+
+    @Test
+    fun `decode singular double`() {
+        val field = fieldOf(Fixed64Val(3.14.toRawBits().toULong()))
+        assertThat(ExtensionCodecs.double.decodeSingular(field)).isEqualTo(3.14)
+    }
+
+    @Test
+    fun `decode singular string`() {
+        val field = fieldOf(LengthDelimitedVal(Bytes("hello".encodeToByteArray())))
+        assertThat(ExtensionCodecs.string.decodeSingular(field)).isEqualTo("hello")
+    }
+
+    @Test
+    fun `decode singular bytes`() {
+        val data = byteArrayOf(1, 2, 3)
+        val field = fieldOf(LengthDelimitedVal(Bytes(data)))
+        assertThat(ExtensionCodecs.bytes.decodeSingular(field)?.bytes).isEqualTo(data)
+    }
+
+    @Test
+    fun `decode repeated varints`() {
+        val field = fieldOf(VarintVal(1uL), VarintVal(2uL), VarintVal(3uL))
+        assertThat(ExtensionCodecs.int32.decodeRepeated(field)).containsExactly(1, 2, 3).inOrder()
+    }
+
+    @Test
+    fun `decode repeated fixed32`() {
+        val field = fieldOf(Fixed32Val(10u), Fixed32Val(20u))
+        assertThat(ExtensionCodecs.fixed32.decodeRepeated(field)).containsExactly(10u, 20u).inOrder()
+    }
+
+    @Test
+    fun `decode repeated strings`() {
+        val field =
+            fieldOf(
+                LengthDelimitedVal(Bytes("a".encodeToByteArray())),
+                LengthDelimitedVal(Bytes("b".encodeToByteArray()))
+            )
+        assertThat(ExtensionCodecs.string.decodeRepeated(field)).containsExactly("a", "b").inOrder()
+    }
+
+    @Test
+    fun `encode round-trip int32`() {
+        val encoded = ExtensionCodecs.int32.encode(1u, 42)
+        val decoded =
+            ExtensionCodecs.int32.decodeSingular(
+                buildField(encoded)
+            )
+        assertThat(decoded).isEqualTo(42)
+    }
+
+    @Test
+    fun `encode round-trip bool`() {
+        val encoded = ExtensionCodecs.bool.encode(1u, true)
+        val decoded =
+            ExtensionCodecs.bool.decodeSingular(
+                buildField(encoded)
+            )
+        assertThat(decoded).isTrue()
+    }
+
+    @Test
+    fun `encode round-trip string`() {
+        val encoded = ExtensionCodecs.string.encode(1u, "hello")
+        val decoded =
+            ExtensionCodecs.string.decodeSingular(
+                buildField(encoded)
+            )
+        assertThat(decoded).isEqualTo("hello")
+    }
+
+    @Test
+    fun `decode singular returns last value for multiple entries`() {
+        val field = fieldOf(VarintVal(1uL), VarintVal(2uL), VarintVal(3uL))
+        assertThat(ExtensionCodecs.int32.decodeSingular(field)).isEqualTo(3)
+    }
+
+    @Test
+    fun `decode singular returns null for empty field`() {
+        val field = emptyField()
+        assertThat(ExtensionCodecs.int32.decodeSingular(field)).isNull()
+        assertThat(ExtensionCodecs.string.decodeSingular(field)).isNull()
+        assertThat(ExtensionCodecs.fixed32.decodeSingular(field)).isNull()
+        assertThat(ExtensionCodecs.fixed64.decodeSingular(field)).isNull()
+    }
+
+    @Test
+    fun `operator get on message`() {
+        val ext = Extension<TestMsg, Int>(1u, ExtensionCodecs.int32)
+        val msg = TestMsg(VarintVal(42uL))
+        assertThat(msg[ext]).isEqualTo(42)
+    }
+
+    @Test
+    fun `operator get returns null for missing extension`() {
+        val ext = Extension<TestMsg, Int>(999u, ExtensionCodecs.int32)
+        val msg = TestMsg(VarintVal(42uL))
+        assertThat(msg[ext]).isNull()
+    }
+
+    @Test
+    fun `repeated operator get on message`() {
+        val ext = RepeatedExtension<TestMsg, Int>(1u, ExtensionCodecs.int32)
+        val msg =
+            TestMsg(
+                UnknownFieldSet.Builder().apply {
+                    add(UnknownField.varint(1u, 10))
+                    add(UnknownField.varint(1u, 20))
+                    add(UnknownField.varint(1u, 30))
+                }.build()
+            )
+        assertThat(msg[ext]).containsExactly(10, 20, 30).inOrder()
+    }
+
+    @Test
+    fun `repeated operator get returns empty list for missing extension`() {
+        val ext = RepeatedExtension<TestMsg, Int>(999u, ExtensionCodecs.int32)
+        val msg = TestMsg(VarintVal(42uL))
+        assertThat(msg[ext]).isEmpty()
+    }
+
+    private fun fieldOf(vararg values: UnknownValue): UnknownFieldSet.Field =
+        UnknownFieldSet.Field.Builder().apply { values.forEach { add(it) } }.build()
+
+    private fun emptyField(): UnknownFieldSet.Field =
+        UnknownFieldSet.Field.Builder().build()
+
+    private fun buildField(unknownField: UnknownField): UnknownFieldSet.Field =
+        UnknownFieldSet.Field.Builder().apply { add(unknownField.value) }.build()
+
+    @OptIn(OnlyForUseByGeneratedProtoCode::class)
+    private class TestMsg(
+        override val unknownFields: UnknownFieldSet
+    ) : AbstractMessage() {
+        constructor(value: UnknownValue) : this(
+            UnknownFieldSet.Builder().apply {
+                add(UnknownField.varint(1u, (value as VarintVal).value.toLong()))
+            }.build()
+        )
+
+        override fun serializedSize() =
+            unknownFields.size()
+        override fun serialize(writer: Writer) =
+            writer.writeUnknown(unknownFields)
+    }
+}

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
@@ -229,6 +229,7 @@ class ReaderValidationTest {
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object EmptyMessage : AbstractDeserializer<EmptyMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -247,6 +248,7 @@ private object EmptyMessage : AbstractDeserializer<EmptyMessage>(), Message {
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object Fixed32FieldMessage : AbstractDeserializer<Fixed32FieldMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -269,6 +271,7 @@ private object Fixed32FieldMessage : AbstractDeserializer<Fixed32FieldMessage>()
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object Fixed64FieldMessage : AbstractDeserializer<Fixed64FieldMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -291,6 +294,7 @@ private object Fixed64FieldMessage : AbstractDeserializer<Fixed64FieldMessage>()
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object VarintFieldMessage : AbstractDeserializer<VarintFieldMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -309,6 +313,7 @@ private object VarintFieldMessage : AbstractDeserializer<VarintFieldMessage>(), 
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object NestedLenDelimitedMessage : AbstractDeserializer<NestedLenDelimitedMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}
@@ -331,6 +336,7 @@ private object NestedLenDelimitedMessage : AbstractDeserializer<NestedLenDelimit
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 private object RecursiveMessage : AbstractDeserializer<RecursiveMessage>(), Message {
+    override val unknownFields = UnknownFieldSet.empty()
     override fun serializedSize() =
         0
     override fun serialize(writer: Writer) {}

--- a/protokt-runtime/src/nonJvmMain/kotlin/protokt/v1/Message.kt
+++ b/protokt-runtime/src/nonJvmMain/kotlin/protokt/v1/Message.kt
@@ -16,6 +16,8 @@
 package protokt.v1
 
 actual interface Message {
+    actual val unknownFields: UnknownFieldSet
+
     actual fun serializedSize(): Int
 
     actual fun serialize(writer: Writer)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ apply(plugin = "net.vivin.gradle-semantic-build-versioning")
 rootProject.name = "protokt"
 
 include(
+    "protokt-bootstrap",
     "protokt-codegen",
     "protokt-core",
     "protokt-core-lite",

--- a/shared-src/reflect/protokt/v1/reflect/FieldType.kt
+++ b/shared-src/reflect/protokt/v1/reflect/FieldType.kt
@@ -15,7 +15,6 @@
 
 package protokt.v1.reflect
 
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type
 import protokt.v1.Writer
 import kotlin.reflect.KClass
 
@@ -106,26 +105,26 @@ internal sealed class FieldType {
         }
 
     companion object {
-        fun from(type: Type) =
-            when (type) {
-                Type.TYPE_BOOL -> Bool
-                Type.TYPE_BYTES -> Bytes
-                Type.TYPE_DOUBLE -> Double
-                Type.TYPE_ENUM -> Enum
-                Type.TYPE_FIXED32 -> Fixed32
-                Type.TYPE_FIXED64 -> Fixed64
-                Type.TYPE_FLOAT -> Float
-                Type.TYPE_INT32 -> Int32
-                Type.TYPE_INT64 -> Int64
-                Type.TYPE_MESSAGE -> Message
-                Type.TYPE_SFIXED32 -> SFixed32
-                Type.TYPE_SFIXED64 -> SFixed64
-                Type.TYPE_SINT32 -> SInt32
-                Type.TYPE_SINT64 -> SInt64
-                Type.TYPE_STRING -> String
-                Type.TYPE_UINT32 -> UInt32
-                Type.TYPE_UINT64 -> UInt64
-                else -> error("Unknown type: $type")
+        fun from(typeValue: Int) =
+            when (typeValue) {
+                1 -> Double
+                2 -> Float
+                3 -> Int64
+                4 -> UInt64
+                5 -> Int32
+                6 -> Fixed64
+                7 -> Fixed32
+                8 -> Bool
+                9 -> String
+                11 -> Message
+                12 -> Bytes
+                13 -> UInt32
+                14 -> Enum
+                15 -> SFixed32
+                16 -> SFixed64
+                17 -> SInt32
+                18 -> SInt64
+                else -> error("Unknown type: $typeValue")
             }
     }
 }

--- a/testing/interop/src/test/kotlin/protokt/v1/testing/ExtensionInteropTest.kt
+++ b/testing/interop/src/test/kotlin/protokt/v1/testing/ExtensionInteropTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.DescriptorProtos
+import com.toasttab.protokt.v1.ProtoktProtos
+import org.junit.jupiter.api.Test
+import protokt.v1.Extension
+import protokt.v1.ExtensionCodecs
+import protokt.v1.RepeatedExtension
+import protokt.v1.get
+import protokt.v1.google.protobuf.FieldOptions
+
+class ExtensionInteropTest {
+    private val propertyExt =
+        Extension<FieldOptions, protokt.v1.FieldOptions>(
+            1253u,
+            ExtensionCodecs.message(protokt.v1.FieldOptions)
+        )
+
+    @Test
+    fun `read protokt field options from wire bytes`() {
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setExtension(
+                    ProtoktProtos.property,
+                    ProtoktProtos.FieldOptions.newBuilder()
+                        .setWrap("java.util.UUID")
+                        .build()
+                )
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        val opts = protoktFieldOptions[propertyExt]
+
+        assertThat(opts).isNotNull()
+        assertThat(opts!!.wrap).isEqualTo("java.util.UUID")
+    }
+
+    @Test
+    fun `read protokt field options with non-null accessor`() {
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setExtension(
+                    ProtoktProtos.property,
+                    ProtoktProtos.FieldOptions.newBuilder()
+                        .setGenerateNonNullAccessor(true)
+                        .setDeprecationMessage("old field")
+                        .build()
+                )
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        val opts = protoktFieldOptions[propertyExt]!!
+
+        assertThat(opts.generateNonNullAccessor).isTrue()
+        assertThat(opts.deprecationMessage).isEqualTo("old field")
+    }
+
+    @Test
+    fun `missing extension returns null`() {
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setDeprecated(true)
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        assertThat(protoktFieldOptions[propertyExt]).isNull()
+    }
+
+    @Test
+    fun `read descriptor field options from live proto`() {
+        val descriptor =
+            com.toasttab.protokt.v1.testing.WrappersDynamic.Wrappers.getDescriptor()
+
+        val uuidField = descriptor.findFieldByName("uuid")
+        val javaOpts = uuidField.options
+
+        val protoktOpts = FieldOptions.deserialize(javaOpts.toByteArray())
+        val opts = protoktOpts[propertyExt]
+
+        assertThat(opts).isNotNull()
+        assertThat(opts!!.wrap).isEqualTo("java.util.UUID")
+    }
+
+    @Test
+    fun `scalar extension round-trip`() {
+        val ext = Extension<FieldOptions, Boolean>(99999u, ExtensionCodecs.bool)
+
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder()
+                .setDeprecated(true)
+                .build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        assertThat(protoktFieldOptions[ext]).isNull()
+    }
+
+    @Test
+    fun `repeated extension`() {
+        val ext = RepeatedExtension<FieldOptions, String>(99999u, ExtensionCodecs.string)
+
+        val javaFieldOptions =
+            DescriptorProtos.FieldOptions.newBuilder().build()
+
+        val protoktFieldOptions =
+            FieldOptions.deserialize(javaFieldOptions.toByteArray())
+
+        assertThat(protoktFieldOptions[ext]).isEmpty()
+    }
+}

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/ToStringTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/ToStringTest.kt
@@ -40,7 +40,7 @@ class ToStringTest {
             }.toString()
         ).isEqualTo(
             "ToStringTestEmpty(" +
-                "unknownFields=UnknownFieldSet(unknownFields={5=Field(" +
+                "unknownFields=UnknownFieldSet(fields={5=Field(" +
                 "varint=[], " +
                 "fixed32=[Fixed32Val(value=10)], " +
                 "fixed64=[], " +
@@ -70,7 +70,7 @@ class ToStringTest {
             "ToStringTest2(" +
                 "`val`=[], " +
                 "extra=foo, " +
-                "unknownFields=UnknownFieldSet(unknownFields={5=Field(" +
+                "unknownFields=UnknownFieldSet(fields={5=Field(" +
                 "varint=[], " +
                 "fixed32=[Fixed32Val(value=10)], " +
                 "fixed64=[], " +

--- a/third-party/proto-google-common-protos-lite/api/proto-google-common-protos-lite.api
+++ b/third-party/proto-google-common-protos-lite/api/proto-google-common-protos-lite.api
@@ -5,7 +5,7 @@ public final class protokt/v1/google/api/Advice : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Advice;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Advice;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -45,7 +45,7 @@ public final class protokt/v1/google/api/AuthProvider : protokt/v1/AbstractMessa
 	public final fun getIssuer ()Ljava/lang/String;
 	public final fun getJwksUri ()Ljava/lang/String;
 	public final fun getJwtLocations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/AuthProvider;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -91,7 +91,7 @@ public final class protokt/v1/google/api/AuthRequirement : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAudiences ()Ljava/lang/String;
 	public final fun getProviderId ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/AuthRequirement;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -129,7 +129,7 @@ public final class protokt/v1/google/api/Authentication : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getProviders ()Ljava/util/List;
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Authentication;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -169,7 +169,7 @@ public final class protokt/v1/google/api/AuthenticationRule : protokt/v1/Abstrac
 	public final fun getOauth ()Lprotokt/v1/google/api/OAuthRequirements;
 	public final fun getRequirements ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/AuthenticationRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -210,7 +210,7 @@ public final class protokt/v1/google/api/Backend : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Backend;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Backend;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -253,7 +253,7 @@ public final class protokt/v1/google/api/BackendRule : protokt/v1/AbstractMessag
 	public final fun getPathTranslation ()Lprotokt/v1/google/api/BackendRule$PathTranslation;
 	public final fun getProtocol ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/BackendRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -357,7 +357,7 @@ public final class protokt/v1/google/api/Billing : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Billing;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumerDestinations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Billing;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -374,7 +374,7 @@ public final class protokt/v1/google/api/Billing$BillingDestination : protokt/v1
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetrics ()Ljava/util/List;
 	public final fun getMonitoredResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Billing$BillingDestination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -547,7 +547,7 @@ public final class protokt/v1/google/api/ClientLibrarySettings : protokt/v1/Abst
 	public final fun getPythonSettings ()Lprotokt/v1/google/api/PythonSettings;
 	public final fun getRestNumericEnums ()Z
 	public final fun getRubySettings ()Lprotokt/v1/google/api/RubySettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ClientLibrarySettings;
@@ -605,7 +605,7 @@ public final class protokt/v1/google/api/CommonLanguageSettings : protokt/v1/Abs
 	public final fun getDestinations ()Ljava/util/List;
 	public final fun getReferenceDocsUri ()Ljava/lang/String;
 	public final fun getSelectiveGapicGeneration ()Lprotokt/v1/google/api/SelectiveGapicGeneration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/CommonLanguageSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -648,7 +648,7 @@ public final class protokt/v1/google/api/ConfigChange : protokt/v1/AbstractMessa
 	public final fun getElement ()Ljava/lang/String;
 	public final fun getNewValue ()Ljava/lang/String;
 	public final fun getOldValue ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ConfigChange;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -691,7 +691,7 @@ public final class protokt/v1/google/api/Context : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Context;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Context;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -730,7 +730,7 @@ public final class protokt/v1/google/api/ContextRule : protokt/v1/AbstractMessag
 	public final fun getProvided ()Ljava/util/List;
 	public final fun getRequested ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ContextRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -774,7 +774,7 @@ public final class protokt/v1/google/api/Control : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnvironment ()Ljava/lang/String;
 	public final fun getMethodPolicies ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Control;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -811,7 +811,7 @@ public final class protokt/v1/google/api/CppSettings : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/CppSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/CppSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -847,7 +847,7 @@ public final class protokt/v1/google/api/CustomHttpPattern : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKind ()Ljava/lang/String;
 	public final fun getPath ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/CustomHttpPattern;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -890,7 +890,7 @@ public final class protokt/v1/google/api/Distribution : protokt/v1/AbstractMessa
 	public final fun getMean ()D
 	public final fun getRange ()Lprotokt/v1/google/api/Distribution$Range;
 	public final fun getSumOfSquaredDeviation ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -906,7 +906,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions : protokt/v1
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Distribution$BucketOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOptions ()Lprotokt/v1/google/api/Distribution$BucketOptions$Options;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -941,7 +941,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions$Explicit : p
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Distribution$BucketOptions$Explicit;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions$Explicit;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -978,7 +978,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions$Exponential 
 	public final fun getGrowthFactor ()D
 	public final fun getNumFiniteBuckets ()I
 	public final fun getScale ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions$Exponential;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1018,7 +1018,7 @@ public final class protokt/v1/google/api/Distribution$BucketOptions$Linear : pro
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNumFiniteBuckets ()I
 	public final fun getOffset ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWidth ()D
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$BucketOptions$Linear;
@@ -1126,7 +1126,7 @@ public final class protokt/v1/google/api/Distribution$Exemplar : protokt/v1/Abst
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getTimestamp ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()D
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$Exemplar;
@@ -1167,7 +1167,7 @@ public final class protokt/v1/google/api/Distribution$Range : protokt/v1/Abstrac
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMax ()D
 	public final fun getMin ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Distribution$Range;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1209,7 +1209,7 @@ public final class protokt/v1/google/api/Documentation : protokt/v1/AbstractMess
 	public final fun getRules ()Ljava/util/List;
 	public final fun getServiceRootUrl ()Ljava/lang/String;
 	public final fun getSummary ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Documentation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1256,7 +1256,7 @@ public final class protokt/v1/google/api/DocumentationRule : protokt/v1/Abstract
 	public final fun getDeprecationDescription ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/DocumentationRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1300,7 +1300,7 @@ public final class protokt/v1/google/api/DotnetSettings : protokt/v1/AbstractMes
 	public final fun getIgnoredResources ()Ljava/util/List;
 	public final fun getRenamedResources ()Ljava/util/Map;
 	public final fun getRenamedServices ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/DotnetSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1348,7 +1348,7 @@ public final class protokt/v1/google/api/Endpoint : protokt/v1/AbstractMessage {
 	public final fun getAllowCors ()Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTarget ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Endpoint;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1590,7 +1590,7 @@ public final class protokt/v1/google/api/FieldInfo : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormat ()Lprotokt/v1/google/api/FieldInfo$Format;
 	public final fun getReferencedTypes ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/FieldInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1665,7 +1665,7 @@ public final class protokt/v1/google/api/FieldPolicy : protokt/v1/AbstractMessag
 	public final fun getResourcePermission ()Ljava/lang/String;
 	public final fun getResourceType ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/FieldPolicy;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1705,7 +1705,7 @@ public final class protokt/v1/google/api/GoSettings : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
 	public final fun getRenamedServices ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/GoSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1743,7 +1743,7 @@ public final class protokt/v1/google/api/Http : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFullyDecodeReservedExpansion ()Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Http;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1782,7 +1782,7 @@ public final class protokt/v1/google/api/HttpBody : protokt/v1/AbstractMessage {
 	public final fun getContentType ()Ljava/lang/String;
 	public final fun getData ()Lprotokt/v1/Bytes;
 	public final fun getExtensions ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/HttpBody;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1825,7 +1825,7 @@ public final class protokt/v1/google/api/HttpRule : protokt/v1/AbstractMessage {
 	public final fun getPattern ()Lprotokt/v1/google/api/HttpRule$Pattern;
 	public final fun getResponseBody ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/HttpRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1939,7 +1939,7 @@ public final class protokt/v1/google/api/JavaSettings : protokt/v1/AbstractMessa
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
 	public final fun getLibraryPackage ()Ljava/lang/String;
 	public final fun getServiceClassNames ()Ljava/util/Map;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/JavaSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -1978,7 +1978,7 @@ public final class protokt/v1/google/api/JwtLocation : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/JwtLocation;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIn ()Lprotokt/v1/google/api/JwtLocation$In;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValuePrefix ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/JwtLocation;
@@ -2053,7 +2053,7 @@ public final class protokt/v1/google/api/LabelDescriptor : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueType ()Lprotokt/v1/google/api/LabelDescriptor$ValueType;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/LabelDescriptor;
@@ -2172,7 +2172,7 @@ public final class protokt/v1/google/api/LogDescriptor : protokt/v1/AbstractMess
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getLabels ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/LogDescriptor;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2214,7 +2214,7 @@ public final class protokt/v1/google/api/Logging : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumerDestinations ()Ljava/util/List;
 	public final fun getProducerDestinations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Logging;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2252,7 +2252,7 @@ public final class protokt/v1/google/api/Logging$LoggingDestination : protokt/v1
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLogs ()Ljava/util/List;
 	public final fun getMonitoredResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Logging$LoggingDestination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2290,7 +2290,7 @@ public final class protokt/v1/google/api/MethodPolicy : protokt/v1/AbstractMessa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestPolicies ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MethodPolicy;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2329,7 +2329,7 @@ public final class protokt/v1/google/api/MethodSettings : protokt/v1/AbstractMes
 	public final fun getAutoPopulatedFields ()Ljava/util/List;
 	public final fun getLongRunning ()Lprotokt/v1/google/api/MethodSettings$LongRunning;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MethodSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2371,7 +2371,7 @@ public final class protokt/v1/google/api/MethodSettings$LongRunning : protokt/v1
 	public final fun getMaxPollDelay ()Lprotokt/v1/google/protobuf/Duration;
 	public final fun getPollDelayMultiplier ()F
 	public final fun getTotalPollTimeout ()Lprotokt/v1/google/protobuf/Duration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MethodSettings$LongRunning;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2413,7 +2413,7 @@ public final class protokt/v1/google/api/Metric : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLabels ()Ljava/util/Map;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Metric;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2459,7 +2459,7 @@ public final class protokt/v1/google/api/MetricDescriptor : protokt/v1/AbstractM
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getUnit ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueType ()Lprotokt/v1/google/api/MetricDescriptor$ValueType;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MetricDescriptor;
@@ -2518,7 +2518,7 @@ public final class protokt/v1/google/api/MetricDescriptor$MetricDescriptorMetada
 	public final fun getLaunchStage ()Lprotokt/v1/google/api/LaunchStage;
 	public final fun getSamplePeriod ()Lprotokt/v1/google/protobuf/Duration;
 	public final fun getTimeSeriesResourceHierarchyLevel ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MetricDescriptor$MetricDescriptorMetadata;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2668,7 +2668,7 @@ public final class protokt/v1/google/api/MetricRule : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetricCosts ()Ljava/util/Map;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MetricRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2706,7 +2706,7 @@ public final class protokt/v1/google/api/MonitoredResource : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLabels ()Ljava/util/Map;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MonitoredResource;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2748,7 +2748,7 @@ public final class protokt/v1/google/api/MonitoredResourceDescriptor : protokt/v
 	public final fun getLaunchStage ()Lprotokt/v1/google/api/LaunchStage;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MonitoredResourceDescriptor;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2793,7 +2793,7 @@ public final class protokt/v1/google/api/MonitoredResourceMetadata : protokt/v1/
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/MonitoredResourceMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSystemLabels ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUserLabels ()Ljava/util/Map;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/MonitoredResourceMetadata;
@@ -2832,7 +2832,7 @@ public final class protokt/v1/google/api/Monitoring : protokt/v1/AbstractMessage
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumerDestinations ()Ljava/util/List;
 	public final fun getProducerDestinations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Monitoring;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2870,7 +2870,7 @@ public final class protokt/v1/google/api/Monitoring$MonitoringDestination : prot
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetrics ()Ljava/util/List;
 	public final fun getMonitoredResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Monitoring$MonitoringDestination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2907,7 +2907,7 @@ public final class protokt/v1/google/api/NodeSettings : protokt/v1/AbstractMessa
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/NodeSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/NodeSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2942,7 +2942,7 @@ public final class protokt/v1/google/api/OAuthRequirements : protokt/v1/Abstract
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/OAuthRequirements;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanonicalScopes ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/OAuthRequirements;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -2979,7 +2979,7 @@ public final class protokt/v1/google/api/Page : protokt/v1/AbstractMessage {
 	public final fun getContent ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSubpages ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Page;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3018,7 +3018,7 @@ public final class protokt/v1/google/api/PhpSettings : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/PhpSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/PhpSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3053,7 +3053,7 @@ public final class protokt/v1/google/api/ProjectProperties : protokt/v1/Abstract
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/ProjectProperties;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getProperties ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ProjectProperties;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3090,7 +3090,7 @@ public final class protokt/v1/google/api/Property : protokt/v1/AbstractMessage {
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Lprotokt/v1/google/api/Property$PropertyType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Property;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3175,7 +3175,7 @@ public final class protokt/v1/google/api/Publishing : protokt/v1/AbstractMessage
 	public final fun getOrganization ()Lprotokt/v1/google/api/ClientLibraryOrganization;
 	public final fun getProtoReferenceDocumentationUri ()Ljava/lang/String;
 	public final fun getRestReferenceDocumentationUri ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Publishing;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3231,7 +3231,7 @@ public final class protokt/v1/google/api/PythonSettings : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
 	public final fun getExperimentalFeatures ()Lprotokt/v1/google/api/PythonSettings$ExperimentalFeatures;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/PythonSettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3269,7 +3269,7 @@ public final class protokt/v1/google/api/PythonSettings$ExperimentalFeatures : p
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getProtobufPythonicTypesEnabled ()Z
 	public final fun getRestAsyncIoEnabled ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUnversionedPackageDisabled ()Z
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/PythonSettings$ExperimentalFeatures;
@@ -3310,7 +3310,7 @@ public final class protokt/v1/google/api/Quota : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLimits ()Ljava/util/List;
 	public final fun getMetricRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Quota;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3355,7 +3355,7 @@ public final class protokt/v1/google/api/QuotaLimit : protokt/v1/AbstractMessage
 	public final fun getMetric ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getUnit ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValues ()Ljava/util/Map;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/QuotaLimit;
@@ -3415,7 +3415,7 @@ public final class protokt/v1/google/api/ResourceDescriptor : protokt/v1/Abstrac
 	public final fun getSingular ()Ljava/lang/String;
 	public final fun getStyle ()Ljava/util/List;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ResourceDescriptor;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3515,7 +3515,7 @@ public final class protokt/v1/google/api/ResourceReference : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChildType ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/ResourceReference;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3553,7 +3553,7 @@ public final class protokt/v1/google/api/RoutingParameter : protokt/v1/AbstractM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getField ()Ljava/lang/String;
 	public final fun getPathTemplate ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/RoutingParameter;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3590,7 +3590,7 @@ public final class protokt/v1/google/api/RoutingRule : protokt/v1/AbstractMessag
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/RoutingRule;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRoutingParameters ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/RoutingRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3625,7 +3625,7 @@ public final class protokt/v1/google/api/RubySettings : protokt/v1/AbstractMessa
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/RubySettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCommon ()Lprotokt/v1/google/api/CommonLanguageSettings;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/RubySettings;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3661,7 +3661,7 @@ public final class protokt/v1/google/api/SelectiveGapicGeneration : protokt/v1/A
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGenerateOmittedAsInternal ()Z
 	public final fun getMethods ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SelectiveGapicGeneration;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3722,7 +3722,7 @@ public final class protokt/v1/google/api/Service : protokt/v1/AbstractMessage {
 	public final fun getSystemParameters ()Lprotokt/v1/google/api/SystemParameters;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getTypes ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUsage ()Lprotokt/v1/google/api/Usage;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Service;
@@ -3808,7 +3808,7 @@ public final class protokt/v1/google/api/SourceInfo : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/SourceInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSourceFiles ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SourceInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3844,7 +3844,7 @@ public final class protokt/v1/google/api/SystemParameter : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHttpHeader ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUrlQueryParameter ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SystemParameter;
@@ -3885,7 +3885,7 @@ public final class protokt/v1/google/api/SystemParameterRule : protokt/v1/Abstra
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getParameters ()Ljava/util/List;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SystemParameterRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3922,7 +3922,7 @@ public final class protokt/v1/google/api/SystemParameters : protokt/v1/AbstractM
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/SystemParameters;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/SystemParameters;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3957,7 +3957,7 @@ public final class protokt/v1/google/api/TypeReference : protokt/v1/AbstractMess
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/TypeReference;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTypeName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/TypeReference;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -3994,7 +3994,7 @@ public final class protokt/v1/google/api/Usage : protokt/v1/AbstractMessage {
 	public final fun getProducerNotificationChannel ()Ljava/lang/String;
 	public final fun getRequirements ()Ljava/util/List;
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Usage;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4035,7 +4035,7 @@ public final class protokt/v1/google/api/UsageRule : protokt/v1/AbstractMessage 
 	public final fun getAllowUnregisteredCalls ()Z
 	public final fun getSelector ()Ljava/lang/String;
 	public final fun getSkipServiceControl ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/UsageRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4074,7 +4074,7 @@ public final class protokt/v1/google/api/Visibility : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/api/Visibility;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRules ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/Visibility;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4110,7 +4110,7 @@ public final class protokt/v1/google/api/VisibilityRule : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRestriction ()Ljava/lang/String;
 	public final fun getSelector ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/api/VisibilityRule;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4153,7 +4153,7 @@ public final class protokt/v1/google/apps/card/v1/Action : protokt/v1/AbstractMe
 	public final fun getParameters ()Ljava/util/List;
 	public final fun getPersistValues ()Z
 	public final fun getRequiredWidgets ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Action;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4169,7 +4169,7 @@ public final class protokt/v1/google/apps/card/v1/Action$ActionParameter : proto
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Action$ActionParameter;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKey ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Action$ActionParameter;
@@ -4288,7 +4288,7 @@ public final class protokt/v1/google/apps/card/v1/BorderStyle : protokt/v1/Abstr
 	public final fun getCornerRadius ()I
 	public final fun getStrokeColor ()Lprotokt/v1/google/type/Color;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/BorderStyle$BorderType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/BorderStyle;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4361,7 +4361,7 @@ public final class protokt/v1/google/apps/card/v1/Button : protokt/v1/AbstractMe
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
 	public final fun getText ()Ljava/lang/String;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/Button$Type;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Button;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4444,7 +4444,7 @@ public final class protokt/v1/google/apps/card/v1/ButtonList : protokt/v1/Abstra
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/ButtonList;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getButtons ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ButtonList;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4486,7 +4486,7 @@ public final class protokt/v1/google/apps/card/v1/Card : protokt/v1/AbstractMess
 	public final fun getPeekCardHeader ()Lprotokt/v1/google/apps/card/v1/Card$CardHeader;
 	public final fun getSectionDividerStyle ()Lprotokt/v1/google/apps/card/v1/Card$DividerStyle;
 	public final fun getSections ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4530,7 +4530,7 @@ public final class protokt/v1/google/apps/card/v1/Card$CardAction : protokt/v1/A
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActionLabel ()Ljava/lang/String;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$CardAction;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4568,7 +4568,7 @@ public final class protokt/v1/google/apps/card/v1/Card$CardFixedFooter : protokt
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPrimaryButton ()Lprotokt/v1/google/apps/card/v1/Button;
 	public final fun getSecondaryButton ()Lprotokt/v1/google/apps/card/v1/Button;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$CardFixedFooter;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4609,7 +4609,7 @@ public final class protokt/v1/google/apps/card/v1/Card$CardHeader : protokt/v1/A
 	public final fun getImageUrl ()Ljava/lang/String;
 	public final fun getSubtitle ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$CardHeader;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4714,7 +4714,7 @@ public final class protokt/v1/google/apps/card/v1/Card$NestedWidget : protokt/v1
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Card$NestedWidget;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/Card$NestedWidget$Data;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$NestedWidget;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4788,7 +4788,7 @@ public final class protokt/v1/google/apps/card/v1/Card$Section : protokt/v1/Abst
 	public final fun getCollapsible ()Z
 	public final fun getHeader ()Ljava/lang/String;
 	public final fun getUncollapsibleWidgetsCount ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWidgets ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Card$Section;
@@ -4832,7 +4832,7 @@ public final class protokt/v1/google/apps/card/v1/Carousel : protokt/v1/Abstract
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Carousel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCarouselCards ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Carousel;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4861,7 +4861,7 @@ public final class protokt/v1/google/apps/card/v1/Carousel$CarouselCard : protok
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Carousel$CarouselCard;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFooterWidgets ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWidgets ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Carousel$CarouselCard;
@@ -4910,7 +4910,7 @@ public final class protokt/v1/google/apps/card/v1/Chip : protokt/v1/AbstractMess
 	public final fun getIcon ()Lprotokt/v1/google/apps/card/v1/Icon;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Chip;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -4956,7 +4956,7 @@ public final class protokt/v1/google/apps/card/v1/ChipList : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChips ()Ljava/util/List;
 	public final fun getLayout ()Lprotokt/v1/google/apps/card/v1/ChipList$Layout;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ChipList;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5023,7 +5023,7 @@ public final class protokt/v1/google/apps/card/v1/CollapseControl : protokt/v1/A
 	public final fun getCollapseButton ()Lprotokt/v1/google/apps/card/v1/Button;
 	public final fun getExpandButton ()Lprotokt/v1/google/apps/card/v1/Button;
 	public final fun getHorizontalAlignment ()Lprotokt/v1/google/apps/card/v1/Widget$HorizontalAlignment;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/CollapseControl;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5062,7 +5062,7 @@ public final class protokt/v1/google/apps/card/v1/Columns : protokt/v1/AbstractM
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Columns;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColumnItems ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Columns;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5092,7 +5092,7 @@ public final class protokt/v1/google/apps/card/v1/Columns$Column : protokt/v1/Ab
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHorizontalAlignment ()Lprotokt/v1/google/apps/card/v1/Widget$HorizontalAlignment;
 	public final fun getHorizontalSizeStyle ()Lprotokt/v1/google/apps/card/v1/Columns$Column$HorizontalSizeStyle;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVerticalAlignment ()Lprotokt/v1/google/apps/card/v1/Columns$Column$VerticalAlignment;
 	public final fun getWidgets ()Ljava/util/List;
 	public fun hashCode ()I
@@ -5195,7 +5195,7 @@ public final class protokt/v1/google/apps/card/v1/Columns$Column$Widgets : proto
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Columns$Column$Widgets;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/Columns$Column$Widgets$Data;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Columns$Column$Widgets;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5331,7 +5331,7 @@ public final class protokt/v1/google/apps/card/v1/DateTimePicker : protokt/v1/Ab
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getTimezoneOffsetDate ()I
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/DateTimePicker$DateTimePickerType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValueMsEpoch ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/DateTimePicker;
@@ -5415,7 +5415,7 @@ public final class protokt/v1/google/apps/card/v1/DecoratedText : protokt/v1/Abs
 	public final fun getText ()Ljava/lang/String;
 	public final fun getTopLabel ()Ljava/lang/String;
 	public final fun getTopLabelText ()Lprotokt/v1/google/apps/card/v1/TextParagraph;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWrapText ()Z
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/DecoratedText;
@@ -5512,7 +5512,7 @@ public final class protokt/v1/google/apps/card/v1/DecoratedText$SwitchControl : 
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getSelected ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/DecoratedText$SwitchControl;
@@ -5583,7 +5583,7 @@ public final class protokt/v1/google/apps/card/v1/Divider : protokt/v1/AbstractM
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Divider;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Divider;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Divider;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5620,7 +5620,7 @@ public final class protokt/v1/google/apps/card/v1/Grid : protokt/v1/AbstractMess
 	public final fun getItems ()Ljava/util/List;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Grid;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5667,7 +5667,7 @@ public final class protokt/v1/google/apps/card/v1/Grid$GridItem : protokt/v1/Abs
 	public final fun getLayout ()Lprotokt/v1/google/apps/card/v1/Grid$GridItem$GridItemLayout;
 	public final fun getSubtitle ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Grid$GridItem;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5740,7 +5740,7 @@ public final class protokt/v1/google/apps/card/v1/Icon : protokt/v1/AbstractMess
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getIcons ()Lprotokt/v1/google/apps/card/v1/Icon$Icons;
 	public final fun getImageType ()Lprotokt/v1/google/apps/card/v1/Widget$ImageType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Icon;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5817,7 +5817,7 @@ public final class protokt/v1/google/apps/card/v1/Image : protokt/v1/AbstractMes
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getImageUrl ()Ljava/lang/String;
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Image;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5859,7 +5859,7 @@ public final class protokt/v1/google/apps/card/v1/ImageComponent : protokt/v1/Ab
 	public final fun getBorderStyle ()Lprotokt/v1/google/apps/card/v1/BorderStyle;
 	public final fun getCropStyle ()Lprotokt/v1/google/apps/card/v1/ImageCropStyle;
 	public final fun getImageUri ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ImageComponent;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5901,7 +5901,7 @@ public final class protokt/v1/google/apps/card/v1/ImageCropStyle : protokt/v1/Ab
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAspectRatio ()D
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/ImageCropStyle$ImageCropType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/ImageCropStyle;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -5976,7 +5976,7 @@ public final class protokt/v1/google/apps/card/v1/MaterialIcon : protokt/v1/Abst
 	public final fun getFill ()Z
 	public final fun getGrade ()I
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getWeight ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/MaterialIcon;
@@ -6018,7 +6018,7 @@ public final class protokt/v1/google/apps/card/v1/OnClick : protokt/v1/AbstractM
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/OnClick;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/OnClick$Data;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OnClick;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6112,7 +6112,7 @@ public final class protokt/v1/google/apps/card/v1/OpenLink : protokt/v1/Abstract
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOnClose ()Lprotokt/v1/google/apps/card/v1/OpenLink$OnClose;
 	public final fun getOpenAs ()Lprotokt/v1/google/apps/card/v1/OpenLink$OpenAs;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OpenLink;
@@ -6200,7 +6200,7 @@ public final class protokt/v1/google/apps/card/v1/OverflowMenu : protokt/v1/Abst
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/OverflowMenu;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getItems ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OverflowMenu;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6238,7 +6238,7 @@ public final class protokt/v1/google/apps/card/v1/OverflowMenu$OverflowMenuItem 
 	public final fun getOnClick ()Lprotokt/v1/google/apps/card/v1/OnClick;
 	public final fun getStartIcon ()Lprotokt/v1/google/apps/card/v1/Icon;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/OverflowMenu$OverflowMenuItem;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6286,7 +6286,7 @@ public final class protokt/v1/google/apps/card/v1/SelectionInput : protokt/v1/Ab
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/SelectionInput$SelectionType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/SelectionInput;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6360,7 +6360,7 @@ public final class protokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSou
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSource;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataSource ()Lprotokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSource$DataSource;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/SelectionInput$PlatformDataSource;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6436,7 +6436,7 @@ public final class protokt/v1/google/apps/card/v1/SelectionInput$SelectionItem :
 	public final fun getSelected ()Z
 	public final fun getStartIcon ()Lprotokt/v1/google/apps/card/v1/SelectionInput$SelectionItem$StartIcon;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/SelectionInput$SelectionItem;
@@ -6530,7 +6530,7 @@ public final class protokt/v1/google/apps/card/v1/Suggestions : protokt/v1/Abstr
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Suggestions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getItems ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Suggestions;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6565,7 +6565,7 @@ public final class protokt/v1/google/apps/card/v1/Suggestions$SuggestionItem : p
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/apps/card/v1/Suggestions$SuggestionItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContent ()Lprotokt/v1/google/apps/card/v1/Suggestions$SuggestionItem$Content;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Suggestions$SuggestionItem;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6621,7 +6621,7 @@ public final class protokt/v1/google/apps/card/v1/TextInput : protokt/v1/Abstrac
 	public final fun getOnChangeAction ()Lprotokt/v1/google/apps/card/v1/Action;
 	public final fun getPlaceholderText ()Ljava/lang/String;
 	public final fun getType ()Lprotokt/v1/google/apps/card/v1/TextInput$Type;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValidation ()Lprotokt/v1/google/apps/card/v1/Validation;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -6702,7 +6702,7 @@ public final class protokt/v1/google/apps/card/v1/TextParagraph : protokt/v1/Abs
 	public final fun getMaxLines ()I
 	public final fun getText ()Ljava/lang/String;
 	public final fun getTextSyntax ()Lprotokt/v1/google/apps/card/v1/TextParagraph$TextSyntax;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/TextParagraph;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6770,7 +6770,7 @@ public final class protokt/v1/google/apps/card/v1/Validation : protokt/v1/Abstra
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCharacterLimit ()I
 	public final fun getInputType ()Lprotokt/v1/google/apps/card/v1/Validation$InputType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Validation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -6848,7 +6848,7 @@ public final class protokt/v1/google/apps/card/v1/Widget : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Lprotokt/v1/google/apps/card/v1/Widget$Data;
 	public final fun getHorizontalAlignment ()Lprotokt/v1/google/apps/card/v1/Widget$HorizontalAlignment;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/apps/card/v1/Widget;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7158,7 +7158,7 @@ public final class protokt/v1/google/cloud/audit/AuditLog : protokt/v1/AbstractM
 	public final fun getServiceData ()Lprotokt/v1/google/protobuf/Any;
 	public final fun getServiceName ()Ljava/lang/String;
 	public final fun getStatus ()Lprotokt/v1/google/rpc/Status;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/AuditLog;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7226,7 +7226,7 @@ public final class protokt/v1/google/cloud/audit/AuthenticationInfo : protokt/v1
 	public final fun getServiceAccountDelegationInfo ()Ljava/util/List;
 	public final fun getServiceAccountKeyName ()Ljava/lang/String;
 	public final fun getThirdPartyPrincipal ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/AuthenticationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7275,7 +7275,7 @@ public final class protokt/v1/google/cloud/audit/AuthorizationInfo : protokt/v1/
 	public final fun getPermissionType ()Lprotokt/v1/google/cloud/audit/AuthorizationInfo$PermissionType;
 	public final fun getResource ()Ljava/lang/String;
 	public final fun getResourceAttributes ()Lprotokt/v1/google/rpc/context/AttributeContext$Resource;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/AuthorizationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7356,7 +7356,7 @@ public final class protokt/v1/google/cloud/audit/OrgPolicyViolationInfo : protok
 	public final fun getPayload ()Lprotokt/v1/google/protobuf/Struct;
 	public final fun getResourceTags ()Ljava/util/Map;
 	public final fun getResourceType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getViolationInfo ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/OrgPolicyViolationInfo;
@@ -7398,7 +7398,7 @@ public final class protokt/v1/google/cloud/audit/PolicyViolationInfo : protokt/v
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/cloud/audit/PolicyViolationInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOrgPolicyViolationInfo ()Lprotokt/v1/google/cloud/audit/OrgPolicyViolationInfo;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/PolicyViolationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7437,7 +7437,7 @@ public final class protokt/v1/google/cloud/audit/RequestMetadata : protokt/v1/Ab
 	public final fun getCallerSuppliedUserAgent ()Ljava/lang/String;
 	public final fun getDestinationAttributes ()Lprotokt/v1/google/rpc/context/AttributeContext$Peer;
 	public final fun getRequestAttributes ()Lprotokt/v1/google/rpc/context/AttributeContext$Request;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/RequestMetadata;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7481,7 +7481,7 @@ public final class protokt/v1/google/cloud/audit/ResourceLocation : protokt/v1/A
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentLocations ()Ljava/util/List;
 	public final fun getOriginalLocations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ResourceLocation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7519,7 +7519,7 @@ public final class protokt/v1/google/cloud/audit/ServiceAccountDelegationInfo : 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthority ()Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$Authority;
 	public final fun getPrincipalSubject ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7582,7 +7582,7 @@ public final class protokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$Fi
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPrincipalEmail ()Ljava/lang/String;
 	public final fun getServiceMetadata ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$FirstPartyPrincipal;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7619,7 +7619,7 @@ public final class protokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$Th
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$ThirdPartyPrincipal;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getThirdPartyClaims ()Lprotokt/v1/google/protobuf/Struct;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ServiceAccountDelegationInfo$ThirdPartyPrincipal;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7657,7 +7657,7 @@ public final class protokt/v1/google/cloud/audit/ViolationInfo : protokt/v1/Abst
 	public final fun getConstraint ()Ljava/lang/String;
 	public final fun getErrorMessage ()Ljava/lang/String;
 	public final fun getPolicyType ()Lprotokt/v1/google/cloud/audit/ViolationInfo$PolicyType;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/audit/ViolationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7730,7 +7730,7 @@ public final class protokt/v1/google/cloud/location/GetLocationRequest : protokt
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/cloud/location/GetLocationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/GetLocationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7768,7 +7768,7 @@ public final class protokt/v1/google/cloud/location/ListLocationsRequest : proto
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPageSize ()I
 	public final fun getPageToken ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/ListLocationsRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7810,7 +7810,7 @@ public final class protokt/v1/google/cloud/location/ListLocationsResponse : prot
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLocations ()Ljava/util/List;
 	public final fun getNextPageToken ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/ListLocationsResponse;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7851,7 +7851,7 @@ public final class protokt/v1/google/cloud/location/Location : protokt/v1/Abstra
 	public final fun getLocationId ()Ljava/lang/String;
 	public final fun getMetadata ()Lprotokt/v1/google/protobuf/Any;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/cloud/location/Location;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7895,7 +7895,7 @@ public final class protokt/v1/google/geo/type/Viewport : protokt/v1/AbstractMess
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHigh ()Lprotokt/v1/google/type/LatLng;
 	public final fun getLow ()Lprotokt/v1/google/type/LatLng;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/geo/type/Viewport;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -7945,7 +7945,7 @@ public final class protokt/v1/google/logging/type/HttpRequest : protokt/v1/Abstr
 	public final fun getResponseSize ()J
 	public final fun getServerIp ()Ljava/lang/String;
 	public final fun getStatus ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUserAgent ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/logging/type/HttpRequest;
@@ -8061,7 +8061,7 @@ public final class protokt/v1/google/longrunning/CancelOperationRequest : protok
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/longrunning/CancelOperationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/CancelOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8096,7 +8096,7 @@ public final class protokt/v1/google/longrunning/DeleteOperationRequest : protok
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/longrunning/DeleteOperationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/DeleteOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8131,7 +8131,7 @@ public final class protokt/v1/google/longrunning/GetOperationRequest : protokt/v
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/longrunning/GetOperationRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/GetOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8170,7 +8170,7 @@ public final class protokt/v1/google/longrunning/ListOperationsRequest : protokt
 	public final fun getPageSize ()I
 	public final fun getPageToken ()Ljava/lang/String;
 	public final fun getReturnPartialSuccess ()Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/ListOperationsRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8214,7 +8214,7 @@ public final class protokt/v1/google/longrunning/ListOperationsResponse : protok
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNextPageToken ()Ljava/lang/String;
 	public final fun getOperations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUnreachable ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/ListOperationsResponse;
@@ -8257,7 +8257,7 @@ public final class protokt/v1/google/longrunning/Operation : protokt/v1/Abstract
 	public final fun getMetadata ()Lprotokt/v1/google/protobuf/Any;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getResult ()Lprotokt/v1/google/longrunning/Operation$Result;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/Operation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8324,7 +8324,7 @@ public final class protokt/v1/google/longrunning/OperationInfo : protokt/v1/Abst
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetadataType ()Ljava/lang/String;
 	public final fun getResponseType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/OperationInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8362,7 +8362,7 @@ public final class protokt/v1/google/longrunning/WaitOperationRequest : protokt/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTimeout ()Lprotokt/v1/google/protobuf/Duration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/longrunning/WaitOperationRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8399,7 +8399,7 @@ public final class protokt/v1/google/rpc/BadRequest : protokt/v1/AbstractMessage
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/BadRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFieldViolations ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/BadRequest;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8437,7 +8437,7 @@ public final class protokt/v1/google/rpc/BadRequest$FieldViolation : protokt/v1/
 	public final fun getField ()Ljava/lang/String;
 	public final fun getLocalizedMessage ()Lprotokt/v1/google/rpc/LocalizedMessage;
 	public final fun getReason ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/BadRequest$FieldViolation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8563,7 +8563,7 @@ public final class protokt/v1/google/rpc/DebugInfo : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDetail ()Ljava/lang/String;
 	public final fun getStackEntries ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/DebugInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8602,7 +8602,7 @@ public final class protokt/v1/google/rpc/ErrorInfo : protokt/v1/AbstractMessage 
 	public final fun getDomain ()Ljava/lang/String;
 	public final fun getMetadata ()Ljava/util/Map;
 	public final fun getReason ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/ErrorInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8641,7 +8641,7 @@ public final class protokt/v1/google/rpc/Help : protokt/v1/AbstractMessage {
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/Help;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLinks ()Ljava/util/List;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/Help;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8676,7 +8676,7 @@ public final class protokt/v1/google/rpc/Help$Link : protokt/v1/AbstractMessage 
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/Help$Link;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/Help$Link;
@@ -8715,7 +8715,7 @@ public final class protokt/v1/google/rpc/LocalizedMessage : protokt/v1/AbstractM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLocale ()Ljava/lang/String;
 	public final fun getMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/LocalizedMessage;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8751,7 +8751,7 @@ public final class protokt/v1/google/rpc/PreconditionFailure : protokt/v1/Abstra
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/PreconditionFailure;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/PreconditionFailure;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getViolations ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/PreconditionFailure;
@@ -8789,7 +8789,7 @@ public final class protokt/v1/google/rpc/PreconditionFailure$Violation : protokt
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getSubject ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/PreconditionFailure$Violation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8827,7 +8827,7 @@ public final class protokt/v1/google/rpc/QuotaFailure : protokt/v1/AbstractMessa
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/QuotaFailure;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/QuotaFailure;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getViolations ()Ljava/util/List;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/QuotaFailure;
@@ -8870,7 +8870,7 @@ public final class protokt/v1/google/rpc/QuotaFailure$Violation : protokt/v1/Abs
 	public final fun getQuotaMetric ()Ljava/lang/String;
 	public final fun getQuotaValue ()J
 	public final fun getSubject ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/QuotaFailure$Violation;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8920,7 +8920,7 @@ public final class protokt/v1/google/rpc/RequestInfo : protokt/v1/AbstractMessag
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestId ()Ljava/lang/String;
 	public final fun getServingData ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/RequestInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -8960,7 +8960,7 @@ public final class protokt/v1/google/rpc/ResourceInfo : protokt/v1/AbstractMessa
 	public final fun getOwner ()Ljava/lang/String;
 	public final fun getResourceName ()Ljava/lang/String;
 	public final fun getResourceType ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/ResourceInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9001,7 +9001,7 @@ public final class protokt/v1/google/rpc/RetryInfo : protokt/v1/AbstractMessage 
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/rpc/RetryInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRetryDelay ()Lprotokt/v1/google/protobuf/Duration;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/RetryInfo;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9038,7 +9038,7 @@ public final class protokt/v1/google/rpc/Status : protokt/v1/AbstractMessage {
 	public final fun getCode ()I
 	public final fun getDetails ()Ljava/util/List;
 	public final fun getMessage ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/Status;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9084,7 +9084,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext : protokt/v1/A
 	public final fun getResource ()Lprotokt/v1/google/rpc/context/AttributeContext$Resource;
 	public final fun getResponse ()Lprotokt/v1/google/rpc/context/AttributeContext$Response;
 	public final fun getSource ()Lprotokt/v1/google/rpc/context/AttributeContext$Peer;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9102,7 +9102,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Api : protokt/
 	public final fun getOperation ()Ljava/lang/String;
 	public final fun getProtocol ()Ljava/lang/String;
 	public final fun getService ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Api;
@@ -9148,7 +9148,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Auth : protokt
 	public final fun getClaims ()Lprotokt/v1/google/protobuf/Struct;
 	public final fun getPresenter ()Ljava/lang/String;
 	public final fun getPrincipal ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Auth;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9228,7 +9228,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Peer : protokt
 	public final fun getPort ()J
 	public final fun getPrincipal ()Ljava/lang/String;
 	public final fun getRegionCode ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Peer;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9282,7 +9282,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Request : prot
 	public final fun getScheme ()Ljava/lang/String;
 	public final fun getSize ()J
 	public final fun getTime ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Request;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9349,7 +9349,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Resource : pro
 	public final fun getService ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getUid ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getUpdateTime ()Lprotokt/v1/google/protobuf/Timestamp;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Resource;
@@ -9411,7 +9411,7 @@ public final class protokt/v1/google/rpc/context/AttributeContext$Response : pro
 	public final fun getHeaders ()Ljava/util/Map;
 	public final fun getSize ()J
 	public final fun getTime ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AttributeContext$Response;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9458,7 +9458,7 @@ public final class protokt/v1/google/rpc/context/AuditContext : protokt/v1/Abstr
 	public final fun getScrubbedResponse ()Lprotokt/v1/google/protobuf/Struct;
 	public final fun getScrubbedResponseItemCount ()I
 	public final fun getTargetResource ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/rpc/context/AuditContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9500,7 +9500,7 @@ public final class protokt/v1/google/shopping/type/Channel : protokt/v1/Abstract
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Channel;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/shopping/type/Channel;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Channel;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9562,7 +9562,7 @@ public final class protokt/v1/google/shopping/type/CustomAttribute : protokt/v1/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGroupValues ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/CustomAttribute;
@@ -9601,7 +9601,7 @@ public final class protokt/v1/google/shopping/type/Destination : protokt/v1/Abst
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Destination;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/shopping/type/Destination;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Destination;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9703,7 +9703,7 @@ public final class protokt/v1/google/shopping/type/Price : protokt/v1/AbstractMe
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmountMicros ()Ljava/lang/Long;
 	public final fun getCurrencyCode ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Price;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9739,7 +9739,7 @@ public final class protokt/v1/google/shopping/type/ReportingContext : protokt/v1
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/ReportingContext;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/shopping/type/ReportingContext;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/ReportingContext;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9869,7 +9869,7 @@ public final class protokt/v1/google/shopping/type/Weight : protokt/v1/AbstractM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmountMicros ()Ljava/lang/Long;
 	public final fun getUnit ()Lprotokt/v1/google/shopping/type/Weight$WeightUnit;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/shopping/type/Weight;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -9985,7 +9985,7 @@ public final class protokt/v1/google/type/Color : protokt/v1/AbstractMessage {
 	public final fun getBlue ()F
 	public final fun getGreen ()F
 	public final fun getRed ()F
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Color;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10027,7 +10027,7 @@ public final class protokt/v1/google/type/Date : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDay ()I
 	public final fun getMonth ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getYear ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Date;
@@ -10073,7 +10073,7 @@ public final class protokt/v1/google/type/DateTime : protokt/v1/AbstractMessage 
 	public final fun getNanos ()I
 	public final fun getSeconds ()I
 	public final fun getTimeOffset ()Lprotokt/v1/google/type/DateTime$TimeOffset;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getYear ()I
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/DateTime;
@@ -10195,7 +10195,7 @@ public final class protokt/v1/google/type/Decimal : protokt/v1/AbstractMessage {
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Decimal;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/type/Decimal;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Decimal;
@@ -10234,7 +10234,7 @@ public final class protokt/v1/google/type/Expr : protokt/v1/AbstractMessage {
 	public final fun getExpression ()Ljava/lang/String;
 	public final fun getLocation ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Expr;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10276,7 +10276,7 @@ public final class protokt/v1/google/type/Fraction : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDenominator ()J
 	public final fun getNumerator ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Fraction;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10314,7 +10314,7 @@ public final class protokt/v1/google/type/Interval : protokt/v1/AbstractMessage 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEndTime ()Lprotokt/v1/google/protobuf/Timestamp;
 	public final fun getStartTime ()Lprotokt/v1/google/protobuf/Timestamp;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Interval;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10352,7 +10352,7 @@ public final class protokt/v1/google/type/LatLng : protokt/v1/AbstractMessage {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLatitude ()D
 	public final fun getLongitude ()D
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/LatLng;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10390,7 +10390,7 @@ public final class protokt/v1/google/type/LocalizedText : protokt/v1/AbstractMes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLanguageCode ()Ljava/lang/String;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/LocalizedText;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10429,7 +10429,7 @@ public final class protokt/v1/google/type/Money : protokt/v1/AbstractMessage {
 	public final fun getCurrencyCode ()Ljava/lang/String;
 	public final fun getNanos ()I
 	public final fun getUnits ()J
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Money;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10537,7 +10537,7 @@ public final class protokt/v1/google/type/PhoneNumber : protokt/v1/AbstractMessa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExtension ()Ljava/lang/String;
 	public final fun getKind ()Lprotokt/v1/google/type/PhoneNumber$Kind;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/PhoneNumber;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10600,7 +10600,7 @@ public final class protokt/v1/google/type/PhoneNumber$ShortCode : protokt/v1/Abs
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNumber ()Ljava/lang/String;
 	public final fun getRegionCode ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/PhoneNumber$ShortCode;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10647,7 +10647,7 @@ public final class protokt/v1/google/type/PostalAddress : protokt/v1/AbstractMes
 	public final fun getRevision ()I
 	public final fun getSortingCode ()Ljava/lang/String;
 	public final fun getSublocality ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/PostalAddress;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10701,7 +10701,7 @@ public final class protokt/v1/google/type/Quaternion : protokt/v1/AbstractMessag
 	public final fun copy (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/Quaternion;
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/type/Quaternion;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getW ()D
 	public final fun getX ()D
 	public final fun getY ()D
@@ -10749,7 +10749,7 @@ public final class protokt/v1/google/type/TimeOfDay : protokt/v1/AbstractMessage
 	public final fun getMinutes ()I
 	public final fun getNanos ()I
 	public final fun getSeconds ()I
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/TimeOfDay;
 	public fun serialize (Lprotokt/v1/Writer;)V
@@ -10790,7 +10790,7 @@ public final class protokt/v1/google/type/TimeZone : protokt/v1/AbstractMessage 
 	public static fun deserialize (Lprotokt/v1/Reader;)Lprotokt/v1/google/type/TimeZone;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()Ljava/lang/String;
-	public final fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
+	public fun getUnknownFields ()Lprotokt/v1/UnknownFieldSet;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static final fun invoke (Lkotlin/jvm/functions/Function1;)Lprotokt/v1/google/type/TimeZone;


### PR DESCRIPTION
## Summary

Builds on #514. Fully self-hosts the codegen pipeline — all protobuf-java descriptor types replaced with protokt's own generated types, and all custom option extension reads replaced with generated extension properties.

### Commit 1: Migrate codegen pipeline to protokt descriptor types
- New `protokt-bootstrap` module with checked-in generated code (descriptor.proto, plugin.proto, protokt.proto)
- All parsers use `protokt.v1.google.protobuf.*` types with nullable fields, plain list names, copy {} DSL
- CodeGeneratorRequest/Response parsed and built with protokt types
- Remove ExtensionRegistry from request parsing
- Remove protobuf-java generation of protokt.proto
- GrpcKotlinGeneratorSupport: serialize at the grpc-kotlin boundary only

### Commit 2: Generate Extension declarations from extend blocks
- Codegen emits typed Kotlin extension properties for `extend` blocks
- Each extension produces `val Extendee.name: T?` backed by `Extension<E, T>`
- Covers all scalar, enum, message, and repeated types
- Regenerated bootstrap includes the 8 protokt option extensions
- Delete hand-written ProtoktExtensions.kt; call sites use generated properties

### Commit 3: Bootstrap maintenance tasks + CI
- `regenerateBootstrap`: downloads well-known protos, runs protoc + codegen
- `verifyBootstrap`: fails if checked-in files don't match fresh generation
- Wired into CI build step

Depends on #514 — review only the top 3 commits.

## Test plan

- [x] Full test suite passes (clean build)
- [x] Generated output is identical to before
- [x] `verifyBootstrap` passes
- [x] Extension properties generated for conformance test protos that define extensions