### PR TITLE
Decode reflected unknown fields by descriptor

### DIFF
--- a/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
+++ b/protokt-reflect/src/jvmMain/kotlin/protokt/v1/google/protobuf/ProtoktReflect.kt
@@ -15,14 +15,18 @@
 
 package protokt.v1.google.protobuf
 
+import com.google.protobuf.CodedInputStream
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.Type
+import com.google.protobuf.DynamicMessage
+import protokt.v1.Bytes
 import protokt.v1.Enum
 import protokt.v1.Fixed32Val
 import protokt.v1.Fixed64Val
 import protokt.v1.GeneratedProperty
 import protokt.v1.LengthDelimitedVal
 import protokt.v1.Message
+import protokt.v1.UnknownValue
 import protokt.v1.VarintVal
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
@@ -98,50 +102,112 @@ internal object ProtoktReflect {
     }
 
     private fun getUnknownField(field: FieldDescriptor, message: Message) =
-        message.unknownFields[field.number.toUInt()]?.let { value ->
-            when {
-                value.varint.isNotEmpty() ->
-                    value.varint
-                        .map(VarintVal::value)
-                        .map {
-                            if (field.type == Type.UINT64) {
-                                it
-                            } else {
-                                it.toLong()
-                            }
-                        }
-
-                value.fixed32.isNotEmpty() ->
-                    value.fixed32.map(Fixed32Val::value)
-
-                value.fixed64.isNotEmpty() ->
-                    value.fixed64.map(Fixed64Val::value)
-
-                value.lengthDelimited.isNotEmpty() ->
-                    value.lengthDelimited
-                        .map(LengthDelimitedVal::value)
-                        .map {
-                            if (field.type == Type.STRING) {
-                                StandardCharsets.UTF_8.decode(it.asReadOnlyBuffer()).toString()
-                            } else {
-                                it
-                            }
-                        }
-
-                else -> error("unknown field for field number ${field.number} existed but was empty")
-            }
+        message.unknownFields[field.number.toUInt()]?.values?.flatMap { value ->
+            decodeUnknownValue(field, value)
         }.let {
             if (field.isRepeated) {
                 if (field.isMapField) {
-                    it ?: emptyMap<Any, Any>()
+                    it.orEmpty()
+                        .filterIsInstance<DynamicMessage>()
+                        .associate { entry ->
+                            entry.getField(field.messageType.findFieldByNumber(1)) to
+                                entry.getField(field.messageType.findFieldByNumber(2))
+                        }
                 } else {
-                    it ?: emptyList<Any>()
+                    it.orEmpty()
                 }
             } else {
-                it?.first()
+                it?.lastOrNull()
             }
         }
 
+    private fun decodeUnknownValue(field: FieldDescriptor, value: UnknownValue): List<Any> =
+        when (value) {
+            is VarintVal -> decodeVarint(field, value.value)?.let(::listOf).orEmpty()
+            is Fixed32Val -> decodeFixed32(field, value.value)?.let(::listOf).orEmpty()
+            is Fixed64Val -> decodeFixed64(field, value.value)?.let(::listOf).orEmpty()
+            is LengthDelimitedVal -> decodeLengthDelimited(field, value.value)
+        }
+
+    private fun decodeVarint(field: FieldDescriptor, value: ULong): Any? =
+        when (field.type) {
+            Type.INT32 -> value.toInt()
+            Type.INT64 -> value.toLong()
+            Type.UINT32 -> value.toUInt()
+            Type.UINT64 -> value
+            Type.SINT32 -> value.toInt().let { (it ushr 1) xor -(it and 1) }
+            Type.SINT64 -> value.toLong().let { (it ushr 1) xor -(it and 1) }
+            Type.BOOL -> value != 0uL
+            Type.ENUM -> ReflectedUnknownEnum(value.toInt())
+            else -> null
+        }
+
+    private fun decodeFixed32(field: FieldDescriptor, value: UInt): Any? =
+        when (field.type) {
+            Type.FIXED32 -> value
+            Type.SFIXED32 -> value.toInt()
+            Type.FLOAT -> Float.fromBits(value.toInt())
+            else -> null
+        }
+
+    private fun decodeFixed64(field: FieldDescriptor, value: ULong): Any? =
+        when (field.type) {
+            Type.FIXED64 -> value
+            Type.SFIXED64 -> value.toLong()
+            Type.DOUBLE -> Double.fromBits(value.toLong())
+            else -> null
+        }
+
+    private fun decodeLengthDelimited(field: FieldDescriptor, value: Bytes): List<Any> =
+        when (field.type) {
+            Type.STRING -> listOf(StandardCharsets.UTF_8.decode(value.asReadOnlyBuffer()).toString())
+
+            Type.BYTES -> listOf(value)
+
+            Type.MESSAGE ->
+                listOf(
+                    DynamicMessage.parseFrom(
+                        field.messageType,
+                        CodedInputStream.newInstance(value.asReadOnlyBuffer()),
+                    )
+                )
+
+            else -> if (field.isRepeated && field.isPackable) decodePacked(field, value) else emptyList()
+        }
+
+    private fun decodePacked(field: FieldDescriptor, value: Bytes): List<Any> {
+        val input = CodedInputStream.newInstance(value.asReadOnlyBuffer())
+        return buildList {
+            while (!input.isAtEnd) {
+                add(
+                    when (field.type) {
+                        Type.INT32 -> input.readInt32()
+                        Type.INT64 -> input.readInt64()
+                        Type.UINT32 -> input.readUInt32().toUInt()
+                        Type.UINT64 -> input.readUInt64().toULong()
+                        Type.SINT32 -> input.readSInt32()
+                        Type.SINT64 -> input.readSInt64()
+                        Type.FIXED32 -> input.readFixed32().toUInt()
+                        Type.FIXED64 -> input.readFixed64().toULong()
+                        Type.SFIXED32 -> input.readSFixed32()
+                        Type.SFIXED64 -> input.readSFixed64()
+                        Type.FLOAT -> input.readFloat()
+                        Type.DOUBLE -> input.readDouble()
+                        Type.BOOL -> input.readBool()
+                        Type.ENUM -> ReflectedUnknownEnum(input.readEnum())
+                        else -> error("field ${field.fullName} is not packable")
+                    }
+                )
+            }
+        }
+    }
+
     fun getField(message: Message, field: FieldDescriptor): Any? =
         getReflectedGettersByClass(message::class)(field, message)
+}
+
+private class ReflectedUnknownEnum(
+    override val value: Int
+) : Enum() {
+    override val name = "UNRECOGNIZED"
 }

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -373,7 +373,7 @@ public final class protokt/v1/UnknownField$Companion {
 
 public final class protokt/v1/UnknownFieldSet {
 	public static final field Companion Lprotokt/v1/UnknownFieldSet$Companion;
-	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun contains-WZ4Q5Ns (I)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun forEach (Lkotlin/jvm/functions/Function2;)V
@@ -396,7 +396,7 @@ public final class protokt/v1/UnknownFieldSet$Companion {
 }
 
 public final class protokt/v1/UnknownFieldSet$Field {
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFixed32 ()Ljava/util/List;
 	public final fun getFixed64 ()Ljava/util/List;

--- a/protokt-runtime/api/protokt-runtime.api
+++ b/protokt-runtime/api/protokt-runtime.api
@@ -401,6 +401,7 @@ public final class protokt/v1/UnknownFieldSet$Field {
 	public final fun getFixed32 ()Ljava/util/List;
 	public final fun getFixed64 ()Ljava/util/List;
 	public final fun getLengthDelimited ()Ljava/util/List;
+	public final fun getValues ()Ljava/util/List;
 	public final fun getVarint ()Ljava/util/List;
 	public fun hashCode ()I
 	public final fun size-WZ4Q5Ns (I)I

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/ExtensionCodec.kt
@@ -156,5 +156,5 @@ private class LengthDelimitedCodec<T>(
         field.lengthDelimited.map(decode)
 
     override fun encode(fieldNumber: UInt, value: T): UnknownField =
-        UnknownField.lengthDelimited(fieldNumber, encode(value).value.value)
+        UnknownField.lengthDelimited(fieldNumber, encode(value).value)
 }

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Reader.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Reader.kt
@@ -65,7 +65,7 @@ interface Reader {
                 UnknownField.fixed64(fieldNumber, readFixed64())
 
             WireFormat.WIRETYPE_LENGTH_DELIMITED ->
-                UnknownField.lengthDelimited(fieldNumber, readBytes().value)
+                UnknownField.lengthDelimited(fieldNumber, readBytes())
 
             WireFormat.WIRETYPE_FIXED32 ->
                 UnknownField.fixed32(fieldNumber, readFixed32())

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownField.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownField.kt
@@ -38,11 +38,14 @@ class UnknownField private constructor(
 
         @JvmStatic
         fun lengthDelimited(fieldNumber: UInt, bytes: ByteArray) =
-            UnknownField(fieldNumber, LengthDelimitedVal(Bytes(bytes)))
+            lengthDelimited(fieldNumber, Bytes.from(bytes))
+
+        internal fun lengthDelimited(fieldNumber: UInt, bytes: Bytes) =
+            UnknownField(fieldNumber, LengthDelimitedVal(bytes))
     }
 }
 
-interface UnknownValue {
+sealed interface UnknownValue {
     fun size(): Int
 }
 

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
@@ -89,30 +89,33 @@ class UnknownFieldSet private constructor(
     // to have to trace the origin of the unknown field.
     class Field
     private constructor(
-        internal val orderedValues: List<UnknownValue>
+        orderedValues: List<UnknownValue>
     ) {
-        val varint = freezeList(orderedValues.filterIsInstance<VarintVal>())
-        val fixed32 = freezeList(orderedValues.filterIsInstance<Fixed32Val>())
-        val fixed64 = freezeList(orderedValues.filterIsInstance<Fixed64Val>())
-        val lengthDelimited = freezeList(orderedValues.filterIsInstance<LengthDelimitedVal>())
+        @OnlyForUseByGeneratedProtoCode
+        val values = orderedValues
+
+        val varint = freezeList(values.filterIsInstance<VarintVal>())
+        val fixed32 = freezeList(values.filterIsInstance<Fixed32Val>())
+        val fixed64 = freezeList(values.filterIsInstance<Fixed64Val>())
+        val lengthDelimited = freezeList(values.filterIsInstance<LengthDelimitedVal>())
 
         private val size
-            get() = orderedValues.size
+            get() = values.size
 
         @OnlyForUseByGeneratedProtoCode
         fun size(fieldNumber: UInt) =
-            (sizeOf(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_VARINT)) * size) + orderedValues.sumOf { it.size() }
+            (sizeOf(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_VARINT)) * size) + values.sumOf { it.size() }
 
         @OnlyForUseByGeneratedProtoCode
         fun write(fieldNumber: UInt, serializer: Writer) {
-            orderedValues.forEach { it.write(fieldNumber, serializer) }
+            values.forEach { it.write(fieldNumber, serializer) }
         }
 
         override fun equals(other: Any?) =
-            other is Field && other.orderedValues == orderedValues
+            other is Field && other.values == values
 
         override fun hashCode() =
-            orderedValues.hashCode()
+            values.hashCode()
 
         override fun toString(): String =
             "Field(" +

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/UnknownFieldSet.kt
@@ -20,6 +20,7 @@ import protokt.v1.Collections.freezeMap
 import protokt.v1.Sizes.sizeOf
 
 class UnknownFieldSet private constructor(
+    private val orderedFields: List<UnknownField>,
     private val fieldMap: Map<UInt, Field>
 ) {
     operator fun get(fieldNumber: UInt): Field? =
@@ -33,11 +34,15 @@ class UnknownFieldSet private constructor(
 
     @OnlyForUseByGeneratedProtoCode
     fun size() =
-        fieldMap.entries.sumOf { (k, v) -> v.size(k) }
+        orderedFields.sumOf { sizeOf(WireFormat.makeTag(it.fieldNumber, it.value.wireType)) + it.value.size() }
 
     @OnlyForUseByGeneratedProtoCode
     fun forEach(action: (UInt, Field) -> Unit) {
         fieldMap.forEach { (k, v) -> action(k, v) }
+    }
+
+    internal fun forEachUnknown(action: (UnknownField) -> Unit) {
+        orderedFields.forEach(action)
     }
 
     override fun equals(other: Any?) =
@@ -51,7 +56,7 @@ class UnknownFieldSet private constructor(
         "UnknownFieldSet(fields=$fieldMap)"
 
     companion object {
-        private val EMPTY = UnknownFieldSet(emptyMap())
+        private val EMPTY = UnknownFieldSet(emptyList(), emptyMap())
 
         fun empty() =
             EMPTY
@@ -62,15 +67,21 @@ class UnknownFieldSet private constructor(
     }
 
     class Builder {
-        private val map = mutableMapOf<UInt, Field.Builder>()
+        private val fields = mutableListOf<UnknownField>()
 
         fun add(unknown: UnknownField) {
-            map.getOrPut(unknown.fieldNumber) { Field.Builder() }
-                .add(unknown.value)
+            fields.add(unknown)
         }
 
-        fun build() =
-            UnknownFieldSet(freezeMap(map.mapValues { (_, v) -> v.build() }))
+        fun build(): UnknownFieldSet {
+            val frozenFields = freezeList(fields)
+            val builders = mutableMapOf<UInt, Field.Builder>()
+            frozenFields.forEach { unknown ->
+                builders.getOrPut(unknown.fieldNumber) { Field.Builder() }
+                    .add(unknown.value)
+            }
+            return UnknownFieldSet(frozenFields, freezeMap(builders.mapValues { (_, v) -> v.build() }))
+        }
     }
 
     // If unknown fields are keyed by tag instead of field number then the bit
@@ -78,43 +89,30 @@ class UnknownFieldSet private constructor(
     // to have to trace the origin of the unknown field.
     class Field
     private constructor(
-        val varint: List<VarintVal>,
-        val fixed32: List<Fixed32Val>,
-        val fixed64: List<Fixed64Val>,
-        val lengthDelimited: List<LengthDelimitedVal>
+        internal val orderedValues: List<UnknownValue>
     ) {
+        val varint = freezeList(orderedValues.filterIsInstance<VarintVal>())
+        val fixed32 = freezeList(orderedValues.filterIsInstance<Fixed32Val>())
+        val fixed64 = freezeList(orderedValues.filterIsInstance<Fixed64Val>())
+        val lengthDelimited = freezeList(orderedValues.filterIsInstance<LengthDelimitedVal>())
+
         private val size
-            get() = varint.size + fixed32.size + fixed64.size + lengthDelimited.size
+            get() = orderedValues.size
 
         @OnlyForUseByGeneratedProtoCode
         fun size(fieldNumber: UInt) =
-            (sizeOf(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_VARINT)) * size) + asSequence().sumOf { it.size() }
-
-        private fun asSequence(): Sequence<UnknownValue> =
-            (varint.asSequence() + fixed32 + fixed64 + lengthDelimited)
+            (sizeOf(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_VARINT)) * size) + orderedValues.sumOf { it.size() }
 
         @OnlyForUseByGeneratedProtoCode
         fun write(fieldNumber: UInt, serializer: Writer) {
-            asSequence().forEach { serializer.write(it, fieldNumber) }
-        }
-
-        private fun Writer.write(
-            unknownValue: UnknownValue,
-            fieldNumber: UInt
-        ) {
-            when (unknownValue) {
-                is VarintVal -> writeTag(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_VARINT)).writeUInt64(unknownValue.value)
-                is Fixed32Val -> writeTag(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32)).writeFixed32(unknownValue.value)
-                is Fixed64Val -> writeTag(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64)).writeFixed64(unknownValue.value)
-                is LengthDelimitedVal -> writeTag(WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED)).write(unknownValue.value)
-            }
+            orderedValues.forEach { it.write(fieldNumber, serializer) }
         }
 
         override fun equals(other: Any?) =
-            equalsUsingSequence(other, { it.size }, Field::asSequence)
+            other is Field && other.orderedValues == orderedValues
 
         override fun hashCode() =
-            hashCodeUsingSequence(asSequence())
+            orderedValues.hashCode()
 
         override fun toString(): String =
             "Field(" +
@@ -125,51 +123,37 @@ class UnknownFieldSet private constructor(
 
         class Builder
         internal constructor() {
-            private var varint: MutableList<VarintVal>? = null
-            private var fixed32: MutableList<Fixed32Val>? = null
-            private var fixed64: MutableList<Fixed64Val>? = null
-            private var lengthDelimited: MutableList<LengthDelimitedVal>? = null
-
-            private fun varint() =
-                varint.let {
-                    it ?: mutableListOf<VarintVal>()
-                        .apply { varint = this }
-                }
-
-            private fun fixed32() =
-                fixed32.let {
-                    it ?: mutableListOf<Fixed32Val>()
-                        .apply { fixed32 = this }
-                }
-
-            private fun fixed64() =
-                fixed64.let {
-                    it ?: mutableListOf<Fixed64Val>()
-                        .apply { fixed64 = this }
-                }
-
-            private fun lengthDelimited() =
-                lengthDelimited.let {
-                    it ?: mutableListOf<LengthDelimitedVal>()
-                        .apply { lengthDelimited = this }
-                }
+            private val values = mutableListOf<UnknownValue>()
 
             fun add(unknown: UnknownValue) {
-                when (unknown) {
-                    is VarintVal -> varint().add(unknown)
-                    is Fixed32Val -> fixed32().add(unknown)
-                    is Fixed64Val -> fixed64().add(unknown)
-                    is LengthDelimitedVal -> lengthDelimited().add(unknown)
-                }
+                values.add(unknown)
             }
 
             fun build() =
-                Field(
-                    varint?.let { freezeList(it) } ?: emptyList(),
-                    fixed32?.let { freezeList(it) } ?: emptyList(),
-                    fixed64?.let { freezeList(it) } ?: emptyList(),
-                    lengthDelimited?.let { freezeList(it) } ?: emptyList()
-                )
+                Field(freezeList(values))
         }
+    }
+}
+
+private val UnknownValue.wireType
+    get() =
+        when (this) {
+            is VarintVal -> WireFormat.WIRETYPE_VARINT
+            is Fixed32Val -> WireFormat.WIRETYPE_FIXED32
+            is Fixed64Val -> WireFormat.WIRETYPE_FIXED64
+            is LengthDelimitedVal -> WireFormat.WIRETYPE_LENGTH_DELIMITED
+        }
+
+internal fun UnknownField.write(serializer: Writer) {
+    value.write(fieldNumber, serializer)
+}
+
+private fun UnknownValue.write(fieldNumber: UInt, serializer: Writer) {
+    serializer.writeTag(WireFormat.makeTag(fieldNumber, wireType))
+    when (val unknownValue = this) {
+        is VarintVal -> serializer.writeUInt64(unknownValue.value)
+        is Fixed32Val -> serializer.writeFixed32(unknownValue.value)
+        is Fixed64Val -> serializer.writeFixed64(unknownValue.value)
+        is LengthDelimitedVal -> serializer.write(unknownValue.value)
     }
 }

--- a/protokt-runtime/src/commonMain/kotlin/protokt/v1/Writer.kt
+++ b/protokt-runtime/src/commonMain/kotlin/protokt/v1/Writer.kt
@@ -72,7 +72,7 @@ interface Writer {
     }
 
     fun writeUnknown(u: UnknownFieldSet) {
-        u.forEach { k, v -> v.write(k, this) }
+        u.forEachUnknown { it.write(this) }
     }
 
     fun toByteArray(): ByteArray

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/UnknownFieldSetTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/UnknownFieldSetTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class UnknownFieldSetTest {
+    @Test
+    fun `serialization preserves wire order`() {
+        val unknownFields =
+            unknownFieldSet(
+                UnknownField.lengthDelimited(15u, "abc".encodeToByteArray()),
+                UnknownField.varint(15u, 123),
+                UnknownField.lengthDelimited(15u, "def".encodeToByteArray()),
+                UnknownField.varint(15u, 456),
+                UnknownField.fixed32(2u, 0x01020304u),
+                UnknownField.varint(1u, 1)
+            )
+
+        val writer = ProtoktWriter(ByteArray(unknownFields.size()))
+        writer.writeUnknown(unknownFields)
+
+        assertThat(writer.toByteArray()).isEqualTo(
+            byteArrayOf(
+                0x7a,
+                0x03,
+                0x61,
+                0x62,
+                0x63,
+                0x78,
+                0x7b,
+                0x7a,
+                0x03,
+                0x64,
+                0x65,
+                0x66,
+                0x78,
+                0xc8.toByte(),
+                0x03,
+                0x15,
+                0x04,
+                0x03,
+                0x02,
+                0x01,
+                0x08,
+                0x01
+            )
+        )
+    }
+
+    @Test
+    fun `lookup retains wire order and typed projections`() {
+        val unknownFields =
+            unknownFieldSet(
+                UnknownField.lengthDelimited(4u, byteArrayOf(1)),
+                UnknownField.varint(4u, 2),
+                UnknownField.lengthDelimited(4u, byteArrayOf(3))
+            )
+
+        assertThat(4u in unknownFields).isTrue()
+        assertThat(unknownFields[4u]?.orderedValues).containsExactly(
+            LengthDelimitedVal(Bytes.from(byteArrayOf(1))),
+            VarintVal(2uL),
+            LengthDelimitedVal(Bytes.from(byteArrayOf(3)))
+        ).inOrder()
+        assertThat(unknownFields[4u]?.varint).containsExactly(VarintVal(2uL))
+        assertThat(unknownFields[4u]?.lengthDelimited).containsExactly(
+            LengthDelimitedVal(Bytes.from(byteArrayOf(1))),
+            LengthDelimitedVal(Bytes.from(byteArrayOf(3)))
+        ).inOrder()
+    }
+
+    @Test
+    fun `field equality includes wire order`() {
+        val lengthThenVarint =
+            unknownFieldSet(
+                UnknownField.lengthDelimited(1u, byteArrayOf(1)),
+                UnknownField.varint(1u, 1)
+            )
+        val varintThenLength =
+            unknownFieldSet(
+                UnknownField.varint(1u, 1),
+                UnknownField.lengthDelimited(1u, byteArrayOf(1))
+            )
+
+        assertThat(lengthThenVarint).isNotEqualTo(varintThenLength)
+    }
+
+    @Test
+    fun `set equality does not depend on order across field numbers`() {
+        val ascending = unknownFieldSet(UnknownField.varint(1u, 1), UnknownField.varint(2u, 2))
+        val descending = unknownFieldSet(UnknownField.varint(2u, 2), UnknownField.varint(1u, 1))
+
+        assertThat(ascending).isEqualTo(descending)
+        assertThat(ascending.hashCode()).isEqualTo(descending.hashCode())
+    }
+
+    @Test
+    fun `public length-delimited factory copies its input`() {
+        val source = byteArrayOf(1, 2, 3)
+        val unknown = UnknownField.lengthDelimited(1u, source)
+
+        source[0] = 9
+
+        assertThat((unknown.value as LengthDelimitedVal).value.bytes).isEqualTo(byteArrayOf(1, 2, 3))
+    }
+
+    @Test
+    fun `internal length-delimited factory retains owned bytes`() {
+        val bytes = Bytes(byteArrayOf(1, 2, 3))
+        val unknown = UnknownField.lengthDelimited(1u, bytes)
+
+        assertThat((unknown.value as LengthDelimitedVal).value).isSameInstanceAs(bytes)
+    }
+
+    private fun unknownFieldSet(vararg fields: UnknownField) =
+        UnknownFieldSet.Builder().apply { fields.forEach(::add) }.build()
+}

--- a/protokt-runtime/src/jvmTest/kotlin/protokt/v1/UnknownFieldSetTest.kt
+++ b/protokt-runtime/src/jvmTest/kotlin/protokt/v1/UnknownFieldSetTest.kt
@@ -63,6 +63,7 @@ class UnknownFieldSetTest {
     }
 
     @Test
+    @OptIn(OnlyForUseByGeneratedProtoCode::class)
     fun `lookup retains wire order and typed projections`() {
         val unknownFields =
             unknownFieldSet(
@@ -72,7 +73,7 @@ class UnknownFieldSetTest {
             )
 
         assertThat(4u in unknownFields).isTrue()
-        assertThat(unknownFields[4u]?.orderedValues).containsExactly(
+        assertThat(unknownFields[4u]?.values).containsExactly(
             LengthDelimitedVal(Bytes.from(byteArrayOf(1))),
             VarintVal(2uL),
             LengthDelimitedVal(Bytes.from(byteArrayOf(3)))

--- a/testing/conformance/failure_list_kt.txt
+++ b/testing/conformance/failure_list_kt.txt
@@ -1,13 +1,11 @@
 # proto3: protokt does not support
 Recommended.Proto3.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput
 Required.Proto3.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput
-Required.Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput
 Required.Proto3.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
 
 # editions: protokt does not support
 Recommended.Editions_Proto3.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput
 Required.Editions_Proto3.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput
-Required.Editions_Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput
 Required.Editions_Proto3.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
 Required.Editions.ProtobufInput.ValidDelimitedExtension.GroupLike.ProtobufOutput
 Required.Editions.ProtobufInput.ValidDelimitedExtension.NotGroupLike.ProtobufOutput
@@ -17,5 +15,4 @@ Required.Editions.ProtobufInput.ValidDelimitedField.NotGroupLike.ProtobufOutput
 # proto2: protokt does not support (mirrors of the proto3 cases above)
 Recommended.Proto2.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput
 Required.Proto2.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput
-Required.Proto2.ProtobufInput.UnknownOrdering.ProtobufOutput
 Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput

--- a/testing/interop/src/test/kotlin/protokt/v1/testing/ProtoktReflectTest.kt
+++ b/testing/interop/src/test/kotlin/protokt/v1/testing/ProtoktReflectTest.kt
@@ -17,12 +17,16 @@ package protokt.v1.testing
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.Descriptors.FieldDescriptor
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import proto3_unittest.UnittestProto3
+import protokt.v1.UnknownField
+import protokt.v1.UnknownFieldSet
 import protokt.v1.google.protobuf.getField
 import protokt.v1.google.protobuf.hasField
 import protokt.v1.proto3_unittest.TestAllTypes
+import protokt.v1.proto3_unittest.TestEmptyMessage
 
 class ProtoktReflectTest {
     private val context = getContextReflectively()
@@ -38,6 +42,28 @@ class ProtoktReflectTest {
 
         assertThat(protoktDefault.getField(field)?.let(context::convertValue))
             .isEqualTo(javaDefault.getField(field))
+    }
+
+    @Test
+    fun `unknown repeated fields combine packed and unpacked values in wire order`() {
+        val field = descriptor.findFieldByName("repeated_int32")
+        val message =
+            unknownMessage(
+                UnknownField.varint(field.number.toUInt(), 1),
+                UnknownField.fixed32(field.number.toUInt(), 99u),
+                UnknownField.lengthDelimited(field.number.toUInt(), byteArrayOf(2, 3)),
+                UnknownField.varint(field.number.toUInt(), 4)
+            )
+
+        assertThat(message.getField(field)).isEqualTo(listOf(1, 2, 3, 4))
+    }
+
+    @Test
+    fun `unknown scalar fields use their descriptor encoding`() {
+        val field = descriptor.findFieldByName("optional_sint32")
+        val message = unknownMessage(UnknownField.varint(field.number.toUInt(), 3))
+
+        assertThat(message.getField(field)).isEqualTo(-2)
     }
 
     companion object {
@@ -64,3 +90,11 @@ class ProtoktReflectTest {
             )
     }
 }
+
+private fun unknownMessage(vararg fields: UnknownField) =
+    TestEmptyMessage {
+        unknownFields =
+            UnknownFieldSet.Builder()
+                .apply { fields.forEach(::add) }
+                .build()
+    }


### PR DESCRIPTION
## Summary

- Decode reflected unknown fields according to their protobuf descriptor instead of selecting the first non-empty wire-type bucket.
- Preserve occurrence order while combining packed and unpacked repeated values, and ignore values with incompatible wire types.
- Decode scalar wire encodings, nested messages, and map entries into the same intermediate forms used by known generated properties.

## Stack

- Depends on #560 for the ordered unknown-value representation.

## Verification

- `./gradlew :testing:interop:test --tests protokt.v1.testing.ProtoktReflectTest :protokt-runtime:apiCheck :spotlessKotlinCheck`
