### PR TITLE
Fix floating-point message semantics

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FloatingPointSupport.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/FloatingPointSupport.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen.generate
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asTypeName
+
+internal fun TypeName.equalsExpression(left: CodeBlock, right: CodeBlock): CodeBlock =
+    CodeBlock.of("%L == %L", canonicalBits(left), canonicalBits(right))
+
+internal fun TypeName.hashCodeExpression(value: CodeBlock): CodeBlock =
+    CodeBlock.of("%L.hashCode()", canonicalBits(value))
+
+internal val TypeName.isFloatingPoint: Boolean
+    get() = copy(nullable = false) == Float::class.asTypeName() || copy(nullable = false) == Double::class.asTypeName()
+
+private fun TypeName.canonicalBits(value: CodeBlock): CodeBlock =
+    if (isFloatingPoint) {
+        CodeBlock.of(if (isNullable) "%L?.toBits()" else "%L.toBits()", value)
+    } else {
+        value
+    }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -310,7 +310,10 @@ private class MessageGenerator(
 
     private fun equalsLines(properties: List<PropertyInfo>) =
         properties.map {
-            CodeBlock.of("other.%N == this.%N &&\n".bindSpaces(), it.name, it.name)
+            CodeBlock.of(
+                "%L &&\n".bindSpaces(),
+                it.propertyType.equalsExpression(CodeBlock.of("other.%N", it.name), CodeBlock.of("this.%N", it.name))
+            )
         }
 
     private fun TypeSpec.Builder.handleHashCode(
@@ -336,7 +339,10 @@ private class MessageGenerator(
 
     private fun hashCodeLines(properties: List<PropertyInfo>) =
         properties.map {
-            CodeBlock.of("result = 31 * result + %N.hashCode()\n".bindSpaces(), it.name)
+            CodeBlock.of(
+                "result = 31 * result + %L\n".bindSpaces(),
+                it.propertyType.hashCodeExpression(CodeBlock.of("%N", it.name))
+            )
         }
 
     private fun TypeSpec.Builder.handleToString(

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/OneofGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/OneofGenerator.kt
@@ -112,7 +112,32 @@ private class OneofGenerator(
                     .addParameter(v.fieldName, v.type)
                     .build()
             )
+            .apply {
+                if (v.type.isFloatingPoint) {
+                    addFunction(equalsFunction(oneof.className.nestedClass(name), v))
+                    addFunction(hashCodeFunction(v))
+                }
+            }
             .handleSuperInterface(implements, v)
+            .build()
+
+    private fun equalsFunction(variantClassName: ClassName, v: OneofGeneratorInfo) =
+        FunSpec.builder("equals")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("other", Any::class.asTypeName().copy(nullable = true))
+            .returns(Boolean::class)
+            .addStatement(
+                "return other is %T && %L",
+                variantClassName,
+                v.type.equalsExpression(CodeBlock.of("other.%N", v.fieldName), CodeBlock.of("%N", v.fieldName))
+            )
+            .build()
+
+    private fun hashCodeFunction(v: OneofGeneratorInfo) =
+        FunSpec.builder("hashCode")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(Int::class)
+            .addStatement("return %L", v.type.hashCodeExpression(CodeBlock.of("%N", v.fieldName)))
             .build()
 
     private fun buildCachingStringVariant(

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/SerializeAndSizeSupport.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/SerializeAndSizeSupport.kt
@@ -80,6 +80,10 @@ private fun StandardField.nonDefault(ctx: Context, property: PropertySpec): Code
 
                 type == FieldType.Bool -> wireValueAccess
 
+                type == FieldType.Float -> CodeBlock.of("%L.toRawBits() != 0", wireValueAccess)
+
+                type == FieldType.Double -> CodeBlock.of("%L.toRawBits() != 0L", wireValueAccess)
+
                 type.scalar -> CodeBlock.of("%L != %L", wireValueAccess, type.defaultValue)
 
                 else -> error("Unsupported non-nullable caching field type: $type")
@@ -96,6 +100,8 @@ private fun StandardField.nonDefault(ctx: Context, property: PropertySpec): Code
             type == FieldType.Bytes || type == FieldType.String -> CodeBlock.of("%L.isNotEmpty()", valueAccess)
             type == FieldType.Enum -> CodeBlock.of("%L.value != 0", valueAccess)
             type == FieldType.Bool -> valueAccess
+            type == FieldType.Float -> CodeBlock.of("%L.toRawBits() != 0", valueAccess)
+            type == FieldType.Double -> CodeBlock.of("%L.toRawBits() != 0L", valueAccess)
             type.scalar -> CodeBlock.of("%L != %L", valueAccess, type.defaultValue)
             else -> error("Field doesn't have nondefault check: $this, $type")
         }

--- a/testing/protokt-generation/src/main/proto/protokt/v1/testing/floating_point.proto
+++ b/testing/protokt-generation/src/main/proto/protokt/v1/testing/floating_point.proto
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.v1.testing;
+
+message FloatingPointMessage {
+  float float_value = 1;
+  double double_value = 2;
+  optional float optional_float = 3;
+
+  oneof selection {
+    float selected_float = 4;
+    double selected_double = 5;
+  }
+
+  repeated float float_values = 6;
+  map<string, double> double_values = 7;
+}

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/FloatingPointTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/FloatingPointTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class FloatingPointTest {
+    @Test
+    fun `NaN payloads are equal and have equal hashes`() {
+        val first =
+            FloatingPointMessage {
+                floatValue = Float.fromBits(0x7fc00001)
+                doubleValue = Double.fromBits(0x7ff8000000000001L)
+                optionalFloat = Float.fromBits(0x7fc00001)
+                selection = FloatingPointMessage.Selection.SelectedDouble(Double.fromBits(0x7ff8000000000001L))
+                floatValues = listOf(Float.fromBits(0x7fc00001))
+                doubleValues = mapOf("nan" to Double.fromBits(0x7ff8000000000001L))
+            }
+        val second =
+            FloatingPointMessage {
+                floatValue = Float.fromBits(0x7fc00002)
+                doubleValue = Double.fromBits(0x7ff8000000000002L)
+                optionalFloat = Float.fromBits(0x7fc00002)
+                selection = FloatingPointMessage.Selection.SelectedDouble(Double.fromBits(0x7ff8000000000002L))
+                floatValues = listOf(Float.fromBits(0x7fc00002))
+                doubleValues = mapOf("nan" to Double.fromBits(0x7ff8000000000002L))
+            }
+
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    }
+
+    @Test
+    fun `signed zeroes are unequal`() {
+        val positive =
+            FloatingPointMessage {
+                floatValue = 0.0f
+                doubleValue = 0.0
+                optionalFloat = 0.0f
+                selection = FloatingPointMessage.Selection.SelectedFloat(0.0f)
+                floatValues = listOf(0.0f)
+                doubleValues = mapOf("zero" to 0.0)
+            }
+        val negative =
+            FloatingPointMessage {
+                floatValue = -0.0f
+                doubleValue = -0.0
+                optionalFloat = -0.0f
+                selection = FloatingPointMessage.Selection.SelectedFloat(-0.0f)
+                floatValues = listOf(-0.0f)
+                doubleValues = mapOf("zero" to -0.0)
+            }
+
+        assertThat(positive).isNotEqualTo(negative)
+    }
+
+    @Test
+    fun `negative zero is serialized and retains its raw bits`() {
+        val positive = FloatingPointMessage { }
+        val negative =
+            FloatingPointMessage {
+                floatValue = -0.0f
+                doubleValue = -0.0
+            }
+
+        assertThat(positive.serializedSize()).isEqualTo(0)
+        assertThat(negative.serializedSize()).isGreaterThan(0)
+
+        val roundTrip = FloatingPointMessage.deserialize(negative.serialize())
+        assertThat(roundTrip.floatValue.toRawBits()).isEqualTo((-0.0f).toRawBits())
+        assertThat(roundTrip.doubleValue.toRawBits()).isEqualTo((-0.0).toRawBits())
+    }
+
+    @Test
+    fun `converted floating point fields use bit equality`() {
+        val first =
+            WellKnownTypes {
+                float = Float.fromBits(0x7fc00001)
+                double = Double.fromBits(0x7ff8000000000001L)
+            }
+        val second =
+            WellKnownTypes {
+                float = Float.fromBits(0x7fc00002)
+                double = Double.fromBits(0x7ff8000000000002L)
+            }
+        val negativeZero =
+            WellKnownTypes {
+                float = -0.0f
+                double = -0.0
+            }
+        val positiveZero =
+            WellKnownTypes {
+                float = 0.0f
+                double = 0.0
+            }
+
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+        assertThat(negativeZero).isNotEqualTo(positiveZero)
+
+        val roundTrip = WellKnownTypes.deserialize(negativeZero.serialize())
+        assertThat(roundTrip.float?.toRawBits()).isEqualTo((-0.0f).toRawBits())
+        assertThat(roundTrip.double?.toRawBits()).isEqualTo((-0.0).toRawBits())
+    }
+}


### PR DESCRIPTION
Protokt should be consistent with protobuf-java re: equality and hashing for floating-point fields.

- Use canonical floating-point bits for equality and hashing so NaN payloads compare consistently and signed zeroes remain distinct.
- Use raw bits for implicit scalar default detection so negative zero is serialized.

## Acceptance Criteria

- Distinct NaN payloads compare equal and produce equal hashes.
- Positive and negative zero compare unequal.
- Negative zero survives serialization and deserialization.
- Repeated and map floating-point fields retain their collection semantics.