### PR TITLE
Carry task dependencies through generated source directories

### DIFF
--- a/buildSrc/src/main/kotlin/RemotePublishing.kt
+++ b/buildSrc/src/main/kotlin/RemotePublishing.kt
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import com.google.protobuf.gradle.GenerateProtoTask
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.KotlinMultiplatform
@@ -22,7 +21,6 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
-import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.the
@@ -91,12 +89,6 @@ fun Project.enablePublishing(defaultJars: Boolean = true) {
             }
             pluginManager.withPlugin(KotlinPlugins.JVM) {
                 configure(KotlinJvm(JavadocJar.Empty()))
-            }
-        }
-
-        afterEvaluate {
-            tasks.withType<Jar> {
-                dependsOn(tasks.withType<GenerateProtoTask>())
             }
         }
     }

--- a/shared-src/gradle-plugin/protokt/v1/gradle/AndroidKmpLibrary.kt
+++ b/shared-src/gradle-plugin/protokt/v1/gradle/AndroidKmpLibrary.kt
@@ -15,6 +15,7 @@
 
 package protokt.v1.gradle
 
+import com.google.protobuf.gradle.GenerateProtoTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.kotlin.dsl.the
@@ -31,8 +32,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
  */
 internal object AndroidKmpLibrary {
     fun configure(project: Project, target: KotlinTarget, config: Config) {
-        project.wireSourceSet(target, "androidMain", "compileAndroidMain", config.extensions, false)
-        project.wireSourceSet(target, "androidHostTest", "compileAndroidHostTest", config.testExtensions, true)
+        project.wireSourceSet(target, "androidMain", config.extensions, false)
+        project.wireSourceSet(target, "androidHostTest", config.testExtensions, true)
 
         // AGP derives baselineProfiles directories as siblings of Kotlin source
         // directories, which places them inside generateProto's output.
@@ -44,20 +45,19 @@ internal object AndroidKmpLibrary {
     private fun Project.wireSourceSet(
         target: KotlinTarget,
         sourceSetName: String,
-        compileTaskName: String,
         extensionsConfiguration: Configuration,
         test: Boolean
     ) {
         val protoSourceSetRoot = if (test) "test" else "main"
         val generateProtoTaskName = if (test) "generateTestProto" else "generateProto"
+        val generateProtoTasks = tasks.withType(GenerateProtoTask::class.java).matching { it.name == generateProtoTaskName }
 
         the<KotlinMultiplatformExtension>().sourceSets.matching { it.name == sourceSetName }.all {
             configurations.getByName(apiConfigurationName).extendsFrom(extensionsConfiguration)
-            kotlin.srcDir(layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/${target.protocPluginName}"))
-
-            tasks.matching { it.name == compileTaskName }.configureEach {
-                dependsOn(generateProtoTaskName)
-            }
+            kotlin.srcDir(
+                files(layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/${target.protocPluginName}"))
+                    .builtBy(generateProtoTasks)
+            )
         }
     }
 }

--- a/shared-src/gradle-plugin/protokt/v1/gradle/ProtobufBuild.kt
+++ b/shared-src/gradle-plugin/protokt/v1/gradle/ProtobufBuild.kt
@@ -23,10 +23,8 @@ import com.google.protobuf.gradle.id
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.provider.Provider
-import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.withType
 import java.net.URLEncoder
 
@@ -40,8 +38,6 @@ internal fun configureProtobufPlugin(
     project.apply<ProtobufPlugin>()
 
     project.configure<ProtobufExtension> {
-        configureSources(project)
-
         protoc {
             artifact = "com.google.protobuf:protoc:${ext.protocVersion}"
         }
@@ -152,16 +148,6 @@ private fun resolveExtensions(project: Project, task: GenerateProtoTask) =
             null
         }
     )
-
-private fun configureSources(project: Project) {
-    project.afterEvaluate {
-        if (project.tasks.findByName("sourcesJar") != null) {
-            tasks.named<Jar>("sourcesJar").configure {
-                from("generated/source/proto/main")
-            }
-        }
-    }
-}
 
 private fun normalizePath(binaryPath: String) =
     if (Os.current.kind == Os.Kind.WINDOWS) {

--- a/shared-src/gradle-plugin/protokt/v1/gradle/ProtoktBuild.kt
+++ b/shared-src/gradle-plugin/protokt/v1/gradle/ProtoktBuild.kt
@@ -252,12 +252,12 @@ private fun Project.linkGenerateProtoTasksAndIncludeGeneratedSource(target: Kotl
     generateProtoTask?.let { genProtoTask ->
         // Only include this target's output directory, not all targets' output directories.
         val targetOutputDir = layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/${target.protocPluginName}")
-        sourceSet.kotlin.srcDir(targetOutputDir)
+        sourceSet.kotlin.srcDir(files(targetOutputDir).builtBy(genProtoTask))
 
         // JVM targets also need the Java protobuf output directory so the Kotlin compiler
         // can resolve references to generated Java classes (e.g., ProtoktProtos).
         if (target.treatTargetAsJvm) {
-            sourceSet.kotlin.srcDir(layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/java"))
+            sourceSet.kotlin.srcDir(files(layout.buildDirectory.dir("generated/sources/proto/$protoSourceSetRoot/java")).builtBy(genProtoTask))
         }
 
         the<SourceSetContainer>()

--- a/shared-src/gradle-plugin/protokt/v1/gradle/ProtoktBuild.kt
+++ b/shared-src/gradle-plugin/protokt/v1/gradle/ProtoktBuild.kt
@@ -38,7 +38,6 @@ import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 internal const val BASE_GROUP_NAME = "com.toasttab.protokt.v1"
 
@@ -263,13 +262,6 @@ private fun Project.linkGenerateProtoTasksAndIncludeGeneratedSource(target: Kotl
         the<SourceSetContainer>()
             .getByName(protoSourceSetRoot)
             .proto { sourceSet.resources.source(this) }
-
-        tasks.withType<KotlinCompilationTask<*>> {
-            if ((test && "Test" in name) || (!test && "Test" !in name)) {
-                logger.log(DEBUG_LOG_LEVEL, "Making task {} a dependency of {}", genProtoTask.name, name)
-                dependsOn(genProtoTask)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
- Preserve each `generateProto` producer relationship when generated source directories are added to Kotlin source sets, including Android KMP source sets.
- Remove blanket compile and publishing dependencies from unrelated protobuf generation tasks.
- Remove the stale manual `sourcesJar` path and let every source-set consumer inherit only the producer for the directory it consumes.

Fixes #545