### PR TITLE
Separate protobuf-java generated package

### DIFF
--- a/extensions/protokt-extensions-lite/src/extensions-proto/protokt/v1/protokt.proto
+++ b/extensions/protokt-extensions-lite/src/extensions-proto/protokt/v1/protokt.proto
@@ -19,7 +19,7 @@ package protokt.v1;
 
 import "google/protobuf/descriptor.proto";
 
-option java_package = "com.toasttab.protokt.v1";
+option java_package = "protokt.v1.java";
 option java_outer_classname = "ProtoktProtos";
 
 message FileOptions {

--- a/extensions/protokt-extensions-lite/src/main/proto/protokt/v1/inet_socket_address.proto
+++ b/extensions/protokt-extensions-lite/src/main/proto/protokt/v1/inet_socket_address.proto
@@ -19,7 +19,7 @@ package protokt.v1;
 
 import "protokt/v1/protokt.proto";
 
-option java_package = "com.toasttab.protokt.v1";
+option java_package = "protokt.v1.java";
 option java_outer_classname = "InetSocketAddressProto";
 option (protokt.v1.file).file_descriptor_object_name = "InetSocketAddressProto";
 

--- a/protokt-reflect/api/protokt-reflect.api
+++ b/protokt-reflect/api/protokt-reflect.api
@@ -1,709 +1,3 @@
-public final class com/toasttab/protokt/v1/ProtoktProtos {
-	public static final field CLASS_FIELD_NUMBER I
-	public static final field ENUM_FIELD_NUMBER I
-	public static final field ENUM_VALUE_FIELD_NUMBER I
-	public static final field FILE_FIELD_NUMBER I
-	public static final field METHOD_FIELD_NUMBER I
-	public static final field ONEOF_FIELD_NUMBER I
-	public static final field PROPERTY_FIELD_NUMBER I
-	public static final field SERVICE_FIELD_NUMBER I
-	public static final field class_ Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field enumValue Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field enum_ Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field file Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field method Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field oneof Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field property Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static final field service Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
-	public static fun getDescriptor ()Lcom/google/protobuf/Descriptors$FileDescriptor;
-	public static fun registerAllExtensions (Lcom/google/protobuf/ExtensionRegistry;)V
-	public static fun registerAllExtensions (Lcom/google/protobuf/ExtensionRegistryLite;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$EnumOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$EnumOptionsOrBuilder {
-	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$EnumOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$EnumOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getDeprecationMessage ()Ljava/lang/String;
-	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$EnumValueOptionsOrBuilder {
-	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$EnumValueOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$EnumValueOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$EnumValueOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getDeprecationMessage ()Ljava/lang/String;
-	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$FieldOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$FieldOptionsOrBuilder {
-	public static final field BYTES_SLICE_FIELD_NUMBER I
-	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
-	public static final field GENERATE_NON_NULL_ACCESSOR_FIELD_NUMBER I
-	public static final field KEY_WRAP_FIELD_NUMBER I
-	public static final field VALUE_WRAP_FIELD_NUMBER I
-	public static final field WRAP_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getBytesSlice ()Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getGenerateNonNullAccessor ()Z
-	public fun getKeyWrap ()Ljava/lang/String;
-	public fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun getValueWrap ()Ljava/lang/String;
-	public fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
-	public fun getWrap ()Ljava/lang/String;
-	public fun getWrapBytes ()Lcom/google/protobuf/ByteString;
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$FieldOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun clearBytesSlice ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun clearGenerateNonNullAccessor ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun clearKeyWrap ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun clearValueWrap ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun clearWrap ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun getBytesSlice ()Z
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getGenerateNonNullAccessor ()Z
-	public fun getKeyWrap ()Ljava/lang/String;
-	public fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
-	public fun getValueWrap ()Ljava/lang/String;
-	public fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
-	public fun getWrap ()Ljava/lang/String;
-	public fun getWrapBytes ()Lcom/google/protobuf/ByteString;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setBytesSlice (Z)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setGenerateNonNullAccessor (Z)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setKeyWrap (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setKeyWrapBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setValueWrap (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setValueWrapBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setWrap (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-	public fun setWrapBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FieldOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$FieldOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getBytesSlice ()Z
-	public abstract fun getDeprecationMessage ()Ljava/lang/String;
-	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public abstract fun getGenerateNonNullAccessor ()Z
-	public abstract fun getKeyWrap ()Ljava/lang/String;
-	public abstract fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
-	public abstract fun getValueWrap ()Ljava/lang/String;
-	public abstract fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
-	public abstract fun getWrap ()Ljava/lang/String;
-	public abstract fun getWrapBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$FileOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$FileOptionsOrBuilder {
-	public static final field FILE_DESCRIPTOR_OBJECT_NAME_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$FileOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public fun clearFileDescriptorObjectName ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public fun setFileDescriptorObjectName (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-	public fun setFileDescriptorObjectNameBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$FileOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$FileOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getFileDescriptorObjectName ()Ljava/lang/String;
-	public abstract fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$MessageOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$MessageOptionsOrBuilder {
-	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
-	public static final field IMPLEMENTS_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getImplements ()Ljava/lang/String;
-	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$MessageOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun clearImplements ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getImplements ()Ljava/lang/String;
-	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun setImplements (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$MessageOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$MessageOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getDeprecationMessage ()Ljava/lang/String;
-	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public abstract fun getImplements ()Ljava/lang/String;
-	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$MethodOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$MethodOptionsOrBuilder {
-	public static final field REQUEST_MARSHALLER_FIELD_NUMBER I
-	public static final field RESPONSE_MARSHALLER_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getRequestMarshaller ()Ljava/lang/String;
-	public fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
-	public fun getResponseMarshaller ()Ljava/lang/String;
-	public fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$MethodOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun clearRequestMarshaller ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun clearResponseMarshaller ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getRequestMarshaller ()Ljava/lang/String;
-	public fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
-	public fun getResponseMarshaller ()Ljava/lang/String;
-	public fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun setRequestMarshaller (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun setRequestMarshallerBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun setResponseMarshaller (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-	public fun setResponseMarshallerBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$MethodOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$MethodOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getRequestMarshaller ()Ljava/lang/String;
-	public abstract fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
-	public abstract fun getResponseMarshaller ()Ljava/lang/String;
-	public abstract fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$OneofOptionsOrBuilder {
-	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
-	public static final field GENERATE_NON_NULL_ACCESSOR_FIELD_NUMBER I
-	public static final field IMPLEMENTS_FIELD_NUMBER I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getGenerateNonNullAccessor ()Z
-	public fun getImplements ()Ljava/lang/String;
-	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$OneofOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun clearDeprecationMessage ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun clearGenerateNonNullAccessor ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun clearImplements ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;
-	public fun getDeprecationMessage ()Ljava/lang/String;
-	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getGenerateNonNullAccessor ()Z
-	public fun getImplements ()Ljava/lang/String;
-	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun setDeprecationMessage (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun setGenerateNonNullAccessor (Z)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun setImplements (Ljava/lang/String;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$OneofOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$OneofOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-	public abstract fun getDeprecationMessage ()Ljava/lang/String;
-	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
-	public abstract fun getGenerateNonNullAccessor ()Z
-	public abstract fun getImplements ()Ljava/lang/String;
-	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$ServiceOptions : com/google/protobuf/GeneratedMessage, com/toasttab/protokt/v1/ProtoktProtos$ServiceOptionsOrBuilder {
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun getDefaultInstance ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getParserForType ()Lcom/google/protobuf/Parser;
-	public fun getSerializedSize ()I
-	public fun hashCode ()I
-	public final fun isInitialized ()Z
-	public static fun newBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public static fun newBuilder (Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun newBuilderForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Ljava/io/InputStream;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom ([B)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static fun parser ()Lcom/google/protobuf/Parser;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun toBuilder ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
-}
-
-public final class com/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, com/toasttab/protokt/v1/ProtoktProtos$ServiceOptionsOrBuilder {
-	public synthetic fun build ()Lcom/google/protobuf/Message;
-	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
-	public fun build ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
-	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
-	public fun buildPartial ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
-	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
-	public fun clear ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
-	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
-	public fun getDefaultInstanceForType ()Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;
-	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
-	public final fun isInitialized ()Z
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
-	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
-	public fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-	public fun mergeFrom (Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions;)Lcom/toasttab/protokt/v1/ProtoktProtos$ServiceOptions$Builder;
-}
-
-public abstract interface class com/toasttab/protokt/v1/ProtoktProtos$ServiceOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
-}
-
 public final class protokt/v1/EnumOptions : protokt/v1/AbstractMessage {
 	public static final field Deserializer Lprotokt/v1/EnumOptions$Deserializer;
 	public synthetic fun <init> (Lprotokt/v1/LazyReference;Lprotokt/v1/UnknownFieldSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1036,6 +330,712 @@ public final class protokt/v1/google/protobuf/Messages {
 public final class protokt/v1/google/protobuf/RuntimeContext {
 	public fun <init> (Ljava/lang/Iterable;)V
 	public final fun convertValue (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class protokt/v1/java/ProtoktProtos {
+	public static final field CLASS_FIELD_NUMBER I
+	public static final field ENUM_FIELD_NUMBER I
+	public static final field ENUM_VALUE_FIELD_NUMBER I
+	public static final field FILE_FIELD_NUMBER I
+	public static final field METHOD_FIELD_NUMBER I
+	public static final field ONEOF_FIELD_NUMBER I
+	public static final field PROPERTY_FIELD_NUMBER I
+	public static final field SERVICE_FIELD_NUMBER I
+	public static final field class_ Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field enumValue Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field enum_ Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field file Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field method Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field oneof Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field property Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static final field service Lcom/google/protobuf/GeneratedMessage$GeneratedExtension;
+	public static fun getDescriptor ()Lcom/google/protobuf/Descriptors$FileDescriptor;
+	public static fun registerAllExtensions (Lcom/google/protobuf/ExtensionRegistry;)V
+	public static fun registerAllExtensions (Lcom/google/protobuf/ExtensionRegistryLite;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$EnumOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$EnumOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$EnumOptions;)Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$EnumOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$EnumOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public fun clearDeprecationMessage ()Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$EnumOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$EnumOptions;)Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$EnumOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$EnumOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$EnumValueOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$EnumValueOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$EnumValueOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$EnumValueOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public fun clearDeprecationMessage ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$EnumValueOptions;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$EnumValueOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$EnumValueOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$FieldOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$FieldOptionsOrBuilder {
+	public static final field BYTES_SLICE_FIELD_NUMBER I
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field GENERATE_NON_NULL_ACCESSOR_FIELD_NUMBER I
+	public static final field KEY_WRAP_FIELD_NUMBER I
+	public static final field VALUE_WRAP_FIELD_NUMBER I
+	public static final field WRAP_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBytesSlice ()Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getGenerateNonNullAccessor ()Z
+	public fun getKeyWrap ()Ljava/lang/String;
+	public fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun getValueWrap ()Ljava/lang/String;
+	public fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getWrap ()Ljava/lang/String;
+	public fun getWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$FieldOptions;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$FieldOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$FieldOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun clearBytesSlice ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun clearDeprecationMessage ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun clearGenerateNonNullAccessor ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun clearKeyWrap ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun clearValueWrap ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun clearWrap ()Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun getBytesSlice ()Z
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$FieldOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getGenerateNonNullAccessor ()Z
+	public fun getKeyWrap ()Ljava/lang/String;
+	public fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getValueWrap ()Ljava/lang/String;
+	public fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
+	public fun getWrap ()Ljava/lang/String;
+	public fun getWrapBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$FieldOptions;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setBytesSlice (Z)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setGenerateNonNullAccessor (Z)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setKeyWrap (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setKeyWrapBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setValueWrap (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setValueWrapBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setWrap (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+	public fun setWrapBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FieldOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$FieldOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getBytesSlice ()Z
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getGenerateNonNullAccessor ()Z
+	public abstract fun getKeyWrap ()Ljava/lang/String;
+	public abstract fun getKeyWrapBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getValueWrap ()Ljava/lang/String;
+	public abstract fun getValueWrapBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getWrap ()Ljava/lang/String;
+	public abstract fun getWrapBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$FileOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$FileOptionsOrBuilder {
+	public static final field FILE_DESCRIPTOR_OBJECT_NAME_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$FileOptions;)Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$FileOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$FileOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public fun clearFileDescriptorObjectName ()Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$FileOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$FileOptions;)Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public fun setFileDescriptorObjectName (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+	public fun setFileDescriptorObjectNameBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$FileOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$FileOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getFileDescriptorObjectName ()Ljava/lang/String;
+	public abstract fun getFileDescriptorObjectNameBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$MessageOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$MessageOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field IMPLEMENTS_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$MessageOptions;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$MessageOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$MessageOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun clearDeprecationMessage ()Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun clearImplements ()Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$MessageOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$MessageOptions;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun setImplements (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$MessageOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$MessageOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getImplements ()Ljava/lang/String;
+	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$MethodOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$MethodOptionsOrBuilder {
+	public static final field REQUEST_MARSHALLER_FIELD_NUMBER I
+	public static final field RESPONSE_MARSHALLER_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getRequestMarshaller ()Ljava/lang/String;
+	public fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public fun getResponseMarshaller ()Ljava/lang/String;
+	public fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$MethodOptions;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$MethodOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$MethodOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun clearRequestMarshaller ()Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun clearResponseMarshaller ()Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$MethodOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getRequestMarshaller ()Ljava/lang/String;
+	public fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public fun getResponseMarshaller ()Ljava/lang/String;
+	public fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$MethodOptions;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun setRequestMarshaller (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun setRequestMarshallerBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun setResponseMarshaller (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+	public fun setResponseMarshallerBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$MethodOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$MethodOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getRequestMarshaller ()Ljava/lang/String;
+	public abstract fun getRequestMarshallerBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getResponseMarshaller ()Ljava/lang/String;
+	public abstract fun getResponseMarshallerBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$OneofOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$OneofOptionsOrBuilder {
+	public static final field DEPRECATION_MESSAGE_FIELD_NUMBER I
+	public static final field GENERATE_NON_NULL_ACCESSOR_FIELD_NUMBER I
+	public static final field IMPLEMENTS_FIELD_NUMBER I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getGenerateNonNullAccessor ()Z
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$OneofOptions;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$OneofOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$OneofOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun clearDeprecationMessage ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun clearGenerateNonNullAccessor ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun clearImplements ()Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$OneofOptions;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getGenerateNonNullAccessor ()Z
+	public fun getImplements ()Ljava/lang/String;
+	public fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$OneofOptions;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun setDeprecationMessage (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun setDeprecationMessageBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun setGenerateNonNullAccessor (Z)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun setImplements (Ljava/lang/String;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+	public fun setImplementsBytes (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$OneofOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$OneofOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+	public abstract fun getDeprecationMessageBytes ()Lcom/google/protobuf/ByteString;
+	public abstract fun getGenerateNonNullAccessor ()Z
+	public abstract fun getImplements ()Ljava/lang/String;
+	public abstract fun getImplementsBytes ()Lcom/google/protobuf/ByteString;
+}
+
+public final class protokt/v1/java/ProtoktProtos$ServiceOptions : com/google/protobuf/GeneratedMessage, protokt/v1/java/ProtoktProtos$ServiceOptionsOrBuilder {
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun getDefaultInstance ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getParserForType ()Lcom/google/protobuf/Parser;
+	public fun getSerializedSize ()I
+	public fun hashCode ()I
+	public final fun isInitialized ()Z
+	public static fun newBuilder ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public static fun newBuilder (Lprotokt/v1/java/ProtoktProtos$ServiceOptions;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun newBuilderForType ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun newBuilderForType ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseDelimitedFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/ByteString;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Ljava/io/InputStream;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Ljava/io/InputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom (Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom ([B)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parseFrom ([BLcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static fun parser ()Lcom/google/protobuf/Parser;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun toBuilder ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun toBuilder ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public fun writeTo (Lcom/google/protobuf/CodedOutputStream;)V
+}
+
+public final class protokt/v1/java/ProtoktProtos$ServiceOptions$Builder : com/google/protobuf/GeneratedMessage$Builder, protokt/v1/java/ProtoktProtos$ServiceOptionsOrBuilder {
+	public synthetic fun build ()Lcom/google/protobuf/Message;
+	public synthetic fun build ()Lcom/google/protobuf/MessageLite;
+	public fun build ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/Message;
+	public synthetic fun buildPartial ()Lcom/google/protobuf/MessageLite;
+	public fun buildPartial ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public synthetic fun clear ()Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/GeneratedMessage$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/Message$Builder;
+	public synthetic fun clear ()Lcom/google/protobuf/MessageLite$Builder;
+	public fun clear ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/Message;
+	public synthetic fun getDefaultInstanceForType ()Lcom/google/protobuf/MessageLite;
+	public fun getDefaultInstanceForType ()Lprotokt/v1/java/ProtoktProtos$ServiceOptions;
+	public static final fun getDescriptor ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public fun getDescriptorForType ()Lcom/google/protobuf/Descriptors$Descriptor;
+	public final fun isInitialized ()Z
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/AbstractMessageLite$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/Message$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lcom/google/protobuf/MessageLite$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/CodedInputStream;Lcom/google/protobuf/ExtensionRegistryLite;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/AbstractMessage$Builder;
+	public synthetic fun mergeFrom (Lcom/google/protobuf/Message;)Lcom/google/protobuf/Message$Builder;
+	public fun mergeFrom (Lcom/google/protobuf/Message;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+	public fun mergeFrom (Lprotokt/v1/java/ProtoktProtos$ServiceOptions;)Lprotokt/v1/java/ProtoktProtos$ServiceOptions$Builder;
+}
+
+public abstract interface class protokt/v1/java/ProtoktProtos$ServiceOptionsOrBuilder : com/google/protobuf/MessageOrBuilder {
 }
 
 public final class protokt/v1/protokt_file_descriptor {

--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/RuntimeContext.kt
@@ -24,13 +24,13 @@ import com.google.protobuf.UnknownFieldSet
 import com.google.protobuf.UnknownFieldSet.Field
 import com.google.protobuf.UnsafeByteOperations
 import com.google.protobuf.WireFormat
-import com.toasttab.protokt.v1.ProtoktProtos
 import protokt.v1.Beta
 import protokt.v1.Bytes
 import protokt.v1.Converter
 import protokt.v1.Enum
 import protokt.v1.GeneratedMessage
 import protokt.v1.Message
+import protokt.v1.java.ProtoktProtos
 import protokt.v1.reflect.ClassLookup
 import protokt.v1.reflect.FieldType
 import protokt.v1.reflect.WellKnownTypes

--- a/testing/interop/src/test/kotlin/protokt/v1/testing/ExtensionInteropTest.kt
+++ b/testing/interop/src/test/kotlin/protokt/v1/testing/ExtensionInteropTest.kt
@@ -17,13 +17,13 @@ package protokt.v1.testing
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.DescriptorProtos
-import com.toasttab.protokt.v1.ProtoktProtos
 import org.junit.jupiter.api.Test
 import protokt.v1.Extension
 import protokt.v1.ExtensionCodecs
 import protokt.v1.RepeatedExtension
 import protokt.v1.get
 import protokt.v1.google.protobuf.FieldOptions
+import protokt.v1.java.ProtoktProtos
 
 class ExtensionInteropTest {
     private val propertyExt =


### PR DESCRIPTION
## Summary

- Move protobuf-java output for Protokt options from the legacy com.toasttab.protokt.v1 namespace to protokt.v1.java.
- Keep protobuf-java generated types separate from Protokt Kotlin output in protokt.v1.
- Apply the same Java package boundary to the InetSocketAddress extension schema.
- Update reflection and interoperability code to use the new generated package.

## Validation

- Verify the reflect JAR and API dump contain protokt.v1.java.ProtoktProtos and no legacy ProtoktProtos classes.
- Verify protobuf-java field options still deserialize through Protokt extensions.
- Verify full and lite extension artifacts retain their existing Kotlin API.