### PR TITLE
Document byte slice ownership

### DIFF
--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/BytesSlice.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/BytesSlice.kt
@@ -17,6 +17,11 @@ package protokt.v1
 
 import kotlin.jvm.JvmStatic
 
+/**
+ * A byte range that may share its backing storage with a larger input buffer.
+ *
+ * Use [toBytes] when retaining a small range would otherwise retain the input buffer.
+ */
 class BytesSlice internal constructor(
     internal val array: ByteArray,
     internal val offset: Int,
@@ -30,6 +35,7 @@ class BytesSlice internal constructor(
     fun isNotEmpty() =
         length > 0
 
+    /** Copies this range into independently owned immutable bytes. */
     fun toBytes() =
         Bytes(array.sliceArray(offset until offset + length))
 

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Reader.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Reader.kt
@@ -20,6 +20,12 @@ interface Reader {
     val lastTag: UInt
 
     fun readBytes(): Bytes
+
+    /**
+     * Reads a byte range that may share storage with the complete input buffer.
+     *
+     * Call [BytesSlice.toBytes] before retaining a small range beyond decoding.
+     */
     fun readBytesSlice(): BytesSlice
     fun readFixed32(): UInt
     fun readFixed64(): ULong


### PR DESCRIPTION
## Summary

- Document that `BytesSlice` may share storage with a larger input buffer.
- Define `toBytes()` as the ownership boundary for retaining a compact immutable copy.
- Document the retention behavior on the generated-code reader API.

## Behavior

- Callers can retain a zero-copy slice when input-buffer retention is acceptable.
- Callers can use `toBytes()` when a small range must not retain the complete decode buffer.
- No duplicate detach or copy API is added.

## Verification

- Runtime JVM tests pass.
- Runtime API validation and Kotlin formatting checks pass.
