### PR TITLE
Memoize serializedSize with a -1 sentinel instead of a Lazy delegate

### DIFF
--- a/protokt-bootstrap/src/main/kotlin/protokt/v1/Protokt.kt
+++ b/protokt-bootstrap/src/main/kotlin/protokt/v1/Protokt.kt
@@ -28,20 +28,15 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.Transient
 
 @GeneratedMessage("protokt.v1.FileOptions")
 public class FileOptions private constructor(
   private val _fileDescriptorObjectName: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
-      result += sizeOf(10u) + sizeOf(_fileDescriptorObjectName.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Specify the name of the Kotlin object that contains the reference to this file's FileDescriptor object.
@@ -50,8 +45,23 @@ public class FileOptions private constructor(
   public val fileDescriptorObjectName: String
     get() = _fileDescriptorObjectName.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_fileDescriptorObjectName.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
@@ -151,17 +161,8 @@ public class MessageOptions private constructor(
   private val _deprecationMessage: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_implements.wireValue().isNotEmpty()) {
-      result += sizeOf(10u) + sizeOf(_implements.wireValue())
-    }
-    if (_deprecationMessage.wireValue().isNotEmpty()) {
-      result += sizeOf(18u) + sizeOf(_deprecationMessage.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Declares that the message class implements an interface. Scoping rules are the same as those for declaring wrapper types.
@@ -177,8 +178,26 @@ public class MessageOptions private constructor(
   public val deprecationMessage: String
     get() = _deprecationMessage.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_implements.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_implements.wireValue())
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_implements.wireValue().isNotEmpty()) {
@@ -318,29 +337,8 @@ public class FieldOptions private constructor(
   private val _valueWrap: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (generateNonNullAccessor) {
-      result += sizeOf(8u) + 1
-    }
-    if (_wrap.wireValue().isNotEmpty()) {
-      result += sizeOf(18u) + sizeOf(_wrap.wireValue())
-    }
-    if (bytesSlice) {
-      result += sizeOf(24u) + 1
-    }
-    if (_deprecationMessage.wireValue().isNotEmpty()) {
-      result += sizeOf(34u) + sizeOf(_deprecationMessage.wireValue())
-    }
-    if (_keyWrap.wireValue().isNotEmpty()) {
-      result += sizeOf(42u) + sizeOf(_keyWrap.wireValue())
-    }
-    if (_valueWrap.wireValue().isNotEmpty()) {
-      result += sizeOf(50u) + sizeOf(_valueWrap.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Expose a wrapper class instead of a raw protobuf type.
@@ -402,8 +400,38 @@ public class FieldOptions private constructor(
   public val valueWrap: String
     get() = _valueWrap.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (generateNonNullAccessor) {
+      result += sizeOf(8u) + 1
+    }
+    if (_wrap.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_wrap.wireValue())
+    }
+    if (bytesSlice) {
+      result += sizeOf(24u) + 1
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(34u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    if (_keyWrap.wireValue().isNotEmpty()) {
+      result += sizeOf(42u) + sizeOf(_keyWrap.wireValue())
+    }
+    if (_valueWrap.wireValue().isNotEmpty()) {
+      result += sizeOf(50u) + sizeOf(_valueWrap.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (generateNonNullAccessor) {
@@ -612,20 +640,8 @@ public class OneofOptions private constructor(
   private val _deprecationMessage: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (generateNonNullAccessor) {
-      result += sizeOf(8u) + 1
-    }
-    if (_implements.wireValue().isNotEmpty()) {
-      result += sizeOf(18u) + sizeOf(_implements.wireValue())
-    }
-    if (_deprecationMessage.wireValue().isNotEmpty()) {
-      result += sizeOf(26u) + sizeOf(_deprecationMessage.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Make the sealed class implement an interface, enforcing the presence of a property in each possible variant. Scoping rules  are the same as those for declaring wrapper types.
@@ -641,8 +657,29 @@ public class OneofOptions private constructor(
   public val deprecationMessage: String
     get() = _deprecationMessage.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (generateNonNullAccessor) {
+      result += sizeOf(8u) + 1
+    }
+    if (_implements.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_implements.wireValue())
+    }
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(26u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (generateNonNullAccessor) {
@@ -779,14 +816,8 @@ public class EnumOptions private constructor(
   private val _deprecationMessage: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_deprecationMessage.wireValue().isNotEmpty()) {
-      result += sizeOf(10u) + sizeOf(_deprecationMessage.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Provides a message for deprecation
@@ -795,8 +826,23 @@ public class EnumOptions private constructor(
   public val deprecationMessage: String
     get() = _deprecationMessage.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_deprecationMessage.wireValue().isNotEmpty()) {
@@ -895,14 +941,8 @@ public class EnumValueOptions private constructor(
   private val _deprecationMessage: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_deprecationMessage.wireValue().isNotEmpty()) {
-      result += sizeOf(10u) + sizeOf(_deprecationMessage.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Provides a message for deprecation
@@ -911,8 +951,23 @@ public class EnumValueOptions private constructor(
   public val deprecationMessage: String
     get() = _deprecationMessage.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_deprecationMessage.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_deprecationMessage.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_deprecationMessage.wireValue().isNotEmpty()) {
@@ -1010,12 +1065,20 @@ public class EnumValueOptions private constructor(
 public class ServiceOptions private constructor(
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    unknownFields.size()
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int =
+    unknownFields.size()
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     writer.writeUnknown(unknownFields)
@@ -1087,17 +1150,8 @@ public class MethodOptions private constructor(
   private val _responseMarshaller: LazyReference<Bytes, String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_requestMarshaller.wireValue().isNotEmpty()) {
-      result += sizeOf(10u) + sizeOf(_requestMarshaller.wireValue())
-    }
-    if (_responseMarshaller.wireValue().isNotEmpty()) {
-      result += sizeOf(18u) + sizeOf(_responseMarshaller.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Provides a custom request marshaller for the generated method descriptor. Substitutes the provided expression directly for `com.toasttab.protokt.grpc.KtMarshaller(<request_type>)`
@@ -1113,8 +1167,26 @@ public class MethodOptions private constructor(
   public val responseMarshaller: String
     get() = _responseMarshaller.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_requestMarshaller.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_requestMarshaller.wireValue())
+    }
+    if (_responseMarshaller.wireValue().isNotEmpty()) {
+      result += sizeOf(18u) + sizeOf(_responseMarshaller.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_requestMarshaller.wireValue().isNotEmpty()) {

--- a/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/Descriptor.kt
+++ b/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/Descriptor.kt
@@ -51,6 +51,7 @@ import kotlin.ULong
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.Transient
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto files it parses.
@@ -116,17 +117,26 @@ public class FileDescriptorSet private constructor(
   public val `file`: List<FileDescriptorProto>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (`file`.isNotEmpty()) {
       result += (sizeOf(10u) * `file`.size) + `file`.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     `file`.forEach { writer.writeTag(10u).write(it) }
@@ -268,7 +278,27 @@ public class FileDescriptorProto private constructor(
   public val edition: Edition?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  @GeneratedProperty(2)
+  public val `package`: String?
+    get() = _package?.value()
+
+  /**
+   * The syntax of the proto file. The supported values are "proto2", "proto3", and "editions".
+   *
+   *  If `edition` is present, this value must be "editions". WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
+   */
+  @GeneratedProperty(12)
+  public val syntax: String?
+    get() = _syntax?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -319,28 +349,17 @@ public class FileDescriptorProto private constructor(
       result += sizeOf(112u) + sizeOf(edition)
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  @GeneratedProperty(2)
-  public val `package`: String?
-    get() = _package?.value()
-
-  /**
-   * The syntax of the proto file. The supported values are "proto2", "proto3", and "editions".
-   *
-   *  If `edition` is present, this value must be "editions". WARNING: This field should only be used by protobuf plugins or special cases like the proto compiler. Other uses are discouraged and developers should rely on the protoreflect APIs for their client language.
-   */
-  @GeneratedProperty(12)
-  public val syntax: String?
-    get() = _syntax?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -730,7 +749,14 @@ public class DescriptorProto private constructor(
   public val reservedName: List<String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -772,15 +798,17 @@ public class DescriptorProto private constructor(
         }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -1078,7 +1106,10 @@ public class DescriptorProto private constructor(
     public val options: ExtensionRangeOptions?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (start != null) {
         result += sizeOf(8u) + sizeOf(start)
@@ -1090,11 +1121,17 @@ public class DescriptorProto private constructor(
         result += sizeOf(26u) + sizeOf(options)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (start != null) {
@@ -1225,7 +1262,10 @@ public class DescriptorProto private constructor(
     public val end: Int?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (start != null) {
         result += sizeOf(8u) + sizeOf(start)
@@ -1234,11 +1274,17 @@ public class DescriptorProto private constructor(
         result += sizeOf(16u) + sizeOf(end)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (start != null) {
@@ -1367,7 +1413,10 @@ public class ExtensionRangeOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (declaration.isNotEmpty()) {
       result += (sizeOf(18u) * declaration.size) + declaration.sumOf { sizeOf(it) }
@@ -1382,11 +1431,17 @@ public class ExtensionRangeOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     declaration.forEach { writer.writeTag(18u).write(it) }
@@ -1582,7 +1637,24 @@ public class ExtensionRangeOptions private constructor(
     public val repeated: Boolean?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    /**
+     * The fully-qualified name of the extension field. There must be a leading dot in front of the full name.
+     */
+    @GeneratedProperty(2)
+    public val fullName: String?
+      get() = _fullName?.value()
+
+    /**
+     * The fully-qualified type name of the extension field. Unlike Metadata.type, Declaration.type must have a leading dot for messages and enums.
+     */
+    @GeneratedProperty(3)
+    public val type: String?
+      get() = _type?.value()
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (number != null) {
         result += sizeOf(8u) + sizeOf(number)
@@ -1600,25 +1672,17 @@ public class ExtensionRangeOptions private constructor(
         result += sizeOf(48u) + 1
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    /**
-     * The fully-qualified name of the extension field. There must be a leading dot in front of the full name.
-     */
-    @GeneratedProperty(2)
-    public val fullName: String?
-      get() = _fullName?.value()
-
-    /**
-     * The fully-qualified type name of the extension field. Unlike Metadata.type, Declaration.type must have a leading dot for messages and enums.
-     */
-    @GeneratedProperty(3)
-    public val type: String?
-      get() = _type?.value()
-
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (number != null) {
@@ -1822,7 +1886,42 @@ public class FieldDescriptorProto private constructor(
   public val proto3Optional: Boolean?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  /**
+   * For extensions, this is the name of the type being extended.  It is resolved in the same manner as type_name.
+   */
+  @GeneratedProperty(2)
+  public val extendee: String?
+    get() = _extendee?.value()
+
+  /**
+   * For message and enum types, this is the name of the type.  If the name starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping rules are used to find the type (i.e. first the nested types within this message are searched, then within the parent, on up to the root namespace).
+   */
+  @GeneratedProperty(6)
+  public val typeName: String?
+    get() = _typeName?.value()
+
+  /**
+   * For numeric types, contains the original text representation of the value. For booleans, "true" or "false". For strings, contains the default text contents (not escaped in any way). For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+   */
+  @GeneratedProperty(7)
+  public val defaultValue: String?
+    get() = _defaultValue?.value()
+
+  /**
+   * JSON name of this field. The value is set by protocol compiler. If the user has set a "json_name" option on this field, that option's value will be used. Otherwise, it's deduced from the field's name by converting it to camelCase.
+   */
+  @GeneratedProperty(10)
+  public val jsonName: String?
+    get() = _jsonName?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -1858,43 +1957,17 @@ public class FieldDescriptorProto private constructor(
       result += sizeOf(136u) + 1
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  /**
-   * For extensions, this is the name of the type being extended.  It is resolved in the same manner as type_name.
-   */
-  @GeneratedProperty(2)
-  public val extendee: String?
-    get() = _extendee?.value()
-
-  /**
-   * For message and enum types, this is the name of the type.  If the name starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping rules are used to find the type (i.e. first the nested types within this message are searched, then within the parent, on up to the root namespace).
-   */
-  @GeneratedProperty(6)
-  public val typeName: String?
-    get() = _typeName?.value()
-
-  /**
-   * For numeric types, contains the original text representation of the value. For booleans, "true" or "false". For strings, contains the default text contents (not escaped in any way). For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-   */
-  @GeneratedProperty(7)
-  public val defaultValue: String?
-    get() = _defaultValue?.value()
-
-  /**
-   * JSON name of this field. The value is set by protocol compiler. If the user has set a "json_name" option on this field, that option's value will be used. Otherwise, it's deduced from the field's name by converting it to camelCase.
-   */
-  @GeneratedProperty(10)
-  public val jsonName: String?
-    get() = _jsonName?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -2298,7 +2371,14 @@ public class OneofDescriptorProto private constructor(
   public val options: OneofOptions?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -2307,15 +2387,17 @@ public class OneofDescriptorProto private constructor(
       result += sizeOf(18u) + sizeOf(options)
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -2447,7 +2529,14 @@ public class EnumDescriptorProto private constructor(
   public val reservedName: List<String>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -2474,15 +2563,17 @@ public class EnumDescriptorProto private constructor(
         }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -2673,7 +2764,10 @@ public class EnumDescriptorProto private constructor(
     public val end: Int?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (start != null) {
         result += sizeOf(8u) + sizeOf(start)
@@ -2682,11 +2776,17 @@ public class EnumDescriptorProto private constructor(
         result += sizeOf(16u) + sizeOf(end)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (start != null) {
@@ -2803,7 +2903,14 @@ public class EnumValueDescriptorProto private constructor(
   public val options: EnumValueOptions?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -2815,15 +2922,17 @@ public class EnumValueDescriptorProto private constructor(
       result += sizeOf(26u) + sizeOf(options)
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -2961,7 +3070,14 @@ public class ServiceDescriptorProto private constructor(
   public val options: ServiceOptions?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -2973,15 +3089,17 @@ public class ServiceDescriptorProto private constructor(
       result += sizeOf(26u) + sizeOf(options)
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -3135,7 +3253,25 @@ public class MethodDescriptorProto private constructor(
   public val serverStreaming: Boolean?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  @GeneratedProperty(1)
+  public val name: String?
+    get() = _name?.value()
+
+  /**
+   * Input and output type names.  These are resolved in the same way as FieldDescriptorProto.type_name, but must refer to a message type.
+   */
+  @GeneratedProperty(2)
+  public val inputType: String?
+    get() = _inputType?.value()
+
+  @GeneratedProperty(3)
+  public val outputType: String?
+    get() = _outputType?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_name != null) {
       result += sizeOf(10u) + sizeOf(_name.wireValue())
@@ -3156,26 +3292,17 @@ public class MethodDescriptorProto private constructor(
       result += sizeOf(48u) + 1
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  @GeneratedProperty(1)
-  public val name: String?
-    get() = _name?.value()
-
-  /**
-   * Input and output type names.  These are resolved in the same way as FieldDescriptorProto.type_name, but must refer to a message type.
-   */
-  @GeneratedProperty(2)
-  public val inputType: String?
-    get() = _inputType?.value()
-
-  @GeneratedProperty(3)
-  public val outputType: String?
-    get() = _outputType?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_name != null) {
@@ -3428,74 +3555,8 @@ public class FileOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_javaPackage != null) {
-      result += sizeOf(10u) + sizeOf(_javaPackage.wireValue())
-    }
-    if (_javaOuterClassname != null) {
-      result += sizeOf(66u) + sizeOf(_javaOuterClassname.wireValue())
-    }
-    if (optimizeFor != null) {
-      result += sizeOf(72u) + sizeOf(optimizeFor)
-    }
-    if (javaMultipleFiles != null) {
-      result += sizeOf(80u) + 1
-    }
-    if (_goPackage != null) {
-      result += sizeOf(90u) + sizeOf(_goPackage.wireValue())
-    }
-    if (ccGenericServices != null) {
-      result += sizeOf(128u) + 1
-    }
-    if (javaGenericServices != null) {
-      result += sizeOf(136u) + 1
-    }
-    if (pyGenericServices != null) {
-      result += sizeOf(144u) + 1
-    }
-    if (javaGenerateEqualsAndHash != null) {
-      result += sizeOf(160u) + 1
-    }
-    if (deprecated != null) {
-      result += sizeOf(184u) + 1
-    }
-    if (javaStringCheckUtf8 != null) {
-      result += sizeOf(216u) + 1
-    }
-    if (ccEnableArenas != null) {
-      result += sizeOf(248u) + 1
-    }
-    if (_objcClassPrefix != null) {
-      result += sizeOf(290u) + sizeOf(_objcClassPrefix.wireValue())
-    }
-    if (_csharpNamespace != null) {
-      result += sizeOf(298u) + sizeOf(_csharpNamespace.wireValue())
-    }
-    if (_swiftPrefix != null) {
-      result += sizeOf(314u) + sizeOf(_swiftPrefix.wireValue())
-    }
-    if (_phpClassPrefix != null) {
-      result += sizeOf(322u) + sizeOf(_phpClassPrefix.wireValue())
-    }
-    if (_phpNamespace != null) {
-      result += sizeOf(330u) + sizeOf(_phpNamespace.wireValue())
-    }
-    if (_phpMetadataNamespace != null) {
-      result += sizeOf(354u) + sizeOf(_phpMetadataNamespace.wireValue())
-    }
-    if (_rubyPackage != null) {
-      result += sizeOf(362u) + sizeOf(_rubyPackage.wireValue())
-    }
-    if (features != null) {
-      result += sizeOf(402u) + sizeOf(features)
-    }
-    if (uninterpretedOption.isNotEmpty()) {
-      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
 
   /**
    * Sets the Java package where classes generated from this .proto will be placed.  By default, the proto package is used, but this is often inappropriate because proto packages do not normally start with backwards domain names.
@@ -3567,8 +3628,83 @@ public class FileOptions private constructor(
   public val rubyPackage: String?
     get() = _rubyPackage?.value()
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_javaPackage != null) {
+      result += sizeOf(10u) + sizeOf(_javaPackage.wireValue())
+    }
+    if (_javaOuterClassname != null) {
+      result += sizeOf(66u) + sizeOf(_javaOuterClassname.wireValue())
+    }
+    if (optimizeFor != null) {
+      result += sizeOf(72u) + sizeOf(optimizeFor)
+    }
+    if (javaMultipleFiles != null) {
+      result += sizeOf(80u) + 1
+    }
+    if (_goPackage != null) {
+      result += sizeOf(90u) + sizeOf(_goPackage.wireValue())
+    }
+    if (ccGenericServices != null) {
+      result += sizeOf(128u) + 1
+    }
+    if (javaGenericServices != null) {
+      result += sizeOf(136u) + 1
+    }
+    if (pyGenericServices != null) {
+      result += sizeOf(144u) + 1
+    }
+    if (javaGenerateEqualsAndHash != null) {
+      result += sizeOf(160u) + 1
+    }
+    if (deprecated != null) {
+      result += sizeOf(184u) + 1
+    }
+    if (javaStringCheckUtf8 != null) {
+      result += sizeOf(216u) + 1
+    }
+    if (ccEnableArenas != null) {
+      result += sizeOf(248u) + 1
+    }
+    if (_objcClassPrefix != null) {
+      result += sizeOf(290u) + sizeOf(_objcClassPrefix.wireValue())
+    }
+    if (_csharpNamespace != null) {
+      result += sizeOf(298u) + sizeOf(_csharpNamespace.wireValue())
+    }
+    if (_swiftPrefix != null) {
+      result += sizeOf(314u) + sizeOf(_swiftPrefix.wireValue())
+    }
+    if (_phpClassPrefix != null) {
+      result += sizeOf(322u) + sizeOf(_phpClassPrefix.wireValue())
+    }
+    if (_phpNamespace != null) {
+      result += sizeOf(330u) + sizeOf(_phpNamespace.wireValue())
+    }
+    if (_phpMetadataNamespace != null) {
+      result += sizeOf(354u) + sizeOf(_phpMetadataNamespace.wireValue())
+    }
+    if (_rubyPackage != null) {
+      result += sizeOf(362u) + sizeOf(_rubyPackage.wireValue())
+    }
+    if (features != null) {
+      result += sizeOf(402u) + sizeOf(features)
+    }
+    if (uninterpretedOption.isNotEmpty()) {
+      result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_javaPackage != null) {
@@ -4130,7 +4266,10 @@ public class MessageOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (messageSetWireFormat != null) {
       result += sizeOf(8u) + 1
@@ -4154,11 +4293,17 @@ public class MessageOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (messageSetWireFormat != null) {
@@ -4419,7 +4564,10 @@ public class FieldOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (ctype != null) {
       result += sizeOf(8u) + sizeOf(ctype)
@@ -4464,11 +4612,17 @@ public class FieldOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (ctype != null) {
@@ -4939,7 +5093,14 @@ public class FieldOptions private constructor(
     public val edition: Edition?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    @GeneratedProperty(2)
+    public val `value`: String?
+      get() = _value?.value()
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (_value != null) {
         result += sizeOf(18u) + sizeOf(_value.wireValue())
@@ -4948,15 +5109,17 @@ public class FieldOptions private constructor(
         result += sizeOf(24u) + sizeOf(edition)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    @GeneratedProperty(2)
-    public val `value`: String?
-      get() = _value?.value()
-
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (_value != null) {
@@ -5089,7 +5252,17 @@ public class FieldOptions private constructor(
     public val editionRemoved: Edition?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    /**
+     * The deprecation warning text if this feature is used after the edition it was marked deprecated in.
+     */
+    @GeneratedProperty(3)
+    public val deprecationWarning: String?
+      get() = _deprecationWarning?.value()
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (editionIntroduced != null) {
         result += sizeOf(8u) + sizeOf(editionIntroduced)
@@ -5104,18 +5277,17 @@ public class FieldOptions private constructor(
         result += sizeOf(32u) + sizeOf(editionRemoved)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    /**
-     * The deprecation warning text if this feature is used after the edition it was marked deprecated in.
-     */
-    @GeneratedProperty(3)
-    public val deprecationWarning: String?
-      get() = _deprecationWarning?.value()
-
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (editionIntroduced != null) {
@@ -5272,7 +5444,10 @@ public class OneofOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (features != null) {
       result += sizeOf(10u) + sizeOf(features)
@@ -5281,11 +5456,17 @@ public class OneofOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (features != null) {
@@ -5425,7 +5606,10 @@ public class EnumOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (allowAlias != null) {
       result += sizeOf(16u) + 1
@@ -5443,11 +5627,17 @@ public class EnumOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (allowAlias != null) {
@@ -5635,7 +5825,10 @@ public class EnumValueOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (deprecated != null) {
       result += sizeOf(8u) + 1
@@ -5653,11 +5846,17 @@ public class EnumValueOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (deprecated != null) {
@@ -5834,7 +6033,10 @@ public class ServiceOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (deprecated != null) {
       result += sizeOf(264u) + 1
@@ -5846,11 +6048,17 @@ public class ServiceOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (deprecated != null) {
@@ -5997,7 +6205,10 @@ public class MethodOptions private constructor(
   public val uninterpretedOption: List<UninterpretedOption>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (deprecated != null) {
       result += sizeOf(264u) + 1
@@ -6012,11 +6223,17 @@ public class MethodOptions private constructor(
       result += (sizeOf(7994u) * uninterpretedOption.size) + uninterpretedOption.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (deprecated != null) {
@@ -6205,7 +6422,21 @@ public class UninterpretedOption private constructor(
   private val _aggregateValue: LazyReference<Bytes, String>?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  /**
+   * The value of the uninterpreted option, in whatever type the tokenizer identified it as during parsing. Exactly one of these should be set.
+   */
+  @GeneratedProperty(3)
+  public val identifierValue: String?
+    get() = _identifierValue?.value()
+
+  @GeneratedProperty(8)
+  public val aggregateValue: String?
+    get() = _aggregateValue?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (name.isNotEmpty()) {
       result += (sizeOf(18u) * name.size) + name.sumOf { sizeOf(it) }
@@ -6229,22 +6460,17 @@ public class UninterpretedOption private constructor(
       result += sizeOf(66u) + sizeOf(_aggregateValue.wireValue())
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  /**
-   * The value of the uninterpreted option, in whatever type the tokenizer identified it as during parsing. Exactly one of these should be set.
-   */
-  @GeneratedProperty(3)
-  public val identifierValue: String?
-    get() = _identifierValue?.value()
-
-  @GeneratedProperty(8)
-  public val aggregateValue: String?
-    get() = _aggregateValue?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     name.forEach { writer.writeTag(18u).write(it) }
@@ -6275,7 +6501,7 @@ public class UninterpretedOption private constructor(
       other.identifierValue == this.identifierValue &&
       other.positiveIntValue == this.positiveIntValue &&
       other.negativeIntValue == this.negativeIntValue &&
-      other.doubleValue == this.doubleValue &&
+      other.doubleValue?.toBits() == this.doubleValue?.toBits() &&
       other.stringValue == this.stringValue &&
       other.aggregateValue == this.aggregateValue &&
       other.unknownFields == unknownFields
@@ -6286,7 +6512,7 @@ public class UninterpretedOption private constructor(
     result = 31 * result + identifierValue.hashCode()
     result = 31 * result + positiveIntValue.hashCode()
     result = 31 * result + negativeIntValue.hashCode()
-    result = 31 * result + doubleValue.hashCode()
+    result = 31 * result + doubleValue?.toBits().hashCode()
     result = 31 * result + stringValue.hashCode()
     result = 31 * result + aggregateValue.hashCode()
     return result
@@ -6455,7 +6681,14 @@ public class UninterpretedOption private constructor(
     public val isExtension: Boolean,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    @GeneratedProperty(1)
+    public val namePart: String
+      get() = _namePart.value()
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (_namePart.wireValue().isNotEmpty()) {
         result += sizeOf(10u) + sizeOf(_namePart.wireValue())
@@ -6464,15 +6697,17 @@ public class UninterpretedOption private constructor(
         result += sizeOf(16u) + 1
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    @GeneratedProperty(1)
-    public val namePart: String
-      get() = _namePart.value()
-
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (_namePart.wireValue().isNotEmpty()) {
@@ -6604,7 +6839,10 @@ public class FeatureSet private constructor(
   public val enforceNamingStyle: EnforceNamingStyle?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (fieldPresence != null) {
       result += sizeOf(8u) + sizeOf(fieldPresence)
@@ -6628,11 +6866,17 @@ public class FeatureSet private constructor(
       result += sizeOf(56u) + sizeOf(enforceNamingStyle)
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (fieldPresence != null) {
@@ -7013,7 +7257,10 @@ public class FeatureSetDefaults private constructor(
   public val maximumEdition: Edition?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (defaults.isNotEmpty()) {
       result += (sizeOf(10u) * defaults.size) + defaults.sumOf { sizeOf(it) }
@@ -7025,11 +7272,17 @@ public class FeatureSetDefaults private constructor(
       result += sizeOf(40u) + sizeOf(maximumEdition)
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     defaults.forEach { writer.writeTag(10u).write(it) }
@@ -7173,7 +7426,10 @@ public class FeatureSetDefaults private constructor(
     public val fixedFeatures: FeatureSet?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (edition != null) {
         result += sizeOf(24u) + sizeOf(edition)
@@ -7185,11 +7441,17 @@ public class FeatureSetDefaults private constructor(
         result += sizeOf(42u) + sizeOf(fixedFeatures)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (edition != null) {
@@ -7326,17 +7588,26 @@ public class SourceCodeInfo private constructor(
   public val location: List<Location>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (location.isNotEmpty()) {
       result += (sizeOf(10u) * location.size) + location.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     location.forEach { writer.writeTag(10u).write(it) }
@@ -7451,35 +7722,8 @@ public class SourceCodeInfo private constructor(
     public val leadingDetachedComments: List<String>,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
-      var result = 0
-      if (path.isNotEmpty()) {
-        result += sizeOf(10u) + path.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
-      }
-      if (span.isNotEmpty()) {
-        result += sizeOf(18u) + span.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
-      }
-      if (_leadingComments != null) {
-        result += sizeOf(26u) + sizeOf(_leadingComments.wireValue())
-      }
-      if (_trailingComments != null) {
-        result += sizeOf(34u) + sizeOf(_trailingComments.wireValue())
-      }
-      if (leadingDetachedComments.isNotEmpty()) {
-        result +=
-          @Suppress("UNCHECKED_CAST")
-          (leadingDetachedComments as LazyConvertingList<Bytes, Any>).let { list ->
-            (sizeOf(50u) * list.size) +
-              run {
-                var sum = 0
-                for (i in list.indices) sum += sizeOf(list.wireGet(i))
-                sum
-              }
-          }
-      }
-      result += unknownFields.size()
-      result
-    }
+    @Transient
+    private var __serializedSize: Int = -1
 
     /**
      * If this SourceCodeInfo represents a complete declaration, these are any comments appearing before and after the declaration which appear to be attached to the declaration.
@@ -7514,8 +7758,44 @@ public class SourceCodeInfo private constructor(
     public val trailingComments: String?
       get() = _trailingComments?.value()
 
-    override fun serializedSize(): Int =
-      __serializedSize
+    private fun __computeSerializedSize(): Int {
+      var result = 0
+      if (path.isNotEmpty()) {
+        result += sizeOf(10u) + path.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
+      }
+      if (span.isNotEmpty()) {
+        result += sizeOf(18u) + span.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
+      }
+      if (_leadingComments != null) {
+        result += sizeOf(26u) + sizeOf(_leadingComments.wireValue())
+      }
+      if (_trailingComments != null) {
+        result += sizeOf(34u) + sizeOf(_trailingComments.wireValue())
+      }
+      if (leadingDetachedComments.isNotEmpty()) {
+        result +=
+          @Suppress("UNCHECKED_CAST")
+          (leadingDetachedComments as LazyConvertingList<Bytes, Any>).let { list ->
+            (sizeOf(50u) * list.size) +
+              run {
+                var sum = 0
+                for (i in list.indices) sum += sizeOf(list.wireGet(i))
+                sum
+              }
+          }
+      }
+      result += unknownFields.size()
+      return result
+    }
+
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (path.isNotEmpty()) {
@@ -7737,17 +8017,26 @@ public class GeneratedCodeInfo private constructor(
   public val `annotation`: List<Annotation>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (`annotation`.isNotEmpty()) {
       result += (sizeOf(10u) * `annotation`.size) + `annotation`.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     `annotation`.forEach { writer.writeTag(10u).write(it) }
@@ -7862,7 +8151,17 @@ public class GeneratedCodeInfo private constructor(
     public val semantic: Semantic?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
+    @Transient
+    private var __serializedSize: Int = -1
+
+    /**
+     * Identifies the filesystem path to the original source .proto.
+     */
+    @GeneratedProperty(2)
+    public val sourceFile: String?
+      get() = _sourceFile?.value()
+
+    private fun __computeSerializedSize(): Int {
       var result = 0
       if (path.isNotEmpty()) {
         result += sizeOf(10u) + path.sumOf { sizeOf(it) }.let { it + sizeOf(it.toUInt()) }
@@ -7880,18 +8179,17 @@ public class GeneratedCodeInfo private constructor(
         result += sizeOf(40u) + sizeOf(semantic)
       }
       result += unknownFields.size()
-      result
+      return result
     }
 
-    /**
-     * Identifies the filesystem path to the original source .proto.
-     */
-    @GeneratedProperty(2)
-    public val sourceFile: String?
-      get() = _sourceFile?.value()
-
-    override fun serializedSize(): Int =
-      __serializedSize
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (path.isNotEmpty()) {

--- a/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/compiler/Plugin.kt
+++ b/protokt-bootstrap/src/main/kotlin/protokt/v1/google/protobuf/compiler/Plugin.kt
@@ -50,6 +50,7 @@ import kotlin.ULong
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.Transient
 
 /**
  * The version number of protocol compiler.
@@ -65,7 +66,17 @@ public class Version private constructor(
   private val _suffix: LazyReference<Bytes, String>?,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  /**
+   * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should be empty for mainline stable releases.
+   */
+  @GeneratedProperty(4)
+  public val suffix: String?
+    get() = _suffix?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (major != null) {
       result += sizeOf(8u) + sizeOf(major)
@@ -80,18 +91,17 @@ public class Version private constructor(
       result += sizeOf(34u) + sizeOf(_suffix.wireValue())
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  /**
-   * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should be empty for mainline stable releases.
-   */
-  @GeneratedProperty(4)
-  public val suffix: String?
-    get() = _suffix?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (major != null) {
@@ -267,7 +277,17 @@ public class CodeGeneratorRequest private constructor(
   public val sourceFileDescriptors: List<FileDescriptorProto>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  /**
+   * The generator parameter passed on the command-line.
+   */
+  @GeneratedProperty(2)
+  public val parameter: String?
+    get() = _parameter?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (fileToGenerate.isNotEmpty()) {
       result +=
@@ -294,18 +314,17 @@ public class CodeGeneratorRequest private constructor(
       result += (sizeOf(138u) * sourceFileDescriptors.size) + sourceFileDescriptors.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  /**
-   * The generator parameter passed on the command-line.
-   */
-  @GeneratedProperty(2)
-  public val parameter: String?
-    get() = _parameter?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (fileToGenerate.isNotEmpty()) {
@@ -509,7 +528,19 @@ public class CodeGeneratorResponse private constructor(
   public val `file`: List<File>,
   override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
 ) : AbstractMessage() {
-  private val __serializedSize: Int by lazy {
+  @Transient
+  private var __serializedSize: Int = -1
+
+  /**
+   * Error message.  If non-empty, code generation failed.  The plugin process should exit with status code zero even if it reports an error in this way.
+   *
+   *  This should be used to indicate errors in .proto files which prevent the code generator from generating correct code.  Errors which indicate a problem in protoc itself -- such as the input CodeGeneratorRequest being unparseable -- should be reported by writing a message to stderr and exiting with a non-zero status code.
+   */
+  @GeneratedProperty(1)
+  public val error: String?
+    get() = _error?.value()
+
+  private fun __computeSerializedSize(): Int {
     var result = 0
     if (_error != null) {
       result += sizeOf(10u) + sizeOf(_error.wireValue())
@@ -527,20 +558,17 @@ public class CodeGeneratorResponse private constructor(
       result += (sizeOf(122u) * `file`.size) + `file`.sumOf { sizeOf(it) }
     }
     result += unknownFields.size()
-    result
+    return result
   }
 
-  /**
-   * Error message.  If non-empty, code generation failed.  The plugin process should exit with status code zero even if it reports an error in this way.
-   *
-   *  This should be used to indicate errors in .proto files which prevent the code generator from generating correct code.  Errors which indicate a problem in protoc itself -- such as the input CodeGeneratorRequest being unparseable -- should be reported by writing a message to stderr and exiting with a non-zero status code.
-   */
-  @GeneratedProperty(1)
-  public val error: String?
-    get() = _error?.value()
-
-  override fun serializedSize(): Int =
-    __serializedSize
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
 
   override fun serialize(writer: Writer) {
     if (_error != null) {
@@ -746,23 +774,8 @@ public class CodeGeneratorResponse private constructor(
     public val generatedCodeInfo: GeneratedCodeInfo?,
     override val unknownFields: UnknownFieldSet = UnknownFieldSet.empty()
   ) : AbstractMessage() {
-    private val __serializedSize: Int by lazy {
-      var result = 0
-      if (_name != null) {
-        result += sizeOf(10u) + sizeOf(_name.wireValue())
-      }
-      if (_insertionPoint != null) {
-        result += sizeOf(18u) + sizeOf(_insertionPoint.wireValue())
-      }
-      if (_content != null) {
-        result += sizeOf(122u) + sizeOf(_content.wireValue())
-      }
-      if (generatedCodeInfo != null) {
-        result += sizeOf(130u) + sizeOf(generatedCodeInfo)
-      }
-      result += unknownFields.size()
-      result
-    }
+    @Transient
+    private var __serializedSize: Int = -1
 
     /**
      * The file name, relative to the output directory.  The name must not contain "." or ".." components and must be relative, not be absolute (so, the file cannot lie outside the output directory).  "/" must be used as the path separator, not "\".
@@ -795,8 +808,32 @@ public class CodeGeneratorResponse private constructor(
     public val content: String?
       get() = _content?.value()
 
-    override fun serializedSize(): Int =
-      __serializedSize
+    private fun __computeSerializedSize(): Int {
+      var result = 0
+      if (_name != null) {
+        result += sizeOf(10u) + sizeOf(_name.wireValue())
+      }
+      if (_insertionPoint != null) {
+        result += sizeOf(18u) + sizeOf(_insertionPoint.wireValue())
+      }
+      if (_content != null) {
+        result += sizeOf(122u) + sizeOf(_content.wireValue())
+      }
+      if (generatedCodeInfo != null) {
+        result += sizeOf(130u) + sizeOf(generatedCodeInfo)
+      }
+      result += unknownFields.size()
+      return result
+    }
+
+    override fun serializedSize(): Int {
+      var size = __serializedSize
+      if (size == -1) {
+        size = __computeSerializedSize()
+        __serializedSize = size
+      }
+      return size
+    }
 
     override fun serialize(writer: Writer) {
       if (_name != null) {

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageGenerator.kt
@@ -269,13 +269,29 @@ private class MessageGenerator(
     private fun dereferenceNullableBackingProperty(propName: String, oneof: Boolean) =
         "requireNotNull($propName) { \"$propName is assumed non-null with (protokt.v1.${if (oneof) "oneof" else "property"}).generate_non_null_accessor but was null\" }".bindSpaces()
 
+    // Memoized with a sentinel rather than `by lazy` so each message holds one Int instead of a
+    // SynchronizedLazyImpl, an initializer lambda, and a boxed result. The unsynchronized write is
+    // a benign race: every thread computes the same value, and Int writes are atomic.
     private fun TypeSpec.Builder.handleMessageSize(propertySpecs: List<PropertySpec>, propertyInfoList: List<PropertyInfo>) {
-        addProperty(generateMessageSize(msg, propertySpecs, ctx, propertyInfoList))
+        addProperty(
+            PropertySpec.builder(SERIALIZED_SIZE, Int::class)
+                .addModifiers(KModifier.PRIVATE)
+                .mutable(true)
+                .addAnnotation(Transient::class)
+                .initializer("-1")
+                .build()
+        )
+        addFunction(generateComputeSerializedSize(msg, propertySpecs, ctx, propertyInfoList))
         addFunction(
             buildFunSpec("serializedSize") {
                 returns(Int::class)
                 addModifiers(KModifier.OVERRIDE)
-                addStatement("return $SERIALIZED_SIZE")
+                addStatement("var·size·=·$SERIALIZED_SIZE")
+                beginControlFlow("if·(size·==·-1)")
+                addStatement("size·=·$COMPUTE_SERIALIZED_SIZE()")
+                addStatement("$SERIALIZED_SIZE·=·size")
+                endControlFlow()
+                addStatement("return·size")
             }
         )
     }

--- a/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageSizeGenerator.kt
+++ b/protokt-codegen/src/main/kotlin/protokt/v1/codegen/generate/MessageSizeGenerator.kt
@@ -16,6 +16,7 @@
 package protokt.v1.codegen.generate
 
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.asTypeName
@@ -37,8 +38,9 @@ import protokt.v1.codegen.util.sizeFn
 import protokt.v1.reflect.FieldType
 
 internal const val SERIALIZED_SIZE = "__serializedSize"
+internal const val COMPUTE_SERIALIZED_SIZE = "__computeSerializedSize"
 
-internal fun generateMessageSize(
+internal fun generateComputeSerializedSize(
     msg: Message,
     properties: List<PropertySpec>,
     ctx: Context,
@@ -64,7 +66,7 @@ private class MessageSizeGenerator(
     private fun propertyInfoForField(f: StandardField): PropertyInfo? =
         propertyInfoList.firstOrNull { it.name == f.fieldName }
 
-    fun generate(): PropertySpec {
+    fun generate(): FunSpec {
         val fieldSizes =
             msg.mapFields(
                 ctx,
@@ -92,24 +94,19 @@ private class MessageSizeGenerator(
                 { oneof, std, _ -> sizeofOneof(oneof, std) }
             )
 
-        return PropertySpec.builder(SERIALIZED_SIZE, Int::class)
+        return FunSpec.builder(COMPUTE_SERIALIZED_SIZE)
             .addModifiers(KModifier.PRIVATE)
-            .delegate(
-                buildCodeBlock {
-                    beginControlFlow("lazy")
-                    add(
-                        if (fieldSizes.isEmpty()) {
-                            CodeBlock.of("unknownFields.size()")
-                        } else {
-                            buildCodeBlock {
-                                addStatement("var·$resultVarName·=·0")
-                                fieldSizes.forEach { fs -> add(fs) }
-                                addStatement("$resultVarName·+=·unknownFields.size()")
-                                addStatement(resultVarName)
-                            }
-                        }
-                    )
-                    endControlFlow()
+            .returns(Int::class)
+            .addCode(
+                if (fieldSizes.isEmpty()) {
+                    CodeBlock.of("return·unknownFields.size()")
+                } else {
+                    buildCodeBlock {
+                        addStatement("var·$resultVarName·=·0")
+                        fieldSizes.forEach { fs -> add(fs) }
+                        addStatement("$resultVarName·+=·unknownFields.size()")
+                        addStatement("return·$resultVarName")
+                    }
                 }
             )
             .build()

--- a/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/SerializedSizeTest.kt
+++ b/testing/protokt-generation/src/test/kotlin/protokt/v1/testing/SerializedSizeTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Toast, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protokt.v1.testing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import protokt.v1.Bytes
+import protokt.v1.UnknownField
+import protokt.v1.UnknownFieldSet
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+
+class SerializedSizeTest {
+    private val populated =
+        ToStringTest2 {
+            `val` = Bytes.from(ByteArray(300))
+            extra = "some extra content"
+        }
+
+    @Test
+    fun `serialized size matches the serialized byte count`() {
+        val withMap = TestProto2Maps { `val` = mapOf(1 to 2, 3 to 4) }
+
+        assertThat(populated.serializedSize()).isEqualTo(populated.serialize().size)
+        assertThat(withMap.serializedSize()).isEqualTo(withMap.serialize().size)
+    }
+
+    @Test
+    fun `an empty message has size zero on every read`() {
+        val empty = ToStringTestEmpty { }
+
+        assertThat(empty.serializedSize()).isEqualTo(0)
+        assertThat(empty.serializedSize()).isEqualTo(0)
+        assertThat(empty.serialize()).isEmpty()
+    }
+
+    @Test
+    fun `unknown fields count towards the serialized size`() {
+        val withUnknowns =
+            populated.copy {
+                unknownFields =
+                    UnknownFieldSet.Builder().apply {
+                        add(UnknownField.fixed32(5u, 10u))
+                    }.build()
+            }
+
+        assertThat(withUnknowns.serializedSize()).isGreaterThan(populated.serializedSize())
+        assertThat(withUnknowns.serializedSize()).isEqualTo(withUnknowns.serialize().size)
+    }
+
+    @Test
+    fun `repeated reads return the same value`() {
+        val first = populated.serializedSize()
+        repeat(10) {
+            assertThat(populated.serializedSize()).isEqualTo(first)
+        }
+    }
+
+    @Test
+    fun `concurrent first reads agree`() {
+        val executor = Executors.newFixedThreadPool(8)
+        try {
+            repeat(50) {
+                val message = ToStringTest2 { extra = "content $it" }
+                val sizes =
+                    executor.invokeAll(List(8) { Callable { message.serializedSize() } })
+                        .map { it.get() }
+
+                assertThat(sizes.toSet()).containsExactly(message.serialize().size)
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Every generated message held `private val __serializedSize: Int by lazy { ... }`. Per instance that is a `SynchronizedLazyImpl` (24 B), a capturing initializer lambda (16 B, plus one synthetic class per message type) and, once read, a boxed `Integer`, on top of the reference field. The generated class now keeps a single transient `Int` initialized to `-1`; the size computation moves into a private `__computeSerializedSize()` and `serializedSize()` memoizes it on first call, the same shape as protobuf-java's `memoizedSize`.

- Codegen only. Generated code relies on nothing new in the runtime; `Message`, `AbstractMessage` and the codec interfaces are unchanged.
- The unsynchronized write is a benign race: every thread computes the same value and `Int` writes are atomic. `-1` is the sentinel because an empty message legitimately has size 0.
- `@Transient` is `kotlin.jvm.Transient`, which is an optional expectation in common code, so multiplatform targets are unaffected; on the JVM it keeps field-based reflection (Gson, Jackson field visibility) from emitting the memo.
- The checked-in bootstrap types were regenerated with `:protokt-codegen:regenerateBootstrap` (license header kept as before). The bootstrap diff looks large because git aligns the moved size-computation body; the only change is the sentinel shape.

This is the `main` counterpart of open-toast/protokt#588 on the 0.x line.

## Generated code before / after (`protokt.v1.FileOptions` from the bootstrap)

```kotlin
-  private val __serializedSize: Int by lazy {
-    var result = 0
-    if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
-      result += sizeOf(10u) + sizeOf(_fileDescriptorObjectName.wireValue())
-    }
-    result += unknownFields.size()
-    result
-  }
+  @Transient
+  private var __serializedSize: Int = -1
...
-  override fun serializedSize(): Int =
-    __serializedSize
+  private fun __computeSerializedSize(): Int {
+    var result = 0
+    if (_fileDescriptorObjectName.wireValue().isNotEmpty()) {
+      result += sizeOf(10u) + sizeOf(_fileDescriptorObjectName.wireValue())
+    }
+    result += unknownFields.size()
+    return result
+  }
+
+  override fun serializedSize(): Int {
+    var size = __serializedSize
+    if (size == -1) {
+      size = __computeSerializedSize()
+      __serializedSize = size
+    }
+    return size
+  }
```

## Measurements

Same change measured on the 0.x line (#588) with JOL on the parsed JMH datasets: retained heap of 101 parsed `GenericMessage1` went from 3,187,792 B / 114,677 objects to 2,791,248 B / 98,154 objects (-12.4%), and 101 small messages from 13,592 B / 510 objects to 8,728 B / 307 objects (-36%). Deserialize allocation per op dropped 6-20% depending on message size; serialize was unchanged. The object layout is identical on `main`, so the per-instance saving (40 B and two objects per message, one class per message type) carries over.

Motivation on our side: heap dumps of Toast's Android POS showed ~7,400 resident protokt v1 messages, each holding a `SynchronizedLazyImpl` plus lambda.

## Verification

- `:protokt-codegen:test`, `:protokt-runtime:jvmTest`, `:testing:protokt-generation:test` green on JDK 17; `spotlessApply` clean.
- New `testing/protokt-generation/.../SerializedSizeTest`: size equals serialized byte count (populated, with a map, empty, with unknown fields), repeated reads stable, concurrent first reads agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
