### PR TITLE
Use caller-owned grpc-node channels

### DIFF
--- a/examples/grpc-node/src/jsMain/kotlin/App.kt
+++ b/examples/grpc-node/src/jsMain/kotlin/App.kt
@@ -35,7 +35,12 @@ suspend fun main() {
                 }
 
                 "client" -> {
-                    HelloWorldClient().greet()
+                    val client = HelloWorldClient()
+                    try {
+                        client.greet()
+                    } finally {
+                        client.close()
+                    }
                 }
 
                 else -> error("unsupported mode: $mode")

--- a/examples/grpc-node/src/jsMain/kotlin/protokt/v1/animals/AnimalsClient.kt
+++ b/examples/grpc-node/src/jsMain/kotlin/protokt/v1/animals/AnimalsClient.kt
@@ -19,20 +19,23 @@ import protokt.v1.animals.DogGrpcKt.DogCoroutineStub
 import protokt.v1.animals.PigGrpcKt.PigCoroutineStub
 import protokt.v1.animals.SheepGrpcKt.SheepCoroutineStub
 import protokt.v1.grpc.ChannelCredentials
+import protokt.v1.grpc.newChannel
 
 class AnimalsClient(
     port: Int
 ) {
+    private val channel = newChannel("localhost:$port", ChannelCredentials.createInsecure())
+
     private val dogStub by lazy {
-        DogCoroutineStub("localhost:$port", ChannelCredentials.createInsecure())
+        DogCoroutineStub(channel)
     }
 
     private val pigStub by lazy {
-        PigCoroutineStub("localhost:$port", ChannelCredentials.createInsecure())
+        PigCoroutineStub(channel)
     }
 
     private val sheepStub by lazy {
-        SheepCoroutineStub("localhost:$port", ChannelCredentials.createInsecure())
+        SheepCoroutineStub(channel)
     }
 
     suspend fun bark() {
@@ -52,6 +55,10 @@ class AnimalsClient(
         val response = sheepStub.baa(request)
         println("Received: ${response.message}")
     }
+
+    fun close() {
+        channel.close()
+    }
 }
 
 /**
@@ -67,19 +74,22 @@ suspend fun main(args: Array<String>) {
 
     val port = 50051
     val client = AnimalsClient(port)
+    try {
+        args.forEach {
+            when (it) {
+                "dog" -> client.bark()
 
-    args.forEach {
-        when (it) {
-            "dog" -> client.bark()
+                "pig" -> client.oink()
 
-            "pig" -> client.oink()
+                "sheep" -> client.baa()
 
-            "sheep" -> client.baa()
-
-            else -> {
-                println("Unknown animal type: \"$it\". Try \"dog\", \"pig\" or \"sheep\".")
-                println(usage)
+                else -> {
+                    println("Unknown animal type: \"$it\". Try \"dog\", \"pig\" or \"sheep\".")
+                    println(usage)
+                }
             }
         }
+    } finally {
+        client.close()
     }
 }

--- a/examples/grpc-node/src/jsMain/kotlin/protokt/v1/helloworld/HelloWorldClient.kt
+++ b/examples/grpc-node/src/jsMain/kotlin/protokt/v1/helloworld/HelloWorldClient.kt
@@ -16,14 +16,20 @@
 package protokt.v1.helloworld
 
 import protokt.v1.grpc.ChannelCredentials
+import protokt.v1.grpc.newChannel
 import protokt.v1.helloworld.GreeterGrpcKt.GreeterCoroutineStub
 
 class HelloWorldClient {
-    private val stub = GreeterCoroutineStub("localhost:50051", ChannelCredentials.createInsecure())
+    private val channel = newChannel("localhost:50051", ChannelCredentials.createInsecure())
+    private val stub = GreeterCoroutineStub(channel)
 
     suspend fun greet(name: String = "world"): HelloReply {
         val reply = stub.sayHello(HelloRequest { this.name = name })
         println("Greeting: ${reply.message}")
         return reply
+    }
+
+    fun close() {
+        channel.close()
     }
 }

--- a/examples/grpc-node/src/jsMain/kotlin/protokt/v1/io/grpc/examples/routeguide/RouteGuideClient.kt
+++ b/examples/grpc-node/src/jsMain/kotlin/protokt/v1/io/grpc/examples/routeguide/RouteGuideClient.kt
@@ -20,13 +20,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import protokt.v1.grpc.ChannelCredentials
+import protokt.v1.grpc.newChannel
 import protokt.v1.io.grpc.examples.routeguide.RouteGuideGrpcKt.RouteGuideCoroutineStub
 import kotlin.random.Random
 import kotlin.random.nextLong
 
 class RouteGuideClient {
     private val random = Random(314159)
-    private val stub = RouteGuideCoroutineStub("localhost:8980", ChannelCredentials.createInsecure())
+    private val channel = newChannel("localhost:8980", ChannelCredentials.createInsecure())
+    private val stub = RouteGuideCoroutineStub(channel)
 
     suspend fun getFeature(latitude: Int, longitude: Int) {
         println("*** GetFeature: lat=$latitude lon=$longitude")
@@ -113,17 +115,24 @@ class RouteGuideClient {
                 delay(500)
             }
         }
+
+    fun close() {
+        channel.close()
+    }
 }
 
 suspend fun clientMain() {
     val features = Database.features()
 
-    RouteGuideClient().let {
-        it.getFeature(409146138, -746188906)
-        it.getFeature(0, 0)
-        it.listFeatures(400000000, -750000000, 420000000, -730000000)
-        it.recordRoute(it.generateRoutePoints(features, 10))
-        it.routeChat()
+    val client = RouteGuideClient()
+    try {
+        client.getFeature(409146138, -746188906)
+        client.getFeature(0, 0)
+        client.listFeatures(400000000, -750000000, 420000000, -730000000)
+        client.recordRoute(client.generateRoutePoints(features, 10))
+        client.routeChat()
+    } finally {
+        client.close()
     }
 }
 

--- a/examples/grpc-node/src/jsTest/kotlin/protokt/v1/animals/AnimalsServerTest.kt
+++ b/examples/grpc-node/src/jsTest/kotlin/protokt/v1/animals/AnimalsServerTest.kt
@@ -21,6 +21,7 @@ import protokt.v1.animals.DogGrpcKt.DogCoroutineStub
 import protokt.v1.animals.PigGrpcKt.PigCoroutineStub
 import protokt.v1.animals.SheepGrpcKt.SheepCoroutineStub
 import protokt.v1.grpc.ChannelCredentials
+import protokt.v1.grpc.newChannel
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -40,16 +41,18 @@ class AnimalsServerTest {
             server.start()
 
             val address = "localhost:${server.port}"
-            val dogStub = DogCoroutineStub(address, ChannelCredentials.createInsecure())
-            val dogBark = dogStub.bark(BarkRequest { })
-            assertEquals("Bark!", dogBark.message)
+            val channel = newChannel(address, ChannelCredentials.createInsecure())
+            try {
+                val dogBark = DogCoroutineStub(channel).bark(BarkRequest { })
+                assertEquals("Bark!", dogBark.message)
 
-            val pigStub = PigCoroutineStub(address, ChannelCredentials.createInsecure())
-            val pigOink = pigStub.oink(OinkRequest { })
-            assertEquals("Oink!", pigOink.message)
+                val pigOink = PigCoroutineStub(channel).oink(OinkRequest { })
+                assertEquals("Oink!", pigOink.message)
 
-            val sheepStub = SheepCoroutineStub(address, ChannelCredentials.createInsecure())
-            val sheepBaa = sheepStub.baa(BaaRequest { })
-            assertEquals("Baa!", sheepBaa.message)
+                val sheepBaa = SheepCoroutineStub(channel).baa(BaaRequest { })
+                assertEquals("Baa!", sheepBaa.message)
+            } finally {
+                channel.close()
+            }
         }
 }

--- a/examples/grpc-node/src/jsTest/kotlin/protokt/v1/helloworld/ErrorHandlingTest.kt
+++ b/examples/grpc-node/src/jsTest/kotlin/protokt/v1/helloworld/ErrorHandlingTest.kt
@@ -17,12 +17,14 @@ package protokt.v1.helloworld
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import protokt.v1.grpc.Channel
 import protokt.v1.grpc.ChannelCredentials
 import protokt.v1.grpc.Server
 import protokt.v1.grpc.ServerCredentials
 import protokt.v1.grpc.Status
 import protokt.v1.grpc.StatusException
 import protokt.v1.grpc.addService
+import protokt.v1.grpc.newChannel
 import protokt.v1.grpc.start
 import protokt.v1.helloworld.GreeterGrpcKt.GreeterCoroutineImplBase
 import protokt.v1.helloworld.GreeterGrpcKt.GreeterCoroutineStub
@@ -34,9 +36,13 @@ import kotlin.test.assertFailsWith
 @OptIn(ExperimentalCoroutinesApi::class)
 class ErrorHandlingTest {
     private val server = Server()
+    private lateinit var channel: Channel
 
     @AfterTest
     fun after() {
+        if (::channel.isInitialized) {
+            channel.close()
+        }
         server.forceShutdown()
     }
 
@@ -47,7 +53,8 @@ class ErrorHandlingTest {
                 .addService(GreeterGrpc.getServiceDescriptor(), NotFoundService())
                 .start("0.0.0.0:0", ServerCredentials.createInsecure())
 
-            val stub = GreeterCoroutineStub("localhost:$port", ChannelCredentials.createInsecure())
+            channel = newChannel("localhost:$port", ChannelCredentials.createInsecure())
+            val stub = GreeterCoroutineStub(channel)
 
             val exception = assertFailsWith<StatusException> {
                 stub.sayHello(HelloRequest { name = "test" })
@@ -62,7 +69,8 @@ class ErrorHandlingTest {
                 .addService(GreeterGrpc.getServiceDescriptor(), RuntimeErrorService())
                 .start("0.0.0.0:0", ServerCredentials.createInsecure())
 
-            val stub = GreeterCoroutineStub("localhost:$port", ChannelCredentials.createInsecure())
+            channel = newChannel("localhost:$port", ChannelCredentials.createInsecure())
+            val stub = GreeterCoroutineStub(channel)
 
             val exception = assertFailsWith<StatusException> {
                 stub.sayHello(HelloRequest { name = "test" })

--- a/examples/grpc-node/src/jsTest/kotlin/protokt/v1/helloworld/HelloWorldServerTest.kt
+++ b/examples/grpc-node/src/jsTest/kotlin/protokt/v1/helloworld/HelloWorldServerTest.kt
@@ -17,7 +17,9 @@ package protokt.v1.helloworld
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import protokt.v1.grpc.Channel
 import protokt.v1.grpc.ChannelCredentials
+import protokt.v1.grpc.newChannel
 import protokt.v1.helloworld.GreeterGrpcKt.GreeterCoroutineStub
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -26,9 +28,13 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 class HelloWorldServerTest {
     private val server = HelloWorldServer(0)
+    private lateinit var channel: Channel
 
     @AfterTest
     fun after() {
+        if (::channel.isInitialized) {
+            channel.close()
+        }
         server.server.forceShutdown()
     }
 
@@ -37,7 +43,8 @@ class HelloWorldServerTest {
         runTest {
             server.start()
 
-            val stub = GreeterCoroutineStub("localhost:${server.port}", ChannelCredentials.createInsecure())
+            channel = newChannel("localhost:${server.port}", ChannelCredentials.createInsecure())
+            val stub = GreeterCoroutineStub(channel)
             val testName = "test name"
 
             val reply = stub.sayHello(HelloRequest { this.name = testName })

--- a/examples/grpc-node/src/jsTest/kotlin/protokt/v1/io/grpc/examples/routeguide/RouteGuideServerTest.kt
+++ b/examples/grpc-node/src/jsTest/kotlin/protokt/v1/io/grpc/examples/routeguide/RouteGuideServerTest.kt
@@ -20,7 +20,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import protokt.v1.grpc.Channel
 import protokt.v1.grpc.ChannelCredentials
+import protokt.v1.grpc.newChannel
 import protokt.v1.io.grpc.examples.routeguide.RouteGuideGrpcKt.RouteGuideCoroutineStub
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -30,9 +32,13 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class RouteGuideServerTest {
     private val server = RouteGuideServer(0)
+    private lateinit var channel: Channel
 
     @AfterTest
     fun after() {
+        if (::channel.isInitialized) {
+            channel.close()
+        }
         server.stop()
     }
 
@@ -41,7 +47,8 @@ class RouteGuideServerTest {
         runTest {
             server.start()
 
-            val stub = RouteGuideCoroutineStub("localhost:${server.port}", ChannelCredentials.createInsecure())
+            channel = newChannel("localhost:${server.port}", ChannelCredentials.createInsecure())
+            val stub = RouteGuideCoroutineStub(channel)
 
             val rectangle = Rectangle {
                 lo = Point {
@@ -63,7 +70,8 @@ class RouteGuideServerTest {
         runTest {
             server.start()
 
-            val stub = RouteGuideCoroutineStub("localhost:${server.port}", ChannelCredentials.createInsecure())
+            channel = newChannel("localhost:${server.port}", ChannelCredentials.createInsecure())
+            val stub = RouteGuideCoroutineStub(channel)
 
             val points = flowOf(
                 Point {
@@ -90,7 +98,8 @@ class RouteGuideServerTest {
         runTest {
             server.start()
 
-            val stub = RouteGuideCoroutineStub("localhost:${server.port}", ChannelCredentials.createInsecure())
+            channel = newChannel("localhost:${server.port}", ChannelCredentials.createInsecure())
+            val stub = RouteGuideCoroutineStub(channel)
 
             val notes = flowOf(
                 RouteNote {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/GrpcKrpcServiceGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/GrpcKrpcServiceGenerator.kt
@@ -63,7 +63,7 @@ private class GrpcKrpcServiceGenerator(
     }
 
     private fun methodFunction(method: Method): FunSpec {
-        val builder = buildFunSpec(method.name.toString()) {
+        val builder = buildFunSpec(method.name.decapitalized) {
             addModifiers(KModifier.ABSTRACT)
 
             if (!method.serverStreaming) {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ProtoMethodNames.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ProtoMethodNames.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen.generate
+
+import io.grpc.kotlin.generator.protoc.ProtoMethodName
+
+internal val ProtoMethodName.decapitalized
+    get() = toMemberSimpleName().name.replaceFirstChar { it.lowercase() }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
@@ -31,7 +31,7 @@ import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.withIndent
 import io.grpc.BindableService
-import io.grpc.ChannelCredentials
+import io.grpc.Channel
 import io.grpc.MethodDescriptor
 import io.grpc.MethodDescriptor.MethodType
 import io.grpc.ServerMethodDefinition
@@ -342,13 +342,11 @@ private class ServiceGenerator(
         return TypeSpec.classBuilder(coroutineStubClassName)
             .primaryConstructor(
                 FunSpec.constructorBuilder()
-                    .addParameter(ParameterSpec("address", String::class.asTypeName()))
-                    .addParameter(ParameterSpec("credentials", pivotClassName(ChannelCredentials::class)))
+                    .addParameter(ParameterSpec("channel", pivotClassName(Channel::class)))
                     .build()
             )
             .addSuperclassConstructorParameter("%M()", grpcServiceObjectClassName.member(getServiceDescriptorFunction.name))
-            .addSuperclassConstructorParameter("address")
-            .addSuperclassConstructorParameter("credentials")
+            .addSuperclassConstructorParameter("channel")
             .superclass(pivotClassName(AbstractCoroutineStub::class).parameterizedBy(coroutineStubClassName))
             .addFunctions(clientImplementations(grpcServiceObjectClassName, getMethodFunctions))
             .build()

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/ServiceGenerator.kt
@@ -73,10 +73,7 @@ private class ServiceGenerator(
         toMemberSimpleName().withSuffix("Method")
 
     private val ProtoMethodName.decapitalizedMethod
-        get() = withMethodSuffix().name.decapitalize()
-
-    private val ProtoMethodName.decapitalized
-        get() = toMemberSimpleName().name.decapitalize()
+        get() = withMethodSuffix().name.replaceFirstChar { it.lowercase() }
 
     private fun grpcImplementations(): List<TypeSpec> =
         if (supportedPlugin()) {

--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/AbstractProtoktCodegenTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/AbstractProtoktCodegenTest.kt
@@ -67,6 +67,20 @@ abstract class AbstractProtoktCodegenTest {
         inputFile: String,
         ext: ProtoktExtension = ProtoktExtension(),
         transform: String.() -> String = { this }
+    ): PluginRunResult =
+        runPlugin(inputFile, ext, KotlinTarget.Jvm, transform)
+
+    protected fun runJsPlugin(
+        inputFile: String,
+        ext: ProtoktExtension
+    ): PluginRunResult =
+        runPlugin(inputFile, ext, KotlinTarget.MultiplatformJs) { this }
+
+    private fun runPlugin(
+        inputFile: String,
+        ext: ProtoktExtension,
+        kotlinTarget: KotlinTarget,
+        transform: String.() -> String
     ): PluginRunResult {
         testFile.writeText(
             Paths.get(Resources.getResource(inputFile).toURI())
@@ -85,7 +99,7 @@ abstract class AbstractProtoktCodegenTest {
             "-I$testDir",
             "-I$extensionsProto",
             "-I$includeProtos",
-            buildPluginOptions(ext),
+            buildPluginOptions(ext, kotlinTarget),
             "$testFile"
         ).joinToString(" ")
             .runCommand(
@@ -103,7 +117,7 @@ abstract class AbstractProtoktCodegenTest {
     }
 }
 
-private fun buildPluginOptions(extension: ProtoktExtension) =
+private fun buildPluginOptions(extension: ProtoktExtension, kotlinTarget: KotlinTarget) =
     "--custom_opt=" +
         (
             extension::class.declaredMemberProperties
@@ -113,7 +127,7 @@ private fun buildPluginOptions(extension: ProtoktExtension) =
                     .filter { it.returnType.classifier as KClass<*> == Boolean::class }
                     .map { "generate_${format(it.name)}=${it.call(extension.generate)}" }
             ).joinToString(",") +
-        ",${format(KOTLIN_TARGET)}=${KotlinTarget.Jvm}"
+        ",${format(KOTLIN_TARGET)}=$kotlinTarget"
 
 private fun format(optionConst: String) =
     CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, optionConst)

--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/AbstractProtoktCodegenTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/AbstractProtoktCodegenTest.kt
@@ -105,9 +105,14 @@ abstract class AbstractProtoktCodegenTest {
 
 private fun buildPluginOptions(extension: ProtoktExtension) =
     "--custom_opt=" +
-        extension::class.declaredMemberProperties
-            .filter { it.returnType.classifier as KClass<*> == Boolean::class }
-            .joinToString(",") { format(it.name) + "=${it.call(extension)}" } +
+        (
+            extension::class.declaredMemberProperties
+                .filter { it.returnType.classifier as KClass<*> == Boolean::class }
+                .map { format(it.name) + "=${it.call(extension)}" } +
+                extension.generate::class.declaredMemberProperties
+                    .filter { it.returnType.classifier as KClass<*> == Boolean::class }
+                    .map { "generate_${format(it.name)}=${it.call(extension.generate)}" }
+            ).joinToString(",") +
         ",${format(KOTLIN_TARGET)}=${KotlinTarget.Jvm}"
 
 private fun format(optionConst: String) =

--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/GrpcKrpcServiceGeneratorTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/GrpcKrpcServiceGeneratorTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import protokt.v1.gradle.ProtoktExtension
+
+class GrpcKrpcServiceGeneratorTest : AbstractProtoktCodegenTest() {
+    @Test
+    fun `method names use lower camel case`() {
+        val extension = ProtoktExtension().apply { generate { grpcKrpcLite() } }
+        val generated =
+            runPlugin("grpc_krpc_method_names.proto", extension)
+                .orFail()
+                .response
+                .fileList
+                .single { it.content.contains("interface NamingService") }
+                .content
+
+        assertThat(generated).contains("fun getURL(")
+        assertThat(generated).contains("fun x(")
+        assertThat(generated).contains("fun ordinaryName(")
+        assertThat(generated).doesNotContain("fun GetURL(")
+        assertThat(generated).doesNotContain("fun X(")
+        assertThat(generated).doesNotContain("fun OrdinaryName(")
+    }
+}

--- a/protokt-codegen/src/test/kotlin/protokt/v1/codegen/GrpcNodeServiceGeneratorTest.kt
+++ b/protokt-codegen/src/test/kotlin/protokt/v1/codegen/GrpcNodeServiceGeneratorTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.codegen
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import protokt.v1.gradle.ProtoktExtension
+
+class GrpcNodeServiceGeneratorTest : AbstractProtoktCodegenTest() {
+    @Test
+    fun `coroutine stub accepts a caller-owned channel`() {
+        val extension = ProtoktExtension().apply { generate { grpcKotlinLite() } }
+        val generated =
+            runJsPlugin("grpc_krpc_method_names.proto", extension)
+                .orFail()
+                .response
+                .fileList
+                .single { it.content.contains("object NamingServiceGrpcKt") }
+                .content
+
+        assertThat(generated).contains("public class NamingServiceCoroutineStub(\n    channel: Channel\n")
+        assertThat(generated).doesNotContain("address: String")
+        assertThat(generated).doesNotContain("credentials: ChannelCredentials")
+    }
+}

--- a/protokt-codegen/src/test/resources/grpc_krpc_method_names.proto
+++ b/protokt-codegen/src/test/resources/grpc_krpc_method_names.proto
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package protokt.v1.codegen.testing;
+
+message Request {}
+
+message Response {}
+
+service NamingService {
+  rpc GetURL(Request) returns (Response);
+  rpc X(Request) returns (Response);
+  rpc OrdinaryName(Request) returns (Response);
+}

--- a/protokt-runtime-grpc-lite/src/jsMain/kotlin/protokt/v1/grpc/AbstractCoroutineStub.kt
+++ b/protokt-runtime-grpc-lite/src/jsMain/kotlin/protokt/v1/grpc/AbstractCoroutineStub.kt
@@ -23,7 +23,6 @@ abstract class AbstractCoroutineStub<S : AbstractCoroutineStub<S>>(
 ) {
     constructor(
         serviceDescriptor: ServiceDescriptor,
-        address: String,
-        credentials: ChannelCredentials
-    ) : this(newClient(serviceDescriptor, address, credentials))
+        channel: Channel
+    ) : this(newClient(serviceDescriptor, channel))
 }

--- a/protokt-runtime-grpc-lite/src/jsMain/kotlin/protokt/v1/grpc/ClientCalls.kt
+++ b/protokt-runtime-grpc-lite/src/jsMain/kotlin/protokt/v1/grpc/ClientCalls.kt
@@ -132,12 +132,18 @@ private fun toStatusException(error: dynamic): StatusException {
     return StatusException(status)
 }
 
-fun newClient(
+/**
+ * Creates a reusable channel. The caller must close it when it is no longer needed.
+ */
+@Beta
+fun newChannel(address: String, credentials: ChannelCredentials): Channel =
+    Channel(address, credentials, js("({})"))
+
+internal fun newClient(
     service: ServiceDescriptor,
-    @Suppress("UNUSED_PARAMETER") address: String,
-    @Suppress("UNUSED_PARAMETER") credentials: ChannelCredentials
+    @Suppress("UNUSED_PARAMETER") channel: Channel
 ): Client {
     @Suppress("UNUSED_VARIABLE")
     val constructor = makeClientConstructor(service.toServiceDefinition())
-    return js("new constructor(address, credentials)") as Client
+    return js("new constructor('', null, {channelOverride: channel})") as Client
 }

--- a/protokt-runtime-grpc-lite/src/jsMain/kotlin/protokt/v1/grpc/GrpcJs.kt
+++ b/protokt-runtime-grpc-lite/src/jsMain/kotlin/protokt/v1/grpc/GrpcJs.kt
@@ -142,6 +142,15 @@ external interface ClientDuplexStream<ReqT, RespT> :
 external class Client
 
 @Beta
+external class Channel internal constructor(
+    address: String,
+    credentials: ChannelCredentials,
+    options: dynamic
+) {
+    fun close()
+}
+
+@Beta
 external fun makeClientConstructor(serviceDefinition: dynamic): (address: String, credentials: ChannelCredentials) -> dynamic
 
 @Beta

--- a/standalone-examples/grpc-krpc/src/commonMain/kotlin/protokt/v1/helloworld/HelloWorld.kt
+++ b/standalone-examples/grpc-krpc/src/commonMain/kotlin/protokt/v1/helloworld/HelloWorld.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.milliseconds
 
 internal class GreeterService : Greeter {
-    override suspend fun SayHello(message: HelloRequest) =
+    override suspend fun sayHello(message: HelloRequest) =
         HelloReply { this.message = "Hello ${message.name}" }
 }
 
@@ -66,7 +66,7 @@ fun runExample() {
                     credentials = plaintext()
                 }
             val greeter = client.withService<Greeter>()
-            val reply = greeter.SayHello(HelloRequest { name = "world" })
+            val reply = greeter.sayHello(HelloRequest { name = "world" })
             println("Received: ${reply.message}")
             server.shutdownNow()
         }

--- a/standalone-examples/grpc-krpc/src/commonTest/kotlin/protokt/v1/helloworld/HelloWorldTest.kt
+++ b/standalone-examples/grpc-krpc/src/commonTest/kotlin/protokt/v1/helloworld/HelloWorldTest.kt
@@ -46,7 +46,7 @@ class HelloWorldTest {
                     }
 
                 val greeter = client.withService<Greeter>()
-                val reply = greeter.SayHello(HelloRequest { name = "test name" })
+                val reply = greeter.sayHello(HelloRequest { name = "test name" })
                 assertEquals("Hello test name", reply.message)
             } finally {
                 server.shutdownNow()

--- a/third-party/proto-google-common-protos-grpc-krpc/api/proto-google-common-protos-grpc-krpc.api
+++ b/third-party/proto-google-common-protos-grpc-krpc/api/proto-google-common-protos-grpc-krpc.api
@@ -1,13 +1,13 @@
 public abstract interface class protokt/v1/google/cloud/location/Locations {
-	public abstract fun GetLocation (Lprotokt/v1/google/cloud/location/GetLocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun ListLocations (Lprotokt/v1/google/cloud/location/ListLocationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getLocation (Lprotokt/v1/google/cloud/location/GetLocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listLocations (Lprotokt/v1/google/cloud/location/ListLocationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class protokt/v1/google/longrunning/Operations {
-	public abstract fun CancelOperation (Lprotokt/v1/google/longrunning/CancelOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun DeleteOperation (Lprotokt/v1/google/longrunning/DeleteOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun GetOperation (Lprotokt/v1/google/longrunning/GetOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun ListOperations (Lprotokt/v1/google/longrunning/ListOperationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun WaitOperation (Lprotokt/v1/google/longrunning/WaitOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancelOperation (Lprotokt/v1/google/longrunning/CancelOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteOperation (Lprotokt/v1/google/longrunning/DeleteOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOperation (Lprotokt/v1/google/longrunning/GetOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listOperations (Lprotokt/v1/google/longrunning/ListOperationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun waitOperation (Lprotokt/v1/google/longrunning/WaitOperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 


### PR DESCRIPTION
## Summary

- Generate Kotlin/JS grpc-node stubs that accept an existing `Channel` instead of constructing a hidden channel from an address and credentials.
- Add a `newChannel` runtime factory that supplies grpc-js defaults without exposing dynamic channel options in Kotlin API.
- Make channel ownership explicit in grpc-node examples and close every test and command-line client channel.
- Exercise one channel shared across several generated service stubs.

## Acceptance criteria

- Generated grpc-node stubs accept a caller-owned `Channel`.
- Multiple generated stubs can make calls over one shared channel.
- The caller controls channel shutdown.
- Generated stubs no longer expose the address-and-credentials constructor.

## Dependency

- Stacked on #571 for the mode-aware codegen test harness. The feature commit is separate.