### PR TITLE
Dispatch conformance driver by message type and fix editions/proto3 packing

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/FieldParser.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/util/FieldParser.kt
@@ -25,6 +25,7 @@ import protokt.v1.codegen.util.ErrorContext.withFieldName
 import protokt.v1.google.protobuf.DescriptorProto
 import protokt.v1.google.protobuf.FeatureSet
 import protokt.v1.google.protobuf.FeatureSet.FieldPresence
+import protokt.v1.google.protobuf.FeatureSet.RepeatedFieldEncoding
 import protokt.v1.google.protobuf.FieldDescriptorProto
 import protokt.v1.google.protobuf.FieldDescriptorProto.Label.OPTIONAL
 import protokt.v1.google.protobuf.FieldDescriptorProto.Label.REPEATED
@@ -235,8 +236,21 @@ internal class FieldParser(
                     // and `packed` is true. If proto3, only explicitly
                     // setting `packed` to false disables packing, since
                     // the default value for an unset boolean is false.
-                    (ctx.proto3 && (fdp.options?.packed == null || fdp.options?.packed == true))
+                    (ctx.proto3 && (fdp.options?.packed == null || fdp.options?.packed == true)) ||
+                    (ctx.edition2023 && packedEdition2023(fdp))
                 )
+
+    private fun packedEdition2023(fdp: FieldDescriptorProto): Boolean {
+        val fieldEncoding = fdp.options?.features?.repeatedFieldEncoding
+        if (fieldEncoding != null && fieldEncoding != RepeatedFieldEncoding.REPEATED_FIELD_ENCODING_UNKNOWN) {
+            return fieldEncoding == RepeatedFieldEncoding.PACKED
+        }
+        val fileEncoding = ctx.fileOptions.default.features?.repeatedFieldEncoding
+        if (fileEncoding != null && fileEncoding != RepeatedFieldEncoding.REPEATED_FIELD_ENCODING_UNKNOWN) {
+            return fileEncoding == RepeatedFieldEncoding.PACKED
+        }
+        return true
+    }
 
     private fun validateNonNullOption(
         fdp: FieldDescriptorProto,

--- a/testing/conformance/driver/src/commonMain/kotlin/protokt/v1/conformance/Main.kt
+++ b/testing/conformance/driver/src/commonMain/kotlin/protokt/v1/conformance/Main.kt
@@ -17,12 +17,15 @@ package protokt.v1.conformance
 
 import protokt.v1.AbstractDeserializer
 import protokt.v1.Collections
+import protokt.v1.Deserializer
 import protokt.v1.Message
 import protokt.v1.OnlyForUseByGeneratedProtoCode
 import protokt.v1.Reader
 import protokt.v1.conformance.ConformanceRequest.Payload.ProtobufPayload
 import protokt.v1.conformance.ConformanceResponse.Result
+import protokt.v1.protobuf_test_messages.editions.TestAllTypesEdition2023
 import protokt.v1.protobuf_test_messages.proto3.TestAllTypesProto3
+import protokt.v1.protobuf_test_messages.editions.proto3.TestAllTypesProto3 as TestAllTypesEditionProto3
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 fun main() =
@@ -60,9 +63,12 @@ private fun processRequest(request: ConformanceRequest): ConformanceStepResult<R
         return ConformanceStepResult.skip()
     }
 
+    val deserializer = deserializerFor(request.messageType.orEmpty())
+        ?: return ConformanceStepResult.skip()
+
     return when (val payload = request.payload) {
-        is ProtobufPayload -> Platform.deserializeProtobuf(payload.protobufPayload.bytes, TestAllTypesProto3)
-        else -> ConformanceStepResult.skip<TestAllTypesProto3>()
+        is ProtobufPayload -> Platform.deserializeProtobuf(payload.protobufPayload.bytes, deserializer)
+        else -> ConformanceStepResult.skip()
     }.flatMap {
         when (request.requestedOutputFormat) {
             WireFormat.PROTOBUF -> Platform.serializeProtobuf(it).map(Result::ProtobufPayload)
@@ -70,6 +76,14 @@ private fun processRequest(request: ConformanceRequest): ConformanceStepResult<R
         }
     }
 }
+
+private fun deserializerFor(messageType: String): Deserializer<out Message>? =
+    when (messageType) {
+        "protobuf_test_messages.proto3.TestAllTypesProto3" -> TestAllTypesProto3
+        "protobuf_test_messages.editions.proto3.TestAllTypesProto3" -> TestAllTypesEditionProto3
+        "protobuf_test_messages.editions.TestAllTypesEdition2023" -> TestAllTypesEdition2023
+        else -> null
+    }
 
 private val supportedMessageTypes =
     setOf(


### PR DESCRIPTION
- Conformance driver dispatches by `request.messageType` instead of always deserializing as `protobuf_test_messages.proto3.TestAllTypesProto3`. The old code happened to round-trip editions/proto3 messages through the proto3 generated type, so the suite passed but never exercised the editions/proto3 generated code.
- Codegen honors `features.repeated_field_encoding` for edition 2023, falling back to file-level features and finally to the edition default (`PACKED`). Without this, edition 2023 fields were always treated as unpacked, which only became visible once the dispatch fix exposed the editions/proto3 generated code to the conformance suite.