### PR TITLE
Carry generateProto task dependency on generated source directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,10 @@ jobs:
         name: integration-repository
         path: build/repos/integration
     - name: Build and test
-      run: ./gradlew "-Dkotlin-integration.version=${{ matrix.kotlin }}" "-Djava-integration.version=${{ matrix.jdk }}" build --stacktrace --no-daemon
+      run: ./gradlew "-Dkotlin-integration.version=${{ matrix.kotlin }}" "-Djava-integration.version=${{ matrix.jdk }}" build publishAllPublicationsToIntegrationTestRepository --stacktrace --no-daemon
       working-directory: gradle-plugin-integration-test
     - name: Verify configuration cache compatibility
-      run: ./gradlew "-Dkotlin-integration.version=${{ matrix.kotlin }}" "-Djava-integration.version=${{ matrix.jdk }}" --configuration-cache build --stacktrace --no-daemon
+      run: ./gradlew "-Dkotlin-integration.version=${{ matrix.kotlin }}" "-Djava-integration.version=${{ matrix.jdk }}" --configuration-cache build publishAllPublicationsToIntegrationTestRepository --stacktrace --no-daemon
       working-directory: gradle-plugin-integration-test
 
   # AGP 9 built-in Kotlin: runs with the default Kotlin version only, since AGP 9
@@ -139,10 +139,10 @@ jobs:
         name: integration-repository
         path: build/repos/integration
     - name: Build and test
-      run: ./gradlew "-Dandroid-integration.version=9.2.1" build --stacktrace --no-daemon
+      run: ./gradlew "-Dandroid-integration.version=9.2.1" build publishAllPublicationsToIntegrationTestRepository --stacktrace --no-daemon
       working-directory: gradle-plugin-integration-test
     - name: Verify configuration cache compatibility
-      run: ./gradlew "-Dandroid-integration.version=9.2.1" --configuration-cache build --stacktrace --no-daemon
+      run: ./gradlew "-Dandroid-integration.version=9.2.1" --configuration-cache build publishAllPublicationsToIntegrationTestRepository --stacktrace --no-daemon
       working-directory: gradle-plugin-integration-test
 
   # Native satellite jobs: download cross-compiled binaries and execute.

--- a/gradle-plugin-integration-test/multiplatform/build.gradle.kts
+++ b/gradle-plugin-integration-test/multiplatform/build.gradle.kts
@@ -20,6 +20,7 @@ import protokt.v1.gradle.protoktExtensions
 plugins {
     kotlin("multiplatform")
     id("com.toasttab.protokt.v1")
+    `maven-publish`
 }
 
 kotlin {
@@ -81,6 +82,19 @@ kotlin {
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
+}
+
+// Publishing schedules every publication artifact (sources jars, metadata jar,
+// module metadata) in the same graph as proto generation, verifying that
+// Gradle's implicit dependency validation passes. CI invokes
+// publishAllPublicationsToIntegrationTestRepository alongside build.
+publishing {
+    repositories {
+        maven {
+            name = "integrationTest"
+            url = uri(layout.buildDirectory.dir("test-repo"))
+        }
+    }
 }
 
 dependencies {

--- a/shared-src/gradle-plugin/protokt/v1/gradle/ProtoktBuild.kt
+++ b/shared-src/gradle-plugin/protokt/v1/gradle/ProtoktBuild.kt
@@ -252,12 +252,12 @@ private fun Project.linkGenerateProtoTasksAndIncludeGeneratedSource(target: Kotl
     generateProtoTask?.let { genProtoTask ->
         // Only include this target's output directory, not all targets' output directories.
         val targetOutputDir = layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/${target.protocPluginName}")
-        sourceSet.kotlin.srcDir(targetOutputDir)
+        sourceSet.kotlin.srcDir(files(targetOutputDir).builtBy(genProtoTask))
 
         // JVM targets also need the Java protobuf output directory so the Kotlin compiler
         // can resolve references to generated Java classes (e.g., ProtoktProtos).
         if (target.treatTargetAsJvm) {
-            sourceSet.kotlin.srcDir(layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/java"))
+            sourceSet.kotlin.srcDir(files(layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/java")).builtBy(genProtoTask))
         }
 
         the<SourceSetContainer>()


### PR DESCRIPTION
I was running into this issue when trying to publish an api module of mine that had protos
  Task ':iosArm64SourcesJar' uses this output of task ':generateProto'
  without declaring an explicit or implicit dependency.

Adding the generated output directories to Kotlin source sets as bare Directory providers loses the producer task information, so tasks that consume the source set without an explicit dependsOn (e.g. the KMP <target>SourcesJar tasks) fail Gradle's implicit-dependency validation with the above error.

My fix is to wrap the source directories in a file collection built by the generate task so every consumer of the source set inherits the dependency. i tested this fix with my own gradle project and it solved the issue.

Closes: https://github.com/open-toast/protokt/issues/545