### PR TITLE
Bound byte string rendering

### DIFF
--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/AbstractBytes.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/AbstractBytes.kt
@@ -38,7 +38,7 @@ abstract class AbstractBytes internal constructor(
         value.contentHashCode()
 
     final override fun toString() =
-        value.contentToString()
+        renderBytes(value, 0, value.size)
 
     internal companion object {
         private val EMPTY = Bytes(ByteArray(0))
@@ -53,3 +53,26 @@ abstract class AbstractBytes internal constructor(
             Bytes(message.serialize())
     }
 }
+
+private const val BYTE_PREVIEW_LIMIT = 32
+private const val HEX_DIGITS = "0123456789abcdef"
+
+internal fun renderBytes(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+) =
+    buildString {
+        append("Bytes(size=")
+        append(length)
+        append(", hex=\"")
+        repeat(minOf(length, BYTE_PREVIEW_LIMIT)) {
+            val value = bytes[offset + it].toInt() and 0xff
+            append(HEX_DIGITS[value ushr 4])
+            append(HEX_DIGITS[value and 0x0f])
+        }
+        if (length > BYTE_PREVIEW_LIMIT) {
+            append("...")
+        }
+        append("\")")
+    }

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/AbstractBytes.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/AbstractBytes.kt
@@ -32,7 +32,7 @@ abstract class AbstractBytes internal constructor(
         BytesSlice(value)
 
     final override fun equals(other: Any?) =
-        other is Bytes && value.contentEquals(other.value)
+        other is AbstractBytes && value.contentEquals(other.value)
 
     final override fun hashCode() =
         value.contentHashCode()

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/BytesSlice.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/BytesSlice.kt
@@ -47,7 +47,7 @@ class BytesSlice internal constructor(
         hashCodeUsingSequence(asSequence())
 
     override fun toString() =
-        asSequence().joinToString(prefix = "[", postfix = "]")
+        renderBytes(array, offset, length)
 
     companion object {
         private val EMPTY = BytesSlice(ByteArray(0), 0, 0)

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/BytesTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/BytesTest.kt
@@ -20,13 +20,18 @@ import org.junit.jupiter.api.Test
 
 class BytesTest {
     @Test
+    fun `empty bytes render with size and an empty preview`() {
+        assertThat(Bytes.empty().toString()).isEqualTo("Bytes(size=0, hex=\"\")")
+    }
+
+    @Test
     fun `bytes to bytes slice and back`() {
         val array = byteArrayOf(1, 2, 3, 4)
         val bytes = Bytes(array)
         val slice = bytes.toBytesSlice()
         val backToBytes = slice.toBytes()
 
-        assertThat(bytes.toString()).isEqualTo(array.contentToString())
+        assertThat(bytes.toString()).isEqualTo("Bytes(size=4, hex=\"01020304\")")
         assertThat(slice.toString()).isEqualTo(bytes.toString())
         assertThat(backToBytes.toString()).isEqualTo(slice.toString())
         assertThat(backToBytes.toString()).isEqualTo(bytes.toString())
@@ -41,9 +46,39 @@ class BytesTest {
         val slice = BytesSlice(array, 1, 2)
         val bytes = slice.toBytes()
 
-        assertThat(slice.toString()).isEqualTo(subarray.contentToString())
+        assertThat(slice.toString()).isEqualTo("Bytes(size=2, hex=\"0203\")")
         assertThat(bytes.toString()).isEqualTo(slice.toString())
 
         assertThat(bytes.bytes).isEqualTo(subarray)
+    }
+
+    @Test
+    fun `bytes render unsigned lowercase hex`() {
+        val bytes = Bytes.from(byteArrayOf(0, 0x0f, 0x10, 0x7f, 0x80.toByte(), 0xff.toByte()))
+
+        assertThat(bytes.toString()).isEqualTo("Bytes(size=6, hex=\"000f107f80ff\")")
+    }
+
+    @Test
+    fun `preview includes all of a 32-byte value`() {
+        val bytes = Bytes.from(ByteArray(32) { it.toByte() })
+
+        assertThat(bytes.toString())
+            .isEqualTo("Bytes(size=32, hex=\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\")")
+    }
+
+    @Test
+    fun `preview truncates values longer than 32 bytes`() {
+        val bytes = Bytes.from(ByteArray(33) { it.toByte() })
+
+        assertThat(bytes.toString())
+            .isEqualTo("Bytes(size=33, hex=\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f...\")")
+    }
+
+    @Test
+    fun `slice preview does not include bytes outside its bounds`() {
+        val slice = BytesSlice(byteArrayOf(0x7f, 1, 2, 3, 0x7f), 1, 3)
+
+        assertThat(slice.toString()).isEqualTo("Bytes(size=3, hex=\"010203\")")
     }
 }

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/BytesTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/BytesTest.kt
@@ -60,6 +60,16 @@ class BytesTest {
     }
 
     @Test
+    fun `abstract bytes subclasses compare symmetrically`() {
+        val bytes = Bytes.from(byteArrayOf(1, 2, 3))
+        val other = TestBytes(byteArrayOf(1, 2, 3))
+
+        assertThat(bytes).isEqualTo(other)
+        assertThat(other).isEqualTo(bytes)
+        assertThat(bytes.hashCode()).isEqualTo(other.hashCode())
+    }
+
+    @Test
     fun `preview includes all of a 32-byte value`() {
         val bytes = Bytes.from(ByteArray(32) { it.toByte() })
 
@@ -82,3 +92,5 @@ class BytesTest {
         assertThat(slice.toString()).isEqualTo("Bytes(size=3, hex=\"010203\")")
     }
 }
+
+private class TestBytes(value: ByteArray) : AbstractBytes(value)

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/ToStringTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/ToStringTest.kt
@@ -53,7 +53,7 @@ class ToStringTest {
         assertThat(
             ToStringTest2 { extra = "foo" }.toString()
         ).isEqualTo(
-            "ToStringTest2(`val`=[], extra=foo)"
+            "ToStringTest2(`val`=Bytes(size=0, hex=\"\"), extra=foo)"
         )
     }
 
@@ -68,7 +68,7 @@ class ToStringTest {
             }.toString()
         ).isEqualTo(
             "ToStringTest2(" +
-                "`val`=[], " +
+                "`val`=Bytes(size=0, hex=\"\"), " +
                 "extra=foo, " +
                 "unknownFields=UnknownFieldSet(fields={5=Field(" +
                 "varint=[], " +


### PR DESCRIPTION
## Summary

- Replace unbounded decimal byte dumps with deterministic `Bytes(size=N, hex="...")` output.
- Render at most 32 bytes as lowercase hexadecimal and mark truncated previews with `...`.
- Give `Bytes` and `BytesSlice` the same representation while respecting slice boundaries.
- Compare every `AbstractBytes` implementation by content so a future second implementation cannot make equality asymmetric.
- Keep empty values explicit without including an unstable identity hash.

## Acceptance criteria

- Empty values, unsigned bytes, the exact preview boundary, truncation, and slice bounds have pinned representations.
- Distinct `AbstractBytes` implementations with the same payload compare equally in both directions and have the same hash code.