### PR TITLE
Reject malformed UTF-8 consistently

### DIFF
--- a/protokt-runtime-kotlinx-io/src/commonMain/kotlin/protokt/v1/KotlinxIoSourceReader.kt
+++ b/protokt-runtime-kotlinx-io/src/commonMain/kotlin/protokt/v1/KotlinxIoSourceReader.kt
@@ -39,9 +39,7 @@ internal class KotlinxIoSourceReader(
             return 0u
         }
         _lastTag = readRawVarint32()
-        if (_lastTag == 0 || WireFormat.getTagFieldNumber(_lastTag) == 0) {
-            throw ProtoktDecodeException("Invalid tag: $_lastTag")
-        }
+        protoktCheck(_lastTag != 0 && WireFormat.getTagFieldNumber(_lastTag) != 0) { "Invalid tag: $_lastTag" }
         return _lastTag.toUInt()
     }
 
@@ -93,9 +91,7 @@ internal class KotlinxIoSourceReader(
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
-            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
-        }
+        protoktCheck(messageDepth < WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
         messageDepth++
         try {
             val length = readRawVarint32()
@@ -104,9 +100,7 @@ internal class KotlinxIoSourceReader(
             currentLimit = bytesRead + length
             try {
                 val result = m.deserialize(this)
-                if (bytesRead != currentLimit) {
-                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
-                }
+                protoktRequire(bytesRead == currentLimit) { WireFormat.MESSAGE_NOT_FULLY_CONSUMED }
                 return result
             } finally {
                 currentLimit = oldLimit
@@ -117,18 +111,14 @@ internal class KotlinxIoSourceReader(
     }
 
     private fun checkLength(length: Int) {
-        if (length < 0) {
-            throw ProtoktDecodeException(WireFormat.NEGATIVE_SIZE)
-        }
-        if (length > currentLimit - bytesRead || !source.request(length.toLong())) {
-            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-        }
+        protoktCheck(length >= 0) { WireFormat.NEGATIVE_SIZE }
+        protoktCheck(length <= currentLimit - bytesRead) { WireFormat.TRUNCATED_MESSAGE }
+        protoktCheck(source.request(length.toLong())) { WireFormat.TRUNCATED_MESSAGE }
     }
 
     private fun checkAvailable(size: Int) {
-        if (currentLimit - bytesRead < size || !source.request(size.toLong())) {
-            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-        }
+        protoktCheck(currentLimit - bytesRead >= size) { WireFormat.TRUNCATED_MESSAGE }
+        protoktCheck(source.request(size.toLong())) { WireFormat.TRUNCATED_MESSAGE }
     }
 
     private fun readSourceByte(): Byte {

--- a/protokt-runtime-kotlinx-io/src/commonMain/kotlin/protokt/v1/KotlinxIoSourceReader.kt
+++ b/protokt-runtime-kotlinx-io/src/commonMain/kotlin/protokt/v1/KotlinxIoSourceReader.kt
@@ -40,7 +40,7 @@ internal class KotlinxIoSourceReader(
         }
         _lastTag = readRawVarint32()
         if (_lastTag == 0 || WireFormat.getTagFieldNumber(_lastTag) == 0) {
-            throw IllegalStateException("Invalid tag: $_lastTag")
+            throw ProtoktDecodeException("Invalid tag: $_lastTag")
         }
         return _lastTag.toUInt()
     }
@@ -82,38 +82,53 @@ internal class KotlinxIoSourceReader(
             checkLength(length)
             val oldLimit = currentLimit
             currentLimit = bytesRead + length
-            while (bytesRead < currentLimit) {
-                acc(this)
+            try {
+                while (bytesRead < currentLimit) {
+                    acc(this)
+                }
+            } finally {
+                currentLimit = oldLimit
             }
-            currentLimit = oldLimit
         }
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        check(++messageDepth <= WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
+        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
+            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
+        }
+        messageDepth++
         try {
             val length = readRawVarint32()
             checkLength(length)
             val oldLimit = currentLimit
             currentLimit = bytesRead + length
-            val res = m.deserialize(this)
-            require(bytesRead == currentLimit) { "Message not fully consumed" }
-            currentLimit = oldLimit
-            return res
+            try {
+                val result = m.deserialize(this)
+                if (bytesRead != currentLimit) {
+                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
+                }
+                return result
+            } finally {
+                currentLimit = oldLimit
+            }
         } finally {
             messageDepth--
         }
     }
 
     private fun checkLength(length: Int) {
-        check(length >= 0) { WireFormat.NEGATIVE_SIZE }
-        check(length <= currentLimit - bytesRead) { WireFormat.TRUNCATED_MESSAGE }
-        check(source.request(length.toLong())) { WireFormat.TRUNCATED_MESSAGE }
+        if (length < 0) {
+            throw ProtoktDecodeException(WireFormat.NEGATIVE_SIZE)
+        }
+        if (length > currentLimit - bytesRead || !source.request(length.toLong())) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
     }
 
     private fun checkAvailable(size: Int) {
-        check(currentLimit - bytesRead >= size) { WireFormat.TRUNCATED_MESSAGE }
-        check(source.request(size.toLong())) { WireFormat.TRUNCATED_MESSAGE }
+        if (currentLimit - bytesRead < size || !source.request(size.toLong())) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
     }
 
     private fun readSourceByte(): Byte {
@@ -139,13 +154,14 @@ internal class KotlinxIoSourceReader(
             shift += 7
         }
         // discard upper bits for oversized varints
-        while (true) {
+        repeat(5) {
             checkAvailable(1)
             val b = readSourceByte().toInt()
             if (b and 0x80 == 0) {
                 return result
             }
         }
+        throw ProtoktDecodeException(WireFormat.MALFORMED_VARINT)
     }
 
     private fun readRawVarint64(): ULong {
@@ -160,7 +176,7 @@ internal class KotlinxIoSourceReader(
             }
             shift += 7
         }
-        throw IllegalStateException("Varint too long")
+        throw ProtoktDecodeException(WireFormat.MALFORMED_VARINT)
     }
 
     private fun readFixed32Bits(): UInt {

--- a/protokt-runtime-kotlinx-io/src/commonMain/kotlin/protokt/v1/KotlinxIoSourceReader.kt
+++ b/protokt-runtime-kotlinx-io/src/commonMain/kotlin/protokt/v1/KotlinxIoSourceReader.kt
@@ -19,7 +19,6 @@ import kotlinx.io.Source
 import kotlinx.io.readByteArray
 import kotlinx.io.readIntLe
 import kotlinx.io.readLongLe
-import kotlinx.io.readString
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 internal class KotlinxIoSourceReader(
@@ -54,8 +53,7 @@ internal class KotlinxIoSourceReader(
     override fun readString(): String {
         val length = readRawVarint32()
         checkLength(length)
-        bytesRead += length
-        return source.readString(length.toLong())
+        return decodeUtf8(readSourceByteArray(length))
     }
 
     override fun readUInt64(): ULong =

--- a/protokt-runtime-protobuf-java/src/jvmMain/kotlin/protokt/v1/ProtobufJavaReader.kt
+++ b/protokt-runtime-protobuf-java/src/jvmMain/kotlin/protokt/v1/ProtobufJavaReader.kt
@@ -16,7 +16,6 @@
 package protokt.v1
 
 import com.google.protobuf.CodedInputStream
-import com.google.protobuf.InvalidProtocolBufferException
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 internal class ProtobufJavaReader(
@@ -95,18 +94,14 @@ internal class ProtobufJavaReader(
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
-            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
-        }
+        protoktCheck(messageDepth < WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
         messageDepth++
         try {
             val length = decode { stream.readRawVarint32() }
             val limit = decode { stream.pushLimit(length) }
             try {
                 val result = m.deserialize(this)
-                if (stream.bytesUntilLimit != 0) {
-                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
-                }
+                protoktRequire(stream.bytesUntilLimit == 0) { WireFormat.MESSAGE_NOT_FULLY_CONSUMED }
                 return result
             } finally {
                 stream.popLimit(limit)
@@ -115,13 +110,4 @@ internal class ProtobufJavaReader(
             messageDepth--
         }
     }
-
-    private inline fun <T> decode(block: () -> T): T =
-        try {
-            block()
-        } catch (e: InvalidProtocolBufferException) {
-            val message = e.message ?: "Malformed protobuf input"
-            val normalizedMessage = if (message.contains("malformed varint", ignoreCase = true)) WireFormat.MALFORMED_VARINT else message
-            throw ProtoktDecodeException(normalizedMessage, e)
-        }
 }

--- a/protokt-runtime-protobuf-java/src/jvmMain/kotlin/protokt/v1/ProtobufJavaReader.kt
+++ b/protokt-runtime-protobuf-java/src/jvmMain/kotlin/protokt/v1/ProtobufJavaReader.kt
@@ -56,7 +56,7 @@ internal class ProtobufJavaReader(
         decode { stream.readSInt64() }
 
     override fun readString() =
-        decode { stream.readString() }
+        decode { stream.readStringRequireUtf8() }
 
     override fun readUInt64() =
         decode { stream.readUInt64().toULong() }

--- a/protokt-runtime-protobuf-java/src/jvmMain/kotlin/protokt/v1/ProtobufJavaReader.kt
+++ b/protokt-runtime-protobuf-java/src/jvmMain/kotlin/protokt/v1/ProtobufJavaReader.kt
@@ -16,6 +16,7 @@
 package protokt.v1
 
 import com.google.protobuf.CodedInputStream
+import com.google.protobuf.InvalidProtocolBufferException
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)
 internal class ProtobufJavaReader(
@@ -28,78 +29,99 @@ internal class ProtobufJavaReader(
         get() = stream.lastTag.toUInt()
 
     override fun readDouble() =
-        stream.readDouble()
+        decode { stream.readDouble() }
 
     override fun readFixed32() =
-        stream.readFixed32().toUInt()
+        decode { stream.readFixed32().toUInt() }
 
     override fun readFixed64() =
-        stream.readFixed64().toULong()
+        decode { stream.readFixed64().toULong() }
 
     override fun readFloat() =
-        stream.readFloat()
+        decode { stream.readFloat() }
 
     override fun readInt64() =
-        stream.readInt64()
+        decode { stream.readInt64() }
 
     override fun readSFixed32() =
-        stream.readSFixed32()
+        decode { stream.readSFixed32() }
 
     override fun readSFixed64() =
-        stream.readSFixed64()
+        decode { stream.readSFixed64() }
 
     override fun readSInt32() =
-        stream.readSInt32()
+        decode { stream.readSInt32() }
 
     override fun readSInt64() =
-        stream.readSInt64()
+        decode { stream.readSInt64() }
 
     override fun readString() =
-        stream.readString()
+        decode { stream.readString() }
 
     override fun readUInt64() =
-        stream.readUInt64().toULong()
+        decode { stream.readUInt64().toULong() }
 
     override fun readTag() =
-        stream.readTag().toUInt()
+        decode { stream.readTag().toUInt() }
 
     override fun readBytes() =
-        Bytes(stream.readByteArray())
+        decode { Bytes(stream.readByteArray()) }
 
     override fun readBytesSlice() =
         if (bytes != null) {
-            val ln = stream.readRawVarint32()
+            val ln = decode { stream.readRawVarint32() }
             val off = stream.totalBytesRead
-            stream.skipRawBytes(ln)
+            decode { stream.skipRawBytes(ln) }
             BytesSlice(bytes, off, ln)
         } else {
-            BytesSlice(stream.readByteArray())
+            decode { BytesSlice(stream.readByteArray()) }
         }
 
     override fun readRepeated(packed: Boolean, acc: Reader.() -> Unit) {
         if (!packed || WireFormat.getTagWireType(lastTag.toInt()) != WireFormat.WIRETYPE_LENGTH_DELIMITED) {
             acc(this)
         } else {
-            stream.readRawVarint32().also { sz ->
-                val limit = stream.pushLimit(sz)
-                while (stream.bytesUntilLimit > 0) {
-                    acc(this)
+            decode { stream.readRawVarint32() }.also { size ->
+                val limit = decode { stream.pushLimit(size) }
+                try {
+                    while (stream.bytesUntilLimit > 0) {
+                        acc(this)
+                    }
+                } finally {
+                    stream.popLimit(limit)
                 }
-                stream.popLimit(limit)
             }
         }
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        check(++messageDepth <= WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
+        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
+            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
+        }
+        messageDepth++
         try {
-            val limit = stream.pushLimit(stream.readRawVarint32())
-            val res = m.deserialize(this)
-            require(stream.bytesUntilLimit == 0)
-            stream.popLimit(limit)
-            return res
+            val length = decode { stream.readRawVarint32() }
+            val limit = decode { stream.pushLimit(length) }
+            try {
+                val result = m.deserialize(this)
+                if (stream.bytesUntilLimit != 0) {
+                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
+                }
+                return result
+            } finally {
+                stream.popLimit(limit)
+            }
         } finally {
             messageDepth--
         }
     }
+
+    private inline fun <T> decode(block: () -> T): T =
+        try {
+            block()
+        } catch (e: InvalidProtocolBufferException) {
+            val message = e.message ?: "Malformed protobuf input"
+            val normalizedMessage = if (message.contains("malformed varint", ignoreCase = true)) WireFormat.MALFORMED_VARINT else message
+            throw ProtoktDecodeException(normalizedMessage, e)
+        }
 }

--- a/protokt-runtime-protobufjs/src/jsMain/kotlin/protokt/v1/ProtobufJsReader.kt
+++ b/protokt-runtime-protobufjs/src/jsMain/kotlin/protokt/v1/ProtobufJsReader.kt
@@ -65,8 +65,13 @@ internal class ProtobufJsReader(
     override fun readSInt64() =
         decode { Long.fromProtobufJsLong(reader.sint64()) }
 
-    override fun readString() =
-        decode { reader.string() }
+    override fun readString(): String {
+        val bytes = decode { reader.bytes().asByteArray() }
+        if (reader.pos > endPosition) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
+        return decodeUtf8(bytes)
+    }
 
     override fun readUInt64() =
         decode { Long.fromProtobufJsLong(reader.uint64()).toULong() }

--- a/protokt-runtime-protobufjs/src/jsMain/kotlin/protokt/v1/ProtobufJsReader.kt
+++ b/protokt-runtime-protobufjs/src/jsMain/kotlin/protokt/v1/ProtobufJsReader.kt
@@ -26,53 +26,70 @@ internal class ProtobufJsReader(
     override val lastTag: UInt
         get() = _lastTag
 
-    override fun readDouble() =
-        reader.double()
+    override fun readDouble(): Double {
+        checkAvailable(8)
+        return decode { reader.double() }
+    }
 
-    override fun readFixed32() =
-        reader.fixed32().toUInt()
+    override fun readFixed32(): UInt {
+        checkAvailable(4)
+        return decode { reader.fixed32().toUInt() }
+    }
 
-    override fun readFixed64() =
-        Long.fromProtobufJsLong(reader.fixed64()).toULong()
+    override fun readFixed64(): ULong {
+        checkAvailable(8)
+        return decode { Long.fromProtobufJsLong(reader.fixed64()).toULong() }
+    }
 
-    override fun readFloat() =
-        reader.float()
+    override fun readFloat(): Float {
+        checkAvailable(4)
+        return decode { reader.float() }
+    }
 
     override fun readInt64() =
-        Long.fromProtobufJsLong(reader.int64())
+        decode { Long.fromProtobufJsLong(reader.int64()) }
 
-    override fun readSFixed32() =
-        reader.sfixed32()
+    override fun readSFixed32(): Int {
+        checkAvailable(4)
+        return decode { reader.sfixed32() }
+    }
 
-    override fun readSFixed64() =
-        Long.fromProtobufJsLong(reader.sfixed64())
+    override fun readSFixed64(): Long {
+        checkAvailable(8)
+        return decode { Long.fromProtobufJsLong(reader.sfixed64()) }
+    }
 
     override fun readSInt32() =
-        reader.sint32()
+        decode { reader.sint32() }
 
     override fun readSInt64() =
-        Long.fromProtobufJsLong(reader.sint64())
+        decode { Long.fromProtobufJsLong(reader.sint64()) }
 
     override fun readString() =
-        reader.string()
+        decode { reader.string() }
 
     override fun readUInt64() =
-        Long.fromProtobufJsLong(reader.uint64()).toULong()
+        decode { Long.fromProtobufJsLong(reader.uint64()).toULong() }
 
     override fun readTag(): UInt {
         _lastTag =
             if (reader.pos == endPosition) {
                 0u
             } else {
+                if (reader.pos > endPosition) {
+                    throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+                }
                 val tag = readInt32()
-                check(tag ushr 3 != 0) { "Invalid tag" }
+                if (tag ushr 3 == 0) {
+                    throw ProtoktDecodeException("Invalid tag: $tag")
+                }
                 tag.toUInt()
             }
         return _lastTag
     }
 
     override fun readBytes() =
-        Bytes(reader.bytes().asByteArray())
+        decode { Bytes(reader.bytes().asByteArray()) }
 
     // Does protobufjs support reading a slice?
     override fun readBytesSlice() =
@@ -83,26 +100,60 @@ internal class ProtobufJsReader(
             acc(this)
         } else {
             val length = readInt32()
-            val endPosition = reader.pos + length
-            while (reader.pos < endPosition) {
+            val packedEndPosition = checkedEndPosition(length)
+            while (reader.pos < packedEndPosition) {
                 acc(this)
+            }
+            if (reader.pos != packedEndPosition) {
+                throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
             }
         }
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        check(++messageDepth <= WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
+        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
+            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
+        }
+        messageDepth++
         try {
             val oldEndPosition = endPosition
-            endPosition = readInt32() + reader.pos
-            val ret = m.deserialize(this)
-            require(reader.pos == endPosition) {
-                "Not at the end of the current message limit as expected"
+            endPosition = checkedEndPosition(readInt32())
+            try {
+                val result = m.deserialize(this)
+                if (reader.pos != endPosition) {
+                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
+                }
+                return result
+            } finally {
+                endPosition = oldEndPosition
             }
-            endPosition = oldEndPosition
-            return ret
         } finally {
             messageDepth--
         }
     }
+
+    private fun checkAvailable(size: Int) {
+        if (size > endPosition - reader.pos) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
+    }
+
+    private fun checkedEndPosition(length: Int): Int {
+        if (length < 0) {
+            throw ProtoktDecodeException(WireFormat.NEGATIVE_SIZE)
+        }
+        if (length > endPosition - reader.pos) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
+        return reader.pos + length
+    }
+
+    private inline fun <T> decode(block: () -> T): T =
+        try {
+            block()
+        } catch (e: ProtoktDecodeException) {
+            throw e
+        } catch (e: Throwable) {
+            throw ProtoktDecodeException(e.message ?: "Malformed protobuf input", e)
+        }
 }

--- a/protokt-runtime-protobufjs/src/jsMain/kotlin/protokt/v1/ProtobufJsReader.kt
+++ b/protokt-runtime-protobufjs/src/jsMain/kotlin/protokt/v1/ProtobufJsReader.kt
@@ -76,13 +76,9 @@ internal class ProtobufJsReader(
             if (reader.pos == endPosition) {
                 0u
             } else {
-                if (reader.pos > endPosition) {
-                    throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-                }
+                protoktCheck(reader.pos <= endPosition) { WireFormat.TRUNCATED_MESSAGE }
                 val tag = readInt32()
-                if (tag ushr 3 == 0) {
-                    throw ProtoktDecodeException("Invalid tag: $tag")
-                }
+                protoktCheck(tag ushr 3 != 0) { "Invalid tag: $tag" }
                 tag.toUInt()
             }
         return _lastTag
@@ -104,25 +100,19 @@ internal class ProtobufJsReader(
             while (reader.pos < packedEndPosition) {
                 acc(this)
             }
-            if (reader.pos != packedEndPosition) {
-                throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-            }
+            protoktCheck(reader.pos == packedEndPosition) { WireFormat.TRUNCATED_MESSAGE }
         }
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
-            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
-        }
+        protoktCheck(messageDepth < WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
         messageDepth++
         try {
             val oldEndPosition = endPosition
             endPosition = checkedEndPosition(readInt32())
             try {
                 val result = m.deserialize(this)
-                if (reader.pos != endPosition) {
-                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
-                }
+                protoktRequire(reader.pos == endPosition) { WireFormat.MESSAGE_NOT_FULLY_CONSUMED }
                 return result
             } finally {
                 endPosition = oldEndPosition
@@ -133,27 +123,12 @@ internal class ProtobufJsReader(
     }
 
     private fun checkAvailable(size: Int) {
-        if (size > endPosition - reader.pos) {
-            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-        }
+        protoktCheck(size <= endPosition - reader.pos) { WireFormat.TRUNCATED_MESSAGE }
     }
 
     private fun checkedEndPosition(length: Int): Int {
-        if (length < 0) {
-            throw ProtoktDecodeException(WireFormat.NEGATIVE_SIZE)
-        }
-        if (length > endPosition - reader.pos) {
-            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-        }
+        protoktCheck(length >= 0) { WireFormat.NEGATIVE_SIZE }
+        protoktCheck(length <= endPosition - reader.pos) { WireFormat.TRUNCATED_MESSAGE }
         return reader.pos + length
     }
-
-    private inline fun <T> decode(block: () -> T): T =
-        try {
-            block()
-        } catch (e: ProtoktDecodeException) {
-            throw e
-        } catch (e: Throwable) {
-            throw ProtoktDecodeException(e.message ?: "Malformed protobuf input", e)
-        }
 }

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -295,6 +295,11 @@ public abstract interface class protokt/v1/Message {
 public abstract interface annotation class protokt/v1/OnlyForUseByGeneratedProtoCode : java/lang/annotation/Annotation {
 }
 
+public final class protokt/v1/ProtoktDecodeException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
 public abstract interface class protokt/v1/Reader {
 	public abstract fun getLastTag-pVg5ArA ()I
 	public fun readBool ()Z

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
@@ -83,7 +83,7 @@ object ExtensionCodecs {
 
     val string: ExtensionCodec<String> =
         LengthDelimitedCodec(
-            { it.value.value.decodeToString() },
+            { decodeUtf8(it.value.value) },
             { LengthDelimitedVal(Bytes(it.encodeToByteArray())) }
         )
 

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktDecodeException.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktDecodeException.kt
@@ -23,3 +23,26 @@ class ProtoktDecodeException : RuntimeException {
 
     constructor(message: String, cause: Throwable) : super(message, cause)
 }
+
+internal inline fun protoktCheck(value: Boolean, lazyMessage: () -> Any) {
+    if (!value) {
+        throw ProtoktDecodeException(lazyMessage().toString())
+    }
+}
+
+internal inline fun protoktRequire(value: Boolean, lazyMessage: () -> Any) {
+    if (!value) {
+        throw ProtoktDecodeException(lazyMessage().toString())
+    }
+}
+
+internal inline fun <T> decode(block: () -> T): T =
+    try {
+        block()
+    } catch (e: ProtoktDecodeException) {
+        throw e
+    } catch (e: Throwable) {
+        val message = e.message ?: "Malformed protobuf input"
+        val normalizedMessage = if (message.contains("malformed varint", ignoreCase = true)) WireFormat.MALFORMED_VARINT else message
+        throw ProtoktDecodeException(normalizedMessage, e)
+    }

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktDecodeException.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktDecodeException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+/**
+ * Thrown when protobuf input is malformed or cannot be fully decoded.
+ */
+class ProtoktDecodeException : RuntimeException {
+    constructor(message: String) : super(message)
+
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktReader.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktReader.kt
@@ -47,6 +47,7 @@ internal class ProtoktReader(
     override fun readString(): String {
         val length = readRawVarint32()
         checkLength(length)
+        validateUtf8(buf, pos, pos + length)
         val s = buf.decodeToString(pos, pos + length)
         pos += length
         return s

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktReader.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktReader.kt
@@ -32,9 +32,7 @@ internal class ProtoktReader(
             return 0u
         }
         _lastTag = readRawVarint32()
-        if (_lastTag == 0 || WireFormat.getTagFieldNumber(_lastTag) == 0) {
-            throw ProtoktDecodeException("Invalid tag: $_lastTag")
-        }
+        protoktCheck(_lastTag != 0 && WireFormat.getTagFieldNumber(_lastTag) != 0) { "Invalid tag: $_lastTag" }
         return _lastTag.toUInt()
     }
 
@@ -90,9 +88,7 @@ internal class ProtoktReader(
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
-            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
-        }
+        protoktCheck(messageDepth < WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
         messageDepth++
         try {
             val length = readRawVarint32()
@@ -101,9 +97,7 @@ internal class ProtoktReader(
             limit = pos + length
             try {
                 val result = m.deserialize(this)
-                if (pos != limit) {
-                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
-                }
+                protoktRequire(pos == limit) { WireFormat.MESSAGE_NOT_FULLY_CONSUMED }
                 return result
             } finally {
                 limit = oldLimit
@@ -114,18 +108,12 @@ internal class ProtoktReader(
     }
 
     private fun checkLength(length: Int) {
-        if (length < 0) {
-            throw ProtoktDecodeException(WireFormat.NEGATIVE_SIZE)
-        }
-        if (length > limit - pos) {
-            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-        }
+        protoktCheck(length >= 0) { WireFormat.NEGATIVE_SIZE }
+        protoktCheck(length <= limit - pos) { WireFormat.TRUNCATED_MESSAGE }
     }
 
     private fun checkAvailable(size: Int) {
-        if (limit - pos < size) {
-            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
-        }
+        protoktCheck(limit - pos >= size) { WireFormat.TRUNCATED_MESSAGE }
     }
 
     private fun readRawVarint32(): Int {

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktReader.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ProtoktReader.kt
@@ -33,7 +33,7 @@ internal class ProtoktReader(
         }
         _lastTag = readRawVarint32()
         if (_lastTag == 0 || WireFormat.getTagFieldNumber(_lastTag) == 0) {
-            throw IllegalStateException("Invalid tag: $_lastTag")
+            throw ProtoktDecodeException("Invalid tag: $_lastTag")
         }
         return _lastTag.toUInt()
     }
@@ -79,36 +79,53 @@ internal class ProtoktReader(
             checkLength(length)
             val oldLimit = limit
             limit = pos + length
-            while (pos < limit) {
-                acc(this)
+            try {
+                while (pos < limit) {
+                    acc(this)
+                }
+            } finally {
+                limit = oldLimit
             }
-            limit = oldLimit
         }
     }
 
     override fun <T : Message> readMessage(m: Deserializer<T>): T {
-        check(++messageDepth <= WireFormat.DEFAULT_RECURSION_LIMIT) { WireFormat.TOO_MANY_LEVELS_OF_NESTING }
+        if (messageDepth >= WireFormat.DEFAULT_RECURSION_LIMIT) {
+            throw ProtoktDecodeException(WireFormat.TOO_MANY_LEVELS_OF_NESTING)
+        }
+        messageDepth++
         try {
             val length = readRawVarint32()
             checkLength(length)
             val oldLimit = limit
             limit = pos + length
-            val res = m.deserialize(this)
-            require(pos == limit) { "Message not fully consumed: pos=$pos, limit=$limit" }
-            limit = oldLimit
-            return res
+            try {
+                val result = m.deserialize(this)
+                if (pos != limit) {
+                    throw ProtoktDecodeException(WireFormat.MESSAGE_NOT_FULLY_CONSUMED)
+                }
+                return result
+            } finally {
+                limit = oldLimit
+            }
         } finally {
             messageDepth--
         }
     }
 
     private fun checkLength(length: Int) {
-        check(length >= 0) { WireFormat.NEGATIVE_SIZE }
-        check(length <= limit - pos) { WireFormat.TRUNCATED_MESSAGE }
+        if (length < 0) {
+            throw ProtoktDecodeException(WireFormat.NEGATIVE_SIZE)
+        }
+        if (length > limit - pos) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
     }
 
     private fun checkAvailable(size: Int) {
-        check(limit - pos >= size) { WireFormat.TRUNCATED_MESSAGE }
+        if (limit - pos < size) {
+            throw ProtoktDecodeException(WireFormat.TRUNCATED_MESSAGE)
+        }
     }
 
     private fun readRawVarint32(): Int {
@@ -124,13 +141,14 @@ internal class ProtoktReader(
             shift += 7
         }
         // discard upper bits for oversized varints
-        while (true) {
+        repeat(5) {
             checkAvailable(1)
             val b = buf[pos++].toInt()
             if (b and 0x80 == 0) {
                 return result
             }
         }
+        throw ProtoktDecodeException(WireFormat.MALFORMED_VARINT)
     }
 
     private fun readRawVarint64(): ULong {
@@ -145,7 +163,7 @@ internal class ProtoktReader(
             }
             shift += 7
         }
-        throw IllegalStateException("Varint too long")
+        throw ProtoktDecodeException(WireFormat.MALFORMED_VARINT)
     }
 
     private fun readFixed32Bits(): UInt {

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Reader.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Reader.kt
@@ -71,13 +71,13 @@ interface Reader {
                 UnknownField.fixed32(fieldNumber, readFixed32())
 
             WireFormat.WIRETYPE_START_GROUP ->
-                throw UnsupportedOperationException("WIRETYPE_START_GROUP")
+                throw ProtoktDecodeException("Groups are not supported")
 
             WireFormat.WIRETYPE_END_GROUP ->
-                throw UnsupportedOperationException("WIRETYPE_END_GROUP")
+                throw ProtoktDecodeException("Groups are not supported")
 
             else ->
-                error("Unrecognized wire type")
+                throw ProtoktDecodeException("Invalid wire type: ${WireFormat.getTagWireType(tag)}")
         }
     }
 

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/StringConverter.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/StringConverter.kt
@@ -21,7 +21,7 @@ object StringConverter : Converter<Bytes, String> {
     override val wrapped = Bytes::class
 
     override fun wrap(unwrapped: Bytes): String =
-        unwrapped.value.decodeToString()
+        decodeUtf8(unwrapped.value)
 
     override fun unwrap(wrapped: String): Bytes =
         Bytes(wrapped.encodeToByteArray())

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Utf8.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Utf8.kt
@@ -16,7 +16,7 @@
 package protokt.v1
 
 /**
- * Validates that [bytes] is well-formed UTF-8. Throws [IllegalArgumentException]
+ * Validates that [bytes] is well-formed UTF-8. Throws [ProtoktDecodeException]
  * on invalid input.
  *
  * Modeled after com.google.protobuf.Utf8.SafeProcessor: fast-path ASCII
@@ -24,24 +24,27 @@ package protokt.v1
  * computation), continuation-byte validation via unsigned comparison.
  */
 internal fun validateUtf8(bytes: ByteArray) {
-    val limit = bytes.size
-    var i = 0
+    validateUtf8(bytes, 0, bytes.size)
+}
+
+internal fun validateUtf8(bytes: ByteArray, startIndex: Int, endIndex: Int) {
+    var i = startIndex
 
     // Fast-path: scan ASCII bytes without per-byte branching into the
     // multi-byte `when`.  Most proto string payloads are predominantly ASCII.
-    while (i < limit && bytes[i] >= 0) {
+    while (i < endIndex && bytes[i] >= 0) {
         i++
     }
 
     // Now handle multi-byte sequences.
-    while (i < limit) {
+    while (i < endIndex) {
         val b0 = bytes[i]
 
         if (b0 >= 0) {
             // 0xxxxxxx – ASCII
             i++
             // Resume tight ASCII scan
-            while (i < limit && bytes[i] >= 0) {
+            while (i < endIndex && bytes[i] >= 0) {
                 i++
             }
             continue
@@ -56,14 +59,14 @@ internal fun validateUtf8(bytes: ByteArray) {
             // Lead byte 0xC2..0xDF (< 0xC2 means overlong or continuation)
             u0 < 0xE0 -> {
                 if (u0 < 0xC2) invalid()
-                if (i + 1 >= limit) invalid()
+                if (i + 1 >= endIndex) invalid()
                 if (bytes[i + 1].toInt() and 0xC0 != 0x80) invalid()
                 i += 2
             }
 
             // Three-byte form: 1110xxxx 10xxxxxx 10xxxxxx
             u0 < 0xF0 -> {
-                if (i + 2 >= limit) invalid()
+                if (i + 2 >= endIndex) invalid()
                 val b1 = bytes[i + 1]
                 val b2 = bytes[i + 2]
                 // Continuation byte check
@@ -77,7 +80,7 @@ internal fun validateUtf8(bytes: ByteArray) {
 
             // Four-byte form: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
             u0 < 0xF5 -> {
-                if (i + 3 >= limit) invalid()
+                if (i + 3 >= endIndex) invalid()
                 val b1 = bytes[i + 1]
                 val b2 = bytes[i + 2]
                 val b3 = bytes[i + 3]
@@ -98,7 +101,12 @@ internal fun validateUtf8(bytes: ByteArray) {
 }
 
 private fun invalid(): Nothing =
-    throw IllegalArgumentException("Invalid UTF-8")
+    throw ProtoktDecodeException(WireFormat.INVALID_UTF8)
+
+internal fun decodeUtf8(bytes: ByteArray): String {
+    validateUtf8(bytes)
+    return bytes.decodeToString()
+}
 
 /**
  * Returns the number of bytes needed to encode [s] as UTF-8,

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/WireFormat.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/WireFormat.kt
@@ -31,6 +31,12 @@ internal object WireFormat {
     const val TOO_MANY_LEVELS_OF_NESTING =
         "Protocol message had too many levels of nesting"
 
+    const val MALFORMED_VARINT =
+        "Protocol message contained a malformed varint."
+
+    const val MESSAGE_NOT_FULLY_CONSUMED =
+        "Protocol message was not fully consumed."
+
     const val WIRETYPE_VARINT = 0
     const val WIRETYPE_FIXED64 = 1
     const val WIRETYPE_LENGTH_DELIMITED = 2

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/WireFormat.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/WireFormat.kt
@@ -22,6 +22,7 @@ internal object WireFormat {
     // error messages inspired by protobuf-java's InvalidProtocolBufferException
     const val NEGATIVE_SIZE =
         "Protocol message had an embedded string or message which claimed to have negative size."
+    const val INVALID_UTF8 = "Protocol message had invalid UTF-8."
 
     const val TRUNCATED_MESSAGE =
         "While parsing a protocol message, the input ended unexpectedly " +

--- a/protokt-runtime/src/commonTest/kotlin/protokt/v1/Utf8ValidationTest.kt
+++ b/protokt-runtime/src/commonTest/kotlin/protokt/v1/Utf8ValidationTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class Utf8ValidationTest {
+    @Test
+    fun `malformed byte sequences are rejected`() {
+        listOf(
+            byteArrayOf(0xC0.toByte(), 0xAF.toByte()),
+            byteArrayOf(0x80.toByte()),
+            byteArrayOf(0xED.toByte(), 0xA0.toByte(), 0x80.toByte()),
+            byteArrayOf(0xE2.toByte(), 0x82.toByte()),
+            byteArrayOf(0xF4.toByte(), 0x90.toByte(), 0x80.toByte(), 0x80.toByte()),
+            byteArrayOf(0xE2.toByte(), 0x28, 0xA1.toByte()),
+        ).forEach { bytes ->
+            assertFailsWith<ProtoktDecodeException> { decodeUtf8(bytes) }
+        }
+    }
+}

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ExtensionTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ExtensionTest.kt
@@ -17,6 +17,7 @@ package protokt.v1
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class ExtensionTest {
     @Test
@@ -103,6 +104,24 @@ class ExtensionTest {
     fun `decode singular string`() {
         val field = fieldOf(LengthDelimitedVal(Bytes("hello".encodeToByteArray())))
         assertThat(ExtensionCodecs.string.decodeSingular(field)).isEqualTo("hello")
+    }
+
+    @Test
+    fun `decode singular string rejects invalid UTF-8`() {
+        val field = fieldOf(LengthDelimitedVal(Bytes(byteArrayOf(0xC0.toByte(), 0xAF.toByte()))))
+
+        val exception = assertThrows<ProtoktDecodeException> { ExtensionCodecs.string.decodeSingular(field) }
+
+        assertThat(exception).hasMessageThat().isEqualTo(WireFormat.INVALID_UTF8)
+    }
+
+    @Test
+    fun `string converter rejects invalid UTF-8`() {
+        val exception = assertThrows<ProtoktDecodeException> {
+            StringConverter.wrap(Bytes(byteArrayOf(0xED.toByte(), 0xA0.toByte(), 0x80.toByte())))
+        }
+
+        assertThat(exception).hasMessageThat().isEqualTo(WireFormat.INVALID_UTF8)
     }
 
     @Test

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
@@ -16,7 +16,9 @@
 package protokt.v1
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.InvalidProtocolBufferException
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -61,7 +63,7 @@ class ReaderValidationTest {
             val bytes = byteArrayOf(0x0a) + NEGATIVE_ONE_VARINT
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readString() }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readString() }
             assertThat(ex).hasMessageThat().endsWith("an embedded string or message which claimed to have negative size.")
         }
 
@@ -71,7 +73,7 @@ class ReaderValidationTest {
             val bytes = byteArrayOf(0x0a) + NEGATIVE_ONE_VARINT
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readBytes() }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readBytes() }
             assertThat(ex).hasMessageThat().endsWith("an embedded string or message which claimed to have negative size.")
         }
 
@@ -81,7 +83,7 @@ class ReaderValidationTest {
             val bytes = byteArrayOf(0x0a) + NEGATIVE_ONE_VARINT
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readMessage(EmptyMessage) }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readMessage(EmptyMessage) }
             assertThat(ex).hasMessageThat().endsWith("an embedded string or message which claimed to have negative size.")
         }
     }
@@ -102,7 +104,7 @@ class ReaderValidationTest {
             )
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readMessage(Fixed32FieldMessage) }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readMessage(Fixed32FieldMessage) }
             assertThat(ex).hasMessageThat().isEqualTo(WireFormat.TRUNCATED_MESSAGE)
         }
 
@@ -118,7 +120,7 @@ class ReaderValidationTest {
             )
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readMessage(Fixed64FieldMessage) }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readMessage(Fixed64FieldMessage) }
             assertThat(ex).hasMessageThat().isEqualTo(WireFormat.TRUNCATED_MESSAGE)
         }
 
@@ -133,7 +135,7 @@ class ReaderValidationTest {
             )
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readMessage(VarintFieldMessage) }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readMessage(VarintFieldMessage) }
             assertThat(ex).hasMessageThat().isEqualTo(WireFormat.TRUNCATED_MESSAGE)
         }
     }
@@ -146,7 +148,7 @@ class ReaderValidationTest {
             val bytes = buildDeeplyNestedMessage(200)
             val reader = codec.reader(bytes)
             val ex =
-                assertThrows<Exception> {
+                assertThrows<ProtoktDecodeException> {
                     reader.readTag()
                     reader.readMessage(RecursiveMessage)
                 }
@@ -179,7 +181,7 @@ class ReaderValidationTest {
             )
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readMessage(NestedLenDelimitedMessage) }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readMessage(NestedLenDelimitedMessage) }
             assertThat(ex).hasMessageThat().isEqualTo(WireFormat.TRUNCATED_MESSAGE)
         }
     }
@@ -192,7 +194,7 @@ class ReaderValidationTest {
             val bytes = byteArrayOf(0x0a) + INT_MAX_VARINT + byteArrayOf(0x00, 0x00)
             val reader = codec.reader(bytes)
             reader.readTag()
-            assertThrows<Exception> { reader.readMessage(EmptyMessage) }
+            assertThrows<ProtoktDecodeException> { reader.readMessage(EmptyMessage) }
         }
 
         @ParameterizedTest
@@ -201,8 +203,88 @@ class ReaderValidationTest {
             val bytes = byteArrayOf(0x0a) + INT_MAX_VARINT + byteArrayOf(0x00)
             val reader = codec.reader(bytes)
             reader.readTag()
-            val ex = assertThrows<Exception> { reader.readString() }
+            val ex = assertThrows<ProtoktDecodeException> { reader.readString() }
             assertThat(ex).hasMessageThat().isEqualTo(WireFormat.TRUNCATED_MESSAGE)
+        }
+    }
+
+    @Nested
+    inner class MalformedWireData {
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `invalid tag`(codec: Codec) {
+            assertThrows<ProtoktDecodeException> {
+                codec.reader(byteArrayOf(0x00)).readTag()
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `invalid wire type`(codec: Codec) {
+            val reader = codec.reader(byteArrayOf(0x0e))
+            reader.readTag()
+
+            assertThrows<ProtoktDecodeException> {
+                reader.readUnknown()
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `overlong varint`(codec: Codec) {
+            val reader = codec.reader(byteArrayOf(0x08) + ByteArray(11) { 0x80.toByte() })
+            reader.readTag()
+
+            val exception =
+                assertThrows<ProtoktDecodeException> {
+                    reader.readUInt64()
+                }
+            assertThat(exception).hasMessageThat().isEqualTo(WireFormat.MALFORMED_VARINT)
+        }
+
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `truncated tag`(codec: Codec) {
+            assertThrows<ProtoktDecodeException> {
+                codec.reader(byteArrayOf(0x80.toByte())).readTag()
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `group wire type`(codec: Codec) {
+            val reader = codec.reader(byteArrayOf(0x0b))
+            reader.readTag()
+
+            assertThrows<ProtoktDecodeException> {
+                reader.readUnknown()
+            }
+        }
+
+        @Test
+        fun `protobuf-java cause retained`() {
+            val reader = loadCodec("protokt.v1.ProtobufJavaCodec").reader(byteArrayOf(0x0a, 0x02, 0x01))
+            reader.readTag()
+
+            val exception = assertThrows<ProtoktDecodeException> { reader.readBytes() }
+            assertThat(exception).hasCauseThat().isInstanceOf(InvalidProtocolBufferException::class.java)
+        }
+    }
+
+    @Nested
+    inner class CallbackFailures {
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `application exception is not wrapped and reader state is restored`(codec: Codec) {
+            val reader = codec.reader(byteArrayOf(0x0a, 0x00, 0x10, 0x01))
+            reader.readTag()
+
+            assertThrows<ApplicationDecodeException> {
+                reader.readMessage(ThrowingDeserializer)
+            }
+
+            assertThat(reader.readTag()).isEqualTo(0x10u)
+            assertThat(reader.readUInt64()).isEqualTo(1uL)
         }
     }
 
@@ -225,6 +307,13 @@ class ReaderValidationTest {
         result.add(v.toByte())
         return result.toByteArray()
     }
+}
+
+private class ApplicationDecodeException : RuntimeException()
+
+private object ThrowingDeserializer : AbstractDeserializer<EmptyMessage>() {
+    override fun deserialize(reader: Reader): EmptyMessage =
+        throw ApplicationDecodeException()
 }
 
 @OptIn(OnlyForUseByGeneratedProtoCode::class)

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/ReaderValidationTest.kt
@@ -212,6 +212,45 @@ class ReaderValidationTest {
     inner class MalformedWireData {
         @ParameterizedTest
         @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `invalid UTF-8`(codec: Codec) {
+            val malformedPayloads =
+                listOf(
+                    byteArrayOf(0xC0.toByte(), 0xAF.toByte()),
+                    byteArrayOf(0x80.toByte()),
+                    byteArrayOf(0xED.toByte(), 0xA0.toByte(), 0x80.toByte()),
+                    byteArrayOf(0xE2.toByte(), 0x82.toByte()),
+                    byteArrayOf(0xF4.toByte(), 0x90.toByte(), 0x80.toByte(), 0x80.toByte()),
+                    byteArrayOf(0xE2.toByte(), 0x28, 0xA1.toByte()),
+                )
+
+            malformedPayloads.forEach { payload ->
+                val reader = codec.reader(byteArrayOf(0x0A, payload.size.toByte()) + payload)
+                reader.readTag()
+
+                val exception = assertThrows<ProtoktDecodeException> { reader.readString() }
+                assertThat(exception).hasMessageThat().isEqualTo(WireFormat.INVALID_UTF8)
+
+                val converterReader = codec.reader(byteArrayOf(0x0A, payload.size.toByte()) + payload)
+                converterReader.readTag()
+                val converterException =
+                    assertThrows<ProtoktDecodeException> { StringConverter.readValidatedBytes(converterReader) }
+                assertThat(converterException).hasMessageThat().isEqualTo(WireFormat.INVALID_UTF8)
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
+        fun `valid UTF-8 boundary code points`(codec: Codec) {
+            val value = "\u0000\u007F\u0080\u07FF\u0800\uD7FF\uE000\uFFFF\uD800\uDC00\uDBFF\uDFFF"
+            val payload = value.encodeToByteArray()
+            val reader = codec.reader(byteArrayOf(0x0A, payload.size.toByte()) + payload)
+            reader.readTag()
+
+            assertThat(reader.readString()).isEqualTo(value)
+        }
+
+        @ParameterizedTest
+        @MethodSource("protokt.v1.ReaderValidationTest#codecs")
         fun `invalid tag`(codec: Codec) {
             assertThrows<ProtoktDecodeException> {
                 codec.reader(byteArrayOf(0x00)).readTag()


### PR DESCRIPTION
## Summary

- Reject malformed UTF-8 from every `Reader.readString()` backend with `ProtoktDecodeException`.
- Validate extension strings and direct `StringConverter` inputs through the same byte-level validator.
- Preserve the minimal codec's zero-copy string path by validating its existing buffer range before decoding.
- Cover overlong encodings, isolated continuations, surrogate encodings, truncation, invalid continuations, out-of-range code points, and valid boundary code points.

## Stack

- Depends on #556 for the common decode exception contract.

## Validation

- All five JVM codec implementations pass the malformed and boundary UTF-8 corpus.
- JVM and JS runtime tests pass; native test sources compile.
- All eight JVM and eight JS conformance configurations pass with zero unexpected failures.
- Runtime backend API checks and formatting checks pass.
