### PR TITLE
Use lower-camel kRPC method names

### DIFF
--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/GrpcKrpcServiceGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/GrpcKrpcServiceGenerator.kt
@@ -63,7 +63,7 @@ private class GrpcKrpcServiceGenerator(
     }
 
     private fun methodFunction(method: Method): FunSpec {
-        val builder = buildFunSpec(method.name.toString()) {
+        val builder = buildFunSpec(method.name.decapitalized) {
             addModifiers(KModifier.ABSTRACT)
 
             if (!method.serverStreaming) {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ProtoMethodNames.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ProtoMethodNames.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen.generate
+
+import io.grpc.kotlin.generator.protoc.ProtoMethodName
+
+internal val ProtoMethodName.decapitalized
+    get() = toMemberSimpleName().name.replaceFirstChar { it.lowercase() }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
@@ -73,10 +73,7 @@ private class ServiceGenerator(
         toMemberSimpleName().withSuffix("Method")
 
     private val ProtoMethodName.decapitalizedMethod
-        get() = withMethodSuffix().name.decapitalize()
-
-    private val ProtoMethodName.decapitalized
-        get() = toMemberSimpleName().name.decapitalize()
+        get() = withMethodSuffix().name.replaceFirstChar { it.lowercase() }
 
     private fun grpcImplementations(): List<TypeSpec> =
         if (supportedPlugin()) {

--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/AbstractProtoktCodegenTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/AbstractProtoktCodegenTest.kt
@@ -105,9 +105,14 @@ abstract class AbstractProtoktCodegenTest {
 
 private fun buildPluginOptions(extension: ProtoktExtension) =
     "--custom_opt=" +
-        extension::class.declaredMemberProperties
-            .filter { it.returnType.classifier as KClass<*> == Boolean::class }
-            .joinToString(",") { format(it.name) + "=${it.call(extension)}" } +
+        (
+            extension::class.declaredMemberProperties
+                .filter { it.returnType.classifier as KClass<*> == Boolean::class }
+                .map { format(it.name) + "=${it.call(extension)}" } +
+                extension.generate::class.declaredMemberProperties
+                    .filter { it.returnType.classifier as KClass<*> == Boolean::class }
+                    .map { "generate_${format(it.name)}=${it.call(extension.generate)}" }
+            ).joinToString(",") +
         ",${format(KOTLIN_TARGET)}=${KotlinTarget.Jvm}"
 
 private fun format(optionConst: String) =

--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/GrpcKrpcServiceGeneratorTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/GrpcKrpcServiceGeneratorTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import protokt.v1.gradle.ProtoktExtension
+
+class GrpcKrpcServiceGeneratorTest : AbstractProtoktCodegenTest() {
+    @Test
+    fun `method names use lower camel case`() {
+        val extension = ProtoktExtension().apply { generate { grpcKrpcLite() } }
+        val generated =
+            runPlugin("grpc_krpc_method_names.proto", extension)
+                .orFail()
+                .response
+                .fileList
+                .single { it.content.contains("interface NamingService") }
+                .content
+
+        assertThat(generated).contains("fun getURL(")
+        assertThat(generated).contains("fun x(")
+        assertThat(generated).contains("fun ordinaryName(")
+        assertThat(generated).doesNotContain("fun GetURL(")
+        assertThat(generated).doesNotContain("fun X(")
+        assertThat(generated).doesNotContain("fun OrdinaryName(")
+    }
+}

--- a/protokt-codegen/src/test/resources/grpc_krpc_method_names.proto
+++ b/protokt-codegen/src/test/resources/grpc_krpc_method_names.proto
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.v1.codegen.testing;
+
+message Request {}
+
+message Response {}
+
+service NamingService {
+  rpc GetURL(Request) returns (Response);
+  rpc X(Request) returns (Response);
+  rpc OrdinaryName(Request) returns (Response);
+}

--- a/standalone-examples/grpc-krpc/src/commonMain/kotlin/protokt/v1/helloworld/HelloWorld.kt
+++ b/standalone-examples/grpc-krpc/src/commonMain/kotlin/protokt/v1/helloworld/HelloWorld.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.milliseconds
 
 internal class GreeterService : Greeter {
-    override suspend fun SayHello(message: HelloRequest) =
+    override suspend fun sayHello(message: HelloRequest) =
         HelloReply { this.message = "Hello ${message.name}" }
 }
 
@@ -66,7 +66,7 @@ fun runExample() {
                     credentials = plaintext()
                 }
             val greeter = client.withService<Greeter>()
-            val reply = greeter.SayHello(HelloRequest { name = "world" })
+            val reply = greeter.sayHello(HelloRequest { name = "world" })
             println("Received: ${reply.message}")
             server.shutdownNow()
         }

--- a/standalone-examples/grpc-krpc/src/commonTest/kotlin/protokt/v1/helloworld/HelloWorldTest.kt
+++ b/standalone-examples/grpc-krpc/src/commonTest/kotlin/protokt/v1/helloworld/HelloWorldTest.kt
@@ -46,7 +46,7 @@ class HelloWorldTest {
                     }
 
                 val greeter = client.withService<Greeter>()
-                val reply = greeter.SayHello(HelloRequest { name = "test name" })
+                val reply = greeter.sayHello(HelloRequest { name = "test name" })
                 assertEquals("Hello test name", reply.message)
             } finally {
                 server.shutdownNow()

--- a/third-party/proto-google-common-protos-grpc-krpc/api/proto-google-common-protos-grpc-krpc.api
+++ b/third-party/proto-google-common-protos-grpc-krpc/api/proto-google-common-protos-grpc-krpc.api
@@ -1,13 +1,13 @@
 public abstract interface class protokt/v1/google/cloud/location/Locations {
-	public abstract fun GetLocation (Lprotokt/v1/google/cloud/location/GetLocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun ListLocations (Lprotokt/v1/google/cloud/location/ListLocationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getLocation (Lprotokt/v1/google/cloud/location/GetLocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listLocations (Lprotokt/v1/google/cloud/location/ListLocationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class protokt/v1/google/longrunning/Operations {
-	public abstract fun CancelOperation (Lprotokt/v1/google/longrunning/CancelOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun DeleteOperation (Lprotokt/v1/google/longrunning/DeleteOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun GetOperation (Lprotokt/v1/google/longrunning/GetOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun ListOperations (Lprotokt/v1/google/longrunning/ListOperationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun WaitOperation (Lprotokt/v1/google/longrunning/WaitOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancelOperation (Lprotokt/v1/google/longrunning/CancelOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteOperation (Lprotokt/v1/google/longrunning/DeleteOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOperation (Lprotokt/v1/google/longrunning/GetOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listOperations (Lprotokt/v1/google/longrunning/ListOperationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun waitOperation (Lprotokt/v1/google/longrunning/WaitOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 


### PR DESCRIPTION
## Summary

- Generate lower-camel Kotlin member names for kRPC methods, matching the coroutine gRPC generator.
- Preserve acronym tails and handle single-letter method names through the shared protobuf method-name conversion.
- Forward nested generation settings through the codegen test harness so mode-specific fixtures exercise the requested generator.

## Acceptance criteria

- `GetURL`, `X`, and `OrdinaryName` generate as `getURL`, `x`, and `ordinaryName`.
- kRPC interfaces do not expose UpperCamelCase RPC members.