### PR TITLE
Pass PGP env vars to publishPlugins release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,7 @@ jobs:
     - name: Publish Gradle plugin
       run: ./gradlew publishPlugins --no-configuration-cache --stacktrace --no-daemon
       env:
+        PGP_KEY: ${{ secrets.PGP_KEY }}
+        PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}
         GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PORTAL_PUBLISH_KEY }}
         GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PORTAL_PUBLISH_SECRET }}


### PR DESCRIPTION
The native targets PR split the single release step into two (Maven Central + Gradle Plugin Portal) but only kept `PGP_KEY`/`PGP_PASSWORD` on the first step. Pass the PGP env vars to the `publishPlugins` step so signing configuration succeeds.