### PR TITLE
Replace Jackson with kotlinx-serialization

### DIFF
--- a/examples/grpc-java-lite/build.gradle.kts
+++ b/examples/grpc-java-lite/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     protobuf(project(":examples:protos"))
 
     implementation(project(":examples:protos"))
-    implementation(libs.jackson)
 
     runtimeOnly(libs.protobuf.lite)
 }

--- a/examples/protos/build.gradle.kts
+++ b/examples/protos/build.gradle.kts
@@ -31,23 +31,15 @@ protokt {
 
 kotlin {
     sourceSets {
-        val commonMain by getting {}
-
-        val jvmMain by getting {
+        val commonMain by getting {
             dependencies {
-                implementation(libs.jackson)
+                implementation(libs.kotlinx.serialization.json)
             }
         }
 
         val jvmTest by getting {
             dependencies {
                 runtimeOnly(libs.protobuf.java) // unclear why this is needed; no tests
-            }
-        }
-
-        val jsMain by getting {
-            dependencies {
-                implementation(libs.kotlinx.serialization.json)
             }
         }
 

--- a/examples/protos/src/commonMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/commonMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -15,6 +15,41 @@
 
 package protokt.v1.io.grpc.examples.routeguide
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
 expect object Database {
     fun features(): List<Feature>
 }
+
+internal fun parseFeatures(json: String): List<Feature> =
+    Json.decodeFromString<JsonFeatureDatabase>(json)
+        .feature
+        .map { f ->
+            Feature {
+                name = f.name
+                location = f.location?.let { l ->
+                    Point {
+                        latitude = l.latitude
+                        longitude = l.longitude
+                    }
+                }
+            }
+        }
+
+@Serializable
+internal data class JsonFeatureDatabase(
+    val feature: List<JsonFeature>
+)
+
+@Serializable
+internal data class JsonFeature(
+    val name: String = "",
+    val location: JsonPoint? = null
+)
+
+@Serializable
+internal data class JsonPoint(
+    val latitude: Int = 0,
+    val longitude: Int = 0
+)

--- a/examples/protos/src/commonMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/commonMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -18,24 +18,24 @@ package protokt.v1.io.grpc.examples.routeguide
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
-expect object Database {
-    fun features(): List<Feature>
-}
+internal expect fun loadRouteGuideJson(): String
 
-internal fun parseFeatures(json: String): List<Feature> =
-    Json.decodeFromString<JsonFeatureDatabase>(json)
-        .feature
-        .map { f ->
-            Feature {
-                name = f.name
-                location = f.location?.let { l ->
-                    Point {
-                        latitude = l.latitude
-                        longitude = l.longitude
+object Database {
+    fun features(): List<Feature> =
+        Json.decodeFromString<JsonFeatureDatabase>(loadRouteGuideJson())
+            .feature
+            .map { f ->
+                Feature {
+                    name = f.name
+                    location = f.location?.let { l ->
+                        Point {
+                            latitude = l.latitude
+                            longitude = l.longitude
+                        }
                     }
                 }
             }
-        }
+}
 
 @Serializable
 internal data class JsonFeatureDatabase(

--- a/examples/protos/src/jsMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/jsMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -15,16 +15,11 @@
 
 package protokt.v1.io.grpc.examples.routeguide
 
-actual object Database {
-    actual fun features(): List<Feature> =
-        parseFeatures(featuresJson())
-
-    private fun featuresJson(): String =
-        js(
-            """
-                JSON.stringify(
-                    require('../../../../../examples/protos/src/commonMain/resources/protokt/v1/io/grpc/examples/routeguide/route_guide_db.json')
-                )
-            """
-        ) as String
-}
+internal actual fun loadRouteGuideJson(): String =
+    js(
+        """
+            JSON.stringify(
+                require('../../../../../examples/protos/src/commonMain/resources/protokt/v1/io/grpc/examples/routeguide/route_guide_db.json')
+            )
+        """
+    ) as String

--- a/examples/protos/src/jsMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/jsMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -15,24 +15,9 @@
 
 package protokt.v1.io.grpc.examples.routeguide
 
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-
 actual object Database {
-    actual fun features() =
-        Json.decodeFromString<FeatureDatabase>(featuresJson())
-            .feature
-            .map { f ->
-                Feature {
-                    name = f.name
-                    location = f.location.let { l ->
-                        Point {
-                            latitude = l.latitude
-                            longitude = l.longitude
-                        }
-                    }
-                }
-            }
+    actual fun features(): List<Feature> =
+        parseFeatures(featuresJson())
 
     private fun featuresJson(): String =
         js(
@@ -42,21 +27,4 @@ actual object Database {
                 )
             """
         ) as String
-
-    @Serializable
-    data class FeatureDatabase(
-        val feature: List<JsonFeature>
-    )
-
-    @Serializable
-    data class JsonFeature(
-        val name: String,
-        val location: JsonPoint
-    )
-
-    @Serializable
-    data class JsonPoint(
-        val latitude: Int,
-        val longitude: Int
-    )
 }

--- a/examples/protos/src/jvmMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/jvmMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -15,9 +15,7 @@
 
 package protokt.v1.io.grpc.examples.routeguide
 
-actual object Database {
-    actual fun features(): List<Feature> =
-        javaClass.getResourceAsStream("route_guide_db.json").use {
-            parseFeatures(it!!.reader().readText())
-        }
-}
+internal actual fun loadRouteGuideJson(): String =
+    Database::class.java.getResourceAsStream("route_guide_db.json")!!.use {
+        it.reader().readText()
+    }

--- a/examples/protos/src/jvmMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/jvmMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -15,39 +15,9 @@
 
 package protokt.v1.io.grpc.examples.routeguide
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.readValue
-
 actual object Database {
     actual fun features(): List<Feature> =
         javaClass.getResourceAsStream("route_guide_db.json").use {
-            ObjectMapper()
-                .registerModule(KotlinModule.Builder().build())
-                .readValue<JsonFeatureDatabase>(it!!.reader())
-        }.feature.map { f ->
-            Feature {
-                name = f.name
-                location = f.location?.let { l ->
-                    Point {
-                        latitude = l.latitude
-                        longitude = l.longitude
-                    }
-                }
-            }
+            parseFeatures(it!!.reader().readText())
         }
-
-    private data class JsonFeatureDatabase(
-        val feature: List<JsonFeature>
-    )
-
-    private data class JsonFeature(
-        val name: String = "",
-        val location: JsonPoint? = null
-    )
-
-    private data class JsonPoint(
-        val latitude: Int = 0,
-        val longitude: Int = 0
-    )
 }

--- a/examples/protos/src/nativeMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
+++ b/examples/protos/src/nativeMain/kotlin/protokt/v1/io/grpc/examples/routeguide/Database.kt
@@ -15,7 +15,5 @@
 
 package protokt.v1.io.grpc.examples.routeguide
 
-actual object Database {
-    actual fun features(): List<Feature> =
-        error("Not implemented on native")
-}
+internal actual fun loadRouteGuideJson(): String =
+    error("Not implemented on native")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ buf = "1.47.2"
 okio = "3.17.0"
 classgraph = "4.8.184"
 grpc-js = "1.12.4"
-jackson = "2.21.3"
 junit = "6.0.3"
 truth = "1.4.5"
 
@@ -113,7 +112,6 @@ classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classg
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpc-kotlin" }
 grpc-testing = { module = "io.grpc:grpc-testing", version.ref = "grpc-java" }
-jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage = { module = "org.junit.vintage:junit-vintage-engine" }

--- a/testing/interop/build.gradle.kts
+++ b/testing/interop/build.gradle.kts
@@ -39,6 +39,5 @@ dependencies {
     testImplementation(project(":testing:protobuf-java"))
     testImplementation(kotlin("reflect"))
     testImplementation(libs.classgraph)
-    testImplementation(libs.jackson)
     testImplementation(libs.protobuf.java)
 }

--- a/testing/protokt-generation/build.gradle.kts
+++ b/testing/protokt-generation/build.gradle.kts
@@ -37,7 +37,5 @@ dependencies {
     implementation(libs.grpc.kotlin.stub)
     implementation(libs.grpc.stub)
 
-    testImplementation(libs.jackson)
-
     testRuntimeOnly(libs.protobuf.java)
 }


### PR DESCRIPTION
- Lift `@Serializable` JSON models and `parseFeatures()` helper into `commonMain` so all targets share the same deserialization logic
- Replace Jackson `ObjectMapper` usage in `jvmMain` with `kotlinx-serialization-json` (already used in `jsMain`)
- Remove Jackson dependency from `examples/protos`, `examples/grpc-java-lite`, `testing/interop`, and `testing/protokt-generation`
- Remove Jackson from the version catalog entirely